### PR TITLE
2.7.3 SDLC uplift (image publishing + mutation testing)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,162 @@
+name: Docker Publish
+
+# Issue 2.7.2 — multi-arch image build, GHCR push, Helm tag bump.
+#
+# Tag selection is event-driven via docker/metadata-action:
+#   • pull_request          → build only, do NOT push (proves Dockerfiles build)
+#   • push to main          → push :main + :sha-<commit> (traceable dev images)
+#   • push tag vX.Y.Z       → push :X.Y.Z, :X.Y, :latest  AND  bump Helm tags
+#   • workflow_dispatch     → manual run (push :main + :sha unless on a tag)
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Dockerfile"
+      - "proto/**"
+      - ".github/workflows/docker-publish.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # ghcr.io/<owner>/mariaalpha/<service> — matches the Helm image helper, which
+  # renders "{{ registry }}/{{ repository }}/<svc>:{{ tag }}".
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}/mariaalpha
+
+jobs:
+  build:
+    name: Build & push (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    # arm64 layers build under QEMU emulation; the gradle-in-Docker services are
+    # the slow ones, so give each matrix leg plenty of headroom.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { service: market-data-gateway, dockerfile: market-data-gateway/Dockerfile }
+          - { service: strategy-engine,     dockerfile: strategy-engine/Dockerfile }
+          - { service: execution-engine,    dockerfile: execution-engine/Dockerfile }
+          - { service: order-manager,       dockerfile: order-manager/Dockerfile }
+          - { service: post-trade,          dockerfile: post-trade/Dockerfile }
+          - { service: api-gateway,         dockerfile: api-gateway/Dockerfile }
+          - { service: ml-signal-service,   dockerfile: ml-signal-service/Dockerfile }
+          - { service: ui,                  dockerfile: ui/Dockerfile }
+    steps:
+      - uses: actions/checkout@v4
+
+      # The ml-signal-service image COPYs proto/generated/python/, which is
+      # git-ignored and so must be generated before `docker build` (same step the
+      # e2e job in ci.yml runs).
+      - name: Generate Python proto stubs
+        if: matrix.service == 'ml-signal-service'
+        run: |
+          pip install grpcio-tools==1.70.0 --quiet
+          bash proto/generate_python.sh
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      # No login on PRs — those runs build but never push, and forks have no
+      # write access to GHCR anyway.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.service }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+          # latest=auto attaches :latest only for non-prerelease semver tags,
+          # never on a branch build.
+          flavor: |
+            latest=auto
+          labels: |
+            org.opencontainers.image.title=mariaalpha-${{ matrix.service }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  # Once every image for a release tag is published, point the umbrella chart at
+  # the new GHCR images. Lands as a PR (peter-evans/create-pull-request) so the
+  # bump still flows through CI/review instead of bypassing branch protection.
+  update-helm:
+    name: Bump Helm image tags
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Resolve release version
+        id: version
+        # refs/tags/v1.2.3 → 1.2.3
+        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump global image registry + tag
+        env:
+          VERSION: ${{ steps.version.outputs.tag }}
+          REGISTRY_NS: ${{ env.REGISTRY }}/${{ github.repository_owner }}
+        run: |
+          # mikefarah yq (preinstalled on ubuntu-latest) preserves comments.
+          yq -i '
+            .global.images.registry = strenv(REGISTRY_NS) |
+            .global.images.tag = strenv(VERSION)
+          ' charts/mariaalpha/values.yaml
+          echo "----- charts/mariaalpha/values.yaml global.images -----"
+          yq '.global.images' charts/mariaalpha/values.yaml
+
+      - name: Open Helm bump PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/helm-image-tag-${{ steps.version.outputs.tag }}
+          base: main
+          commit-message: "chore(helm): pin images to ${{ steps.version.outputs.tag }}"
+          title: "chore(helm): pin images to ${{ steps.version.outputs.tag }}"
+          body: |
+            Automated by `docker-publish.yml` after publishing the
+            `v${{ steps.version.outputs.tag }}` images to GHCR.
+
+            Points `charts/mariaalpha/values.yaml` `global.images` at
+            `${{ env.REGISTRY }}/${{ github.repository_owner }}/mariaalpha/<svc>:${{ steps.version.outputs.tag }}`.
+          labels: |
+            component:ci-cd
+            type:infra

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,94 @@
+name: Mutation Testing
+
+on:
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pitest:
+    name: PITest (Java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Run PITest across all Java services
+        run: ./gradlew pitest --continue
+
+      - name: Upload PITest reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pitest-reports
+          path: "**/build/reports/pitest/**"
+          if-no-files-found: warn
+
+  mutmut:
+    name: mutmut (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: ml-signal-service
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate Python proto stubs
+        working-directory: ${{ github.workspace }}
+        run: |
+          pip install grpcio-tools==1.70.0 --quiet
+          bash proto/generate_python.sh
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run mutmut
+        run: mutmut run || true
+
+      - name: Generate mutmut reports
+        if: always()
+        run: |
+          mutmut results || true
+          mutmut junitxml > mutmut-results.xml || true
+          mutmut html || true
+
+      - name: Mutation summary
+        if: always()
+        run: |
+          {
+            echo '### mutmut — ml-signal-service'
+            echo '```'
+            mutmut results || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutmut reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutmut-reports
+          path: |
+            ml-signal-service/html/
+            ml-signal-service/mutmut-results.xml
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ proto/generated/
 **/__pycache__/
 **/*.py[cod]
 **/*.tgz
+.mutmut-cache
+ml-signal-service/html/
+ml-signal-service/mutmut-results.xml

--- a/README.md
+++ b/README.md
@@ -314,12 +314,21 @@ GitHub Actions workflows run on every push and PR to `main`:
 
 | Workflow | File | What it checks |
 | --- | --- | --- |
-| **CI** | `ci.yml` | Java: Spotless, Checkstyle, SpotBugs, tests + JaCoCo. Python: ruff, mypy, pytest. UI: ESLint, Prettier, tsc. |
+| **CI** | `ci.yml` | Java: Spotless, Checkstyle, SpotBugs, tests + JaCoCo. Python: ruff, mypy, pytest. UI: ESLint, Prettier, tsc. Plus Helm lint + kubeconform and the Docker Compose e2e suite. |
 | **CodeQL** | `codeql.yml` | Security analysis for Java, Python, TypeScript (also runs weekly). |
 | **Snyk** | `snyk.yml` | Dependency vulnerability scanning (requires `SNYK_TOKEN` secret). |
 | **PR Metadata** | `pr-metadata.yml` | Auto-populates labels, milestone, assignee, and project from linked issues. |
 
 Python and UI jobs skip automatically when no source files exist yet. JaCoCo and test reports are uploaded as build artifacts. Snyk requires a `SNYK_TOKEN` repository secret — obtain one from [snyk.io](https://snyk.io).
+
+Two workflows run outside the per-PR critical path:
+
+| Workflow | File | Trigger | What it does |
+| --- | --- | --- | --- |
+| **Docker Publish** | `docker-publish.yml` | push to `main`, `v*.*.*` tags, manual | Multi-arch (amd64/arm64) build of every service image, push to GHCR (`ghcr.io/<owner>/mariaalpha/<svc>`), and — on a version tag — open a PR bumping the Helm chart's image tag. PRs build the images without pushing. |
+| **Mutation Testing** | `mutation.yml` | weekly (Mon 03:00 UTC), manual | PITest (Java services) + mutmut (Python ML service). Advisory only — no score gate; HTML/XML reports are uploaded as artifacts. |
+
+**Cutting a release:** push a `vX.Y.Z` tag. `docker-publish.yml` publishes `:X.Y.Z`, `:X.Y`, and `:latest` for every service, then opens a `chore/helm-image-tag-X.Y.Z` PR repointing `charts/mariaalpha/values.yaml` `global.images` at the GHCR registry and new tag. To deploy from GHCR instead of locally built images, merge that PR (or set `global.images.registry`/`tag` via `-f`/`--set`).
 
 ### Branch rules
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,15 @@ plugins {
     alias(libs.plugins.spring.dependency.management) apply false
     alias(libs.plugins.spotbugs) apply false
     alias(libs.plugins.spotless) apply false
+    alias(libs.plugins.pitest) apply false
 }
 
 val javaVersion = libs.versions.java.get().toInt()
 val springBomCoordinate = libs.spring.boot.bom.get().toString()
 val checkstyleToolVersion = libs.versions.checkstyle.get()
 val tomcatVersion = libs.versions.tomcat.get()
+val pitestToolVersion = libs.versions.pitest.tool.get()
+val pitestJunit5Version = libs.versions.pitest.junit5.get()
 
 subprojects {
     apply(plugin = "java-library")
@@ -47,6 +50,7 @@ subprojects {
         apply(plugin = "com.github.spotbugs")
         apply(plugin = "jacoco")
         apply(plugin = "com.diffplug.spotless")
+        apply(plugin = "info.solidsoft.pitest")
 
         extensions.configure<CheckstyleExtension> {
             toolVersion = checkstyleToolVersion
@@ -86,6 +90,27 @@ subprojects {
                 googleJavaFormat()
                 removeUnusedImports()
             }
+        }
+
+        // Mutation testing (issue 2.7.3). Runs out-of-band via the `mutation.yml`
+        // workflow (scheduled + manual), never on the per-PR critical path.
+        // Advisory by design: no mutationThreshold is set, so a low score never
+        // fails the build — the HTML/XML reports are the deliverable.
+        extensions.configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
+            pitestVersion.set(pitestToolVersion)
+            junit5PluginVersion.set(pitestJunit5Version)
+            targetClasses.set(listOf("com.mariaalpha.*"))
+            // Mutate against the fast unit tests only. PIT passes excludedGroups
+            // to the JUnit 5 companion plugin as platform tags, so the
+            // `integration` (Testcontainers) and `e2e` (full-stack
+            // ComposeContainer) suites — which need Docker per mutant and are
+            // already excluded from the default `test` task — are skipped here too.
+            excludedGroups.set(listOf("integration", "e2e"))
+            jvmArgs.set(listOf("-Xmx1g"))
+            threads.set(Runtime.getRuntime().availableProcessors())
+            outputFormats.set(listOf("HTML", "XML"))
+            timestampedReports.set(false)
+            failWhenNoMutations.set(false)
         }
     }
 }

--- a/docs/technical-design-document.md
+++ b/docs/technical-design-document.md
@@ -1158,22 +1158,26 @@ Java: Gradle with dependency locking + OWASP Dependency-Check + Snyk in CI. Pyth
 graph LR
     subgraph "ci.yml (on push / PR)"
         direction LR
-        JF[Spotless] --> JL[Checkstyle] --> JSB[SpotBugs] --> JT[Tests + JaCoCo] --> JM[PITest] --> JO[OWASP] --> JCQ[CodeQL] --> JS[Snyk]
-        PL[ruff] --> PM[mypy] --> PT[pytest + cov] --> PMT[mutmut] --> PA[pip-audit] --> PCQ[CodeQL] --> PS[Snyk]
+        JF[Spotless] --> JL[Checkstyle] --> JSB[SpotBugs] --> JT[Tests + JaCoCo] --> JO[OWASP] --> JCQ[CodeQL] --> JS[Snyk]
+        PL[ruff] --> PM[mypy] --> PT[pytest + cov] --> PA[pip-audit] --> PCQ[CodeQL] --> PS[Snyk]
         UL[ESLint + Prettier] --> UT[tsc --noEmit]
     end
 ```
 
 A `helm` job inside `ci.yml` (added by issue 2.7.1) runs `helm dependency update`, `helm lint`, and `kubeconform -strict` against the rendered umbrella chart on every PR.
 
-The multi-arch image publish workflow is planned for issue 2.7.2 — not yet on `main`:
+Mutation testing (issue 2.7.3) is intentionally **not** on the per-PR critical path — it is O(mutants × tests) and far too slow. It runs in a dedicated `mutation.yml` workflow on a weekly schedule (plus manual `workflow_dispatch`). PITest covers the six Java services and mutmut covers the Python ML Signal Service; both are advisory (no score gate) and publish their HTML/XML reports as build artifacts.
+
+The multi-arch image publish workflow shipped in issue 2.7.2 as `docker-publish.yml`:
 
 ```mermaid
 graph LR
-    subgraph "docker-publish.yml (planned, issue 2.7.2)"
-        A[Build Docker Images<br/>multi-arch amd64/arm64] --> B[Push to GHCR<br/>ghcr.io/drag0sd0g/mariaalpha] --> C[Update Helm<br/>image tags]
+    subgraph "docker-publish.yml (push to main, v*.*.* tags, manual)"
+        A[Build Docker Images<br/>multi-arch amd64/arm64] --> B[Push to GHCR<br/>ghcr.io/drag0sd0g/mariaalpha] --> C[Bump Helm image tags<br/>via PR, on v* tags]
     end
 ```
+
+Tag selection is event-driven (`docker/metadata-action`): pull requests build the images without pushing; pushes to `main` publish `:main` and `:sha-<commit>`; a `vX.Y.Z` tag publishes `:X.Y.Z`, `:X.Y`, and `:latest` and then opens a PR repointing `charts/mariaalpha/values.yaml` `global.images` at the released GHCR images.
 
 ### 10.2 Kubernetes Deployment (Helm)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ resilience4j = "2.2.0"
 okhttp = "4.12.0"
 caffeine = "3.1.8"
 springdoc = "2.6.0"
+pitest-plugin = "1.19.0"
+pitest-tool = "1.19.6"
+pitest-junit5 = "1.2.3"
 
 [libraries]
 spring-boot-bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
@@ -52,3 +55,4 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs-plugin" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+pitest = { id = "info.solidsoft.pitest", version.ref = "pitest-plugin" }

--- a/justfile
+++ b/justfile
@@ -46,6 +46,20 @@ test-e2e:
 test-python:
     cd ml-signal-service && pytest
 
+# Run mutation testing (Java PITest + Python mutmut) — slow; CI runs this weekly
+mutation:
+    just mutation-java
+    just mutation-python
+
+# PITest mutation analysis across all Java services (reports in build/reports/pitest)
+mutation-java:
+    ./gradlew pitest --continue
+
+# mutmut mutation analysis for the ML Signal Service (config in setup.cfg)
+mutation-python:
+    cd ml-signal-service && mutmut run || true
+    cd ml-signal-service && mutmut results
+
 # Run all linters and format checks (CI gate)
 check:
     ./gradlew spotlessCheck checkstyleMain spotbugsMain

--- a/ml-signal-service/requirements-dev.txt
+++ b/ml-signal-service/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov==6.0.0
 ruff==0.9.4
 mypy==1.14.1
 httpx==0.28.1
+mutmut==2.5.1

--- a/ml-signal-service/setup.cfg
+++ b/ml-signal-service/setup.cfg
@@ -1,0 +1,4 @@
+[mutmut]
+paths_to_mutate=src/ml_signal/
+tests_dir=tests/
+runner=python -m pytest -x -q -m "not integration"


### PR DESCRIPTION
  **2.7.2 (Docker image publish) — docker-publish.yml does all three TDD-specified things:**
  - ✅ Multi-arch linux/amd64,linux/arm64 (QEMU + Buildx) for all 8 services
  - ✅ MGHCR push to ghcr.io/drag0sd0g/6ariaalpha/<svc> — exactly the namespace the Helm image helper renders
  - ✅ GHelmptag update — on v* tags, bumps gpob/l.images.{registry,tag} and opens a PR
  - Event-driven tags (PR=build-only, main=:main/:shg, tag=:X.Y.Z/:X.Y/:latest); ml-signal-service proto generated before its build
  
  **2.7.3 (Mutation testing) — mutation.yml satisfies the issue + NFR-15:**
  - ✅ PITest across all 6 Java services, mutmut for the Python ML service, reports as artifacts, advisory (no gate), off the PR critical path (weekly + manual)

Closes #84