### PR TITLE
2.1.5 TWAP Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Full-stack algorithmic trading engine — see [Technical Design Document](docs/t
 Phase 1 is complete. MariaAlpha ships as a working, end-to-end algorithmic trading engine with the following capabilities:
 
 - **Live market data ingestion** — simulated CSV replay (default) or Alpaca IEX WebSocket, with auto-reconnect and per-symbol in-memory order book
-- **VWAP execution strategy** enhanced by an ML signal — LightGBM classifier (15 technical indicators) called over gRPC with a Resilience4j circuit breaker; strategy hot-swap at runtime via REST
+- **VWAP and TWAP execution strategies** enhanced by an ML signal — LightGBM classifier (15 technical indicators) called over gRPC with a Resilience4j circuit breaker; strategy hot-swap at runtime via REST
 - **Risk check chain** — five composable checks (max notional, max position, max portfolio exposure, max open orders, daily loss limit) with trading halt and resume
 - **Dual exchange routing** — simulated exchange (configurable fill latency + slippage) or Alpaca paper trading (REST + `trade_updates` WebSocket), switchable via `EXECUTION_PROFILE`
 - **Real-time position and P&L tracking** — mark-to-market unrealized P&L, portfolio aggregates, fill history, all persisted in PostgreSQL
@@ -20,7 +20,7 @@ Phase 1 is complete. MariaAlpha ships as a working, end-to-end algorithmic tradi
 
 The Phase 1 acceptance test — `SimulatedHappyPathE2ETest` — boots the full Docker Compose stack (15 long-running services + a one-shot Kafka topics initializer) and traverses the complete Tick-to-Trade pipeline on every CI run. See [`docs/phase-1-completion.md`](docs/phase-1-completion.md) for the full record of what was built.
 
-Phase 2 work has begun landing on `main`: the Smart Order Router (issue 2.1.1), the advanced order-type handlers IOC / FOK / GTC / Iceberg (2.1.3, 2.1.4), and the umbrella Helm chart for Kubernetes deployment (2.7.1) are all shipped. Remaining Phase 2 items — TWAP / Momentum / Implementation Shortfall strategies, Redis distributed position cache, regime classifier, Playwright UI e2e tests, and the docker image publish workflow — are tracked in [§11 of the Technical Design Document](docs/technical-design-document.md#phase-2-full-desk-workflows--sor--rich-analytics).
+Phase 2 work has begun landing on `main`: the Smart Order Router (issue 2.1.1), the advanced order-type handlers IOC / FOK / GTC / Iceberg (2.1.3, 2.1.4), the TWAP execution strategy (2.1.5), and the umbrella Helm chart for Kubernetes deployment (2.7.1) are all shipped. Remaining Phase 2 items — Momentum / Implementation Shortfall strategies, Redis distributed position cache, regime classifier, Playwright UI e2e tests, and the docker image publish workflow — are tracked in [§11 of the Technical Design Document](docs/technical-design-document.md#phase-2-full-desk-workflows--sor--rich-analytics).
 
 ## Prerequisites
 
@@ -146,6 +146,23 @@ curl -X PUT -H "X-API-Key: local-dev-key" \
           ]
         }' \
     http://localhost:8080/api/strategies/VWAP/parameters
+
+# Alternatively, bind & configure TWAP — 100 shares in 6 equal slices between 14:30 and 16:00 NY time.
+curl -X PUT -H "X-API-Key: local-dev-key" \
+    -H "Content-Type: application/json" \
+    -d '{"strategyName":"TWAP"}' \
+    http://localhost:8080/api/strategies/AAPL
+
+curl -X PUT -H "X-API-Key: local-dev-key" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "targetQuantity": 100,
+          "side": "BUY",
+          "startTime": "14:30:00",
+          "endTime": "16:00:00",
+          "numSlices": 6
+        }' \
+    http://localhost:8080/api/strategies/TWAP/parameters
 
 # Place a manual LIMIT order.
 curl -X POST -H "X-API-Key: local-dev-key" \

--- a/docs/technical-design-document.md
+++ b/docs/technical-design-document.md
@@ -1328,7 +1328,7 @@ _(Each row below is a GitHub Issue — descriptions follow the same pattern as P
 | [2.1.2](https://github.com/drag0sd0g/MariaAlpha/issues/54) ✅ | Implement simulated dark pool and internal crossing venues | Execution Engine |
 | [2.1.3](https://github.com/drag0sd0g/MariaAlpha/issues/55) ✅ | Implement IOC and FOK order type handlers | Execution Engine |
 | [2.1.4](https://github.com/drag0sd0g/MariaAlpha/issues/56) ✅ | Implement GTC and Iceberg order type handlers | Execution Engine |
-| [2.1.5](https://github.com/drag0sd0g/MariaAlpha/issues/57) | Implement TWAP strategy | Strategy Engine |
+| [2.1.5](https://github.com/drag0sd0g/MariaAlpha/issues/57) ✅ | Implement TWAP strategy | Strategy Engine |
 | [2.1.6](https://github.com/drag0sd0g/MariaAlpha/issues/58) | Implement Momentum/Trend-following strategy | Strategy Engine |
 | [2.1.7](https://github.com/drag0sd0g/MariaAlpha/issues/59) | Implement Implementation Shortfall algorithm | Strategy Engine |
 | [2.1.8](https://github.com/drag0sd0g/MariaAlpha/issues/60) | Implement POV (Participation Rate) algorithm | Strategy Engine |

--- a/docs/twap-strategy-explainer.md
+++ b/docs/twap-strategy-explainer.md
@@ -1,0 +1,165 @@
+# TWAP Strategy: Concepts and MariaAlpha Implementation
+
+## 1. What Is TWAP?
+
+**TWAP** (Time-Weighted Average Price) is the benchmark price calculated as the simple average of prices sampled at regular intervals over a period:
+
+```
+TWAP = SUM(Price_i) / N
+```
+
+Where each `i` is one of `N` equally-spaced time samples during the period. Unlike VWAP, the samples are **not** weighted by volume — every interval counts the same regardless of how much actually traded in it.
+
+TWAP serves the same two purposes as VWAP:
+
+1. **As a benchmark**: a time-weighted reference an execution can be measured against.
+2. **As an execution algorithm**: an algorithm that slices a large parent order into equal child orders spread evenly across time, so the average fill price tracks the time-weighted average. This is what MariaAlpha implements.
+
+## 2. Why Use TWAP Execution?
+
+Like VWAP, TWAP exists to work a large order into the market without the impact of a single block trade. The difference is **how** the parent is sliced: TWAP ignores the volume profile and simply spreads the order **uniformly over time**.
+
+That trade-off is deliberate and is exactly when you reach for TWAP over VWAP:
+
+- **Illiquid names / no reliable volume profile** — if you can't trust a historical volume curve (thin stock, new listing, unusual session), VWAP's core input is garbage. TWAP needs no profile.
+- **Overnight / extended sessions** — volume patterns break down outside regular trading hours; even spacing is the safer default.
+- **Predictability and simplicity** — the schedule is trivial to reason about ("a slice every five minutes"), which matters for compliance, client communication, and debugging.
+- **Lower information leakage from profile-chasing** — TWAP does not lean into the open/close volume spikes the way VWAP does, so its footprint is flatter and more uniform.
+
+The cost is that TWAP can trade *against* thin liquidity (it will try to do its scheduled slice even when little is trading), so its market impact can be **higher** than VWAP on names with a strong, predictable volume shape. See the comparison table in [`vwap-strategy-explainer.md` §6](vwap-strategy-explainer.md#6-vwap-vs-twap).
+
+## 3. The TWAP Slicing Algorithm
+
+Given:
+- **Parent order**: BUY 100,000 shares of AAPL
+- **Trading window**: 09:30 to 16:00 ET (6h30m = 23,400 seconds)
+- **Number of slices**: `numSlices = 13`
+
+### Step 1: Build an Equal-Duration Schedule
+
+The window is divided into `numSlices` equal intervals. With 13 slices over 23,400 seconds, each slice is 1,800 s (30 minutes):
+
+| Slice | Time | Allocation (of 100,000) |
+|-------|------|-------------------------|
+| 0 | 09:30-10:00 | 7,692 |
+| 1 | 10:00-10:30 | 7,692 |
+| … | … | … |
+| 11 | 15:00-15:30 | 7,692 |
+| 12 | 15:30-16:00 | 7,696 (absorbs remainder) |
+| | | **100,000** |
+
+Boundaries are computed in whole seconds **from the window start** (`start + round(i × total / N)`), not by repeatedly adding a rounded slice width. This keeps the boundaries from drifting and guarantees the final boundary lands exactly on `endTime`.
+
+### Step 2: Execute Each Slice
+
+As the market clock (driven by **tick timestamps**, not the wall clock) crosses into a new slice, the algorithm emits one **child order** for that slice's allocation. The child is a **LIMIT** order at the current best ask (buys) or best bid (sells), giving price protection. Each slice fires **at most once** — re-entering an already-executed slice produces no new signal.
+
+### Step 3: End-of-Day Sweep
+
+If, when the clock reaches `endTime`, there is still unexecuted quantity (e.g. the strategy was started mid-window, or some slices were skipped), the algorithm emits a single final **MARKET** order to sweep the remainder so the parent is fully executed by the deadline.
+
+### Rounding
+
+Each slice receives `round(targetQuantity / numSlices)`; the **last slice absorbs the remainder** so the per-slice allocations always sum exactly to the target. For example, 1,001 shares over 3 slices → 334, 334, 333.
+
+## 4. TWAP in MariaAlpha
+
+### Architecture
+
+TWAP sits in the `strategy-engine` module and implements the same pluggable `TradingStrategy` interface as VWAP, so it is auto-discovered as a Spring `@Component` and registered in the `StrategyRegistry` with **no wiring changes** anywhere else in the pipeline:
+
+```
+                  market-data.ticks (Kafka)
+                         |
+                         v
+             +------- Strategy Engine -------+
+             |                               |
+             |  TradingStrategy interface     |
+             |    +-- VwapStrategy            |
+             |    +-- TwapStrategy            |
+             |    +-- MomentumStrategy (fut.) |
+             |                               |
+             |  StrategyRegistry              |
+             |    auto-discovers @Component   |
+             |    strategies via Spring DI    |
+             |                               |
+             +-------------------------------+
+                         |
+                         v
+                    OrderSignal  --> strategy.signals (Kafka)
+                         |
+                         v
+                  Execution Engine
+```
+
+The `SymbolStrategyRouter` binds a symbol to a strategy name at runtime; the `StrategyEvaluationService` calls `onTick` / `evaluate` and applies the same ML signal confirmation/veto logic to TWAP signals as it does to VWAP. Metrics (`mariaalpha_strategy_signals_total`, `mariaalpha_strategy_evaluation_duration_ms`) are already tagged by `strategy`, so TWAP shows up in Prometheus/Grafana automatically under `strategy="TWAP"`.
+
+### Parameters
+
+| Parameter | Type | Default | Meaning |
+|-----------|------|---------|---------|
+| `targetQuantity` | int | 0 | Total parent quantity to execute |
+| `side` | `BUY` \| `SELL` | `BUY` | Order side |
+| `startTime` | `HH:mm[:ss]` (ET) | `09:30` | Window start (US Eastern) |
+| `endTime` | `HH:mm[:ss]` (ET) | `16:00` | Window end (US Eastern) |
+| `numSlices` | int | 12 | Number of equal time slices |
+
+`getParameters()` additionally returns the derived `slices` list and live `executedSlices` / `totalSlices` counters for monitoring.
+
+Configure at runtime via REST (parameters are addressed by **strategy name**, binding by **symbol**):
+
+```bash
+# Bind TWAP to AAPL
+curl -X PUT -H "X-API-Key: local-dev-key" -H "Content-Type: application/json" \
+    -d '{"strategyName":"TWAP"}' \
+    http://localhost:8080/api/strategies/AAPL
+
+# Configure: 100 shares, 6 equal slices, 14:30-16:00 ET
+curl -X PUT -H "X-API-Key: local-dev-key" -H "Content-Type: application/json" \
+    -d '{"targetQuantity":100,"side":"BUY","startTime":"14:30:00","endTime":"16:00:00","numSlices":6}' \
+    http://localhost:8080/api/strategies/TWAP/parameters
+```
+
+### Market Time
+
+Like VWAP, TWAP uses **tick timestamps** as its clock source (never `System.currentTimeMillis()`), converted to `America/New_York`. This makes the strategy fully deterministic and replayable: a unit test can simulate an entire trading day by feeding ticks with chosen timestamps, and historical replay behaves exactly as live trading would have.
+
+### TWAP vs. VWAP in the Codebase
+
+`TwapStrategy` is intentionally a near-mirror of `VwapStrategy` — same `onTick`/`evaluate` shape, same at-most-once-per-interval guard (`ConcurrentHashMap.putIfAbsent`), same LIMIT-per-interval + MARKET-sweep execution, same bid/ask price resolution. The **only** algorithmic difference is the schedule:
+
+- VWAP takes an explicit `volumeProfile` (a list of `TimeBin`s with volume fractions) and allocates proportionally.
+- TWAP computes its own equal-duration `TwapSlice`s from `numSlices` and allocates uniformly.
+
+The two are kept as separate, self-contained classes (each in its own package) rather than sharing an abstract base, matching the existing repo convention that every `TradingStrategy` is independently discoverable and reads top-to-bottom without indirection.
+
+### Relationship to Other Components
+
+| Component | Role in TWAP |
+|-----------|--------------|
+| **Market Data Gateway** | Provides live ticks (price, bid/ask) that drive the strategy clock |
+| **ML Signal Service** | Can suppress a TWAP child order when a high-confidence signal contradicts the side |
+| **Execution Engine** | Receives `OrderSignal`s, applies risk checks + SOR, submits to the exchange |
+| **TCA (Post-Trade)** | Measures achieved fill price against benchmarks for each completed order |
+
+### Limitations of the Current Implementation
+
+These mirror VWAP's MVP limitations and are deliberate scope cuts:
+
+1. **One signal per slice** — a production TWAP would subdivide each slice into smaller wavelets and randomise timing/size to reduce predictability.
+2. **No fill tracking** — the strategy assumes each child fully fills; it does not yet reconcile against actual fills to re-plan remaining slices.
+3. **No participation cap** — there is no "max % of interval volume" throttle, so on very thin names a slice can still over-trade relative to the tape. (This is precisely the risk that makes TWAP higher-impact than VWAP.)
+4. **No catch-up/slow-down logic** — if the strategy starts mid-window it does not redistribute the skipped quantity across the remaining slices; the leftover is handled by the end-of-window MARKET sweep.
+
+## 5. Testing
+
+- **Unit** — `TwapStrategyTest` covers slice scheduling, equal allocation with last-slice remainder, at-most-once per slice, the end-of-window sweep (including "nothing to sweep" and "sweep only once"), buy/sell price resolution, trade-price fallback, parameter round-trip + state reset, partial parameter updates, a full-trading-day simulation, and degenerate schedules (inverted window, zero slices).
+- **Integration** — `TickConsumerIntegrationTest` publishes a tick to `market-data.ticks` over a Kafka Testcontainer and asserts a `TWAP` `OrderSignal` lands on `strategy.signals`.
+- **End-to-end** — `SimulatedHappyPathE2ETest` binds `MSFT → TWAP` over the full Docker Compose stack and asserts the resulting position fills and the persisted order carries `strategy = "TWAP"`.
+
+## 6. Further Reading
+
+- **Almgren & Chriss (2000)**: "Optimal Execution of Portfolio Transactions" — foundational paper on optimal trade execution.
+- **Kissell & Glantz (2003)**: "Optimal Trading Strategies" — comprehensive coverage of VWAP, TWAP, and implementation shortfall algorithms.
+- **Johnson (2010)**: "Algorithmic Trading & DMA" — practical guide to execution algorithms including TWAP.
+- [`vwap-strategy-explainer.md`](vwap-strategy-explainer.md) — the sibling strategy this one mirrors.

--- a/docs/vwap-strategy-explainer.md
+++ b/docs/vwap-strategy-explainer.md
@@ -126,7 +126,7 @@ MariaAlpha's VWAP strategy sits in the `strategy-engine` module and follows the 
              |                               |
              |  TradingStrategy interface     |
              |    +-- VwapStrategy            |
-             |    +-- TwapStrategy (future)   |
+             |    +-- TwapStrategy            |
              |    +-- MomentumStrategy (fut.) |
              |                               |
              |  StrategyRegistry              |
@@ -191,7 +191,7 @@ All times are converted to `America/New_York` (US Eastern Time) since the primar
 | Benchmark tracking | Better for volume-weighted benchmark | Better for time-weighted benchmark |
 | Market impact | Lower (trades with the crowd) | Higher (may trade against thin volume) |
 
-MariaAlpha implements TWAP as a separate strategy (1.3.x future issue) which simply divides the target quantity into equal slices across evenly-spaced intervals.
+MariaAlpha implements TWAP as a separate strategy (issue 2.1.5) which simply divides the target quantity into equal slices across evenly-spaced intervals. See [`twap-strategy-explainer.md`](twap-strategy-explainer.md) for the design and how it reuses the same `TradingStrategy` plumbing as VWAP.
 
 ## 7. Further Reading
 

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
@@ -85,7 +85,7 @@ class SimulatedHappyPathE2ETest {
         var position = await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofMillis(500))
                 .ignoreExceptions()
-                .until(this::getApplePosition, pos -> pos != null && netQuantity(pos).signum() != 0);
+                .until(() -> getPosition("AAPL"), pos -> pos != null && netQuantity(pos).signum() != 0);
 
         assertThat(netQuantity(position)).as("AAPL net quantity should be 100 after VWAP bin fires")
                 .isEqualByComparingTo(new BigDecimal("100"));
@@ -99,7 +99,9 @@ class SimulatedHappyPathE2ETest {
         assertThat(new BigDecimal(position.get("realizedPnl").asText())).isEqualByComparingTo("0");
 
         var portfolio = httpGetAndCheck("/api/portfolio/summary");
-        assertThat(portfolio.get("openPositions").asInt()).isEqualTo(1);
+        // >= 1 rather than == 1: the TWAP test in this class may have opened an MSFT position too,
+        // and test method order is not guaranteed.
+        assertThat(portfolio.get("openPositions").asInt()).isGreaterThanOrEqualTo(1);
         assertThat(portfolio.has("totalPnl")).isTrue();
 
         var orders = httpGetAndCheck("/api/orders?symbol=AAPL");
@@ -113,6 +115,45 @@ class SimulatedHappyPathE2ETest {
         assertThat(status.get("tradingHalted").asBoolean())
                 .as("daily loss limit should not have tripped on a single 100-share fill")
                 .isFalse();
+    }
+
+    @Test
+    void simulatedTwapTickReachesMsftPositionWithFill() throws Exception {
+        bindTwapToMsftWith50Shares();
+
+        var position = await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofMillis(500))
+                .ignoreExceptions()
+                .until(() -> getPosition("MSFT"), pos -> pos != null && netQuantity(pos).signum() != 0);
+
+        assertThat(netQuantity(position)).as("MSFT net quantity should be 50 after TWAP slice fires")
+                .isEqualByComparingTo(new BigDecimal("50"));
+
+        var avgEntry = new BigDecimal(position.get("avgEntryPrice").asText());
+        assertThat(avgEntry).as("avgEntryPrice within CSV bid/ask span ± slippage")
+                .isBetween(new BigDecimal("415.00"), new BigDecimal("416.00"));
+
+        var orders = httpGetAndCheck("/api/orders?symbol=MSFT");
+        assertThat(orders.isArray()).isTrue();
+        assertThat(orders.size()).isGreaterThanOrEqualTo(1);
+        var order = orders.get(0);
+        assertThat(order.get("status").asText()).isEqualTo("FILLED");
+        assertThat(order.get("strategy").asText()).isEqualTo("TWAP");
+    }
+
+    private void bindTwapToMsftWith50Shares() throws Exception {
+        httpPutAndCheck("/api/strategies/MSFT", "{\"strategyName\":\"TWAP\"}");
+        // Single slice over the one-minute window that the simulated CSV ticks fall into
+        // (CSV MSFT ticks are 14:30:00-14:30:02Z == 10:30:00-10:30:02 America/New_York).
+        var params = MAPPER.writeValueAsString(
+                Map.of(
+                    "targetQuantity", 50,
+                    "side", "BUY",
+                    "startTime", "10:30:00",
+                    "endTime", "10:31:00",
+                    "numSlices", 1));
+        // Parameters are addressed by strategy name, not symbol
+        httpPutAndCheck("/api/strategies/TWAP/parameters", params);
     }
 
     private void bindVwapToAppleWith100Shares() throws Exception {
@@ -138,9 +179,10 @@ class SimulatedHappyPathE2ETest {
         return new BigDecimal(position.get("netQuantity").asText());
     }
 
-    private JsonNode getApplePosition() throws Exception {
+    private JsonNode getPosition(String symbol) throws Exception {
+        var requestPath = "/api/positions/" + symbol;
         HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
-                        .uri(URI.create(baseUrl + "/api/positions/AAPL"))
+                        .uri(URI.create(baseUrl + requestPath))
                         .header("X-API-Key", API_KEY)
                         .GET()
                         .timeout(Duration.ofSeconds(3))
@@ -150,7 +192,7 @@ class SimulatedHappyPathE2ETest {
             return null; // position not yet created
         }
         if(response.statusCode() != 200){
-            throw new IllegalStateException("GET /api/positions/AAPL → " + response.statusCode() + " body="+response.body());
+            throw new IllegalStateException("GET " + requestPath + " → " + response.statusCode() + " body="+response.body());
         }
         return MAPPER.readTree(response.body());
     }

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapSlice.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapSlice.java
@@ -1,0 +1,10 @@
+package com.mariaalpha.strategyengine.strategy.twap;
+
+import java.time.LocalTime;
+
+/**
+ * One equal-duration time interval of a TWAP schedule, half-open {@code [startTime, endTime)} in
+ * the market time zone. Unlike VWAP's {@code TimeBin}, a TWAP slice carries no volume fraction —
+ * the parent quantity is divided equally across the configured number of slices.
+ */
+public record TwapSlice(LocalTime startTime, LocalTime endTime) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategy.java
@@ -1,0 +1,251 @@
+package com.mariaalpha.strategyengine.strategy.twap;
+
+import com.mariaalpha.strategyengine.model.MarketTick;
+import com.mariaalpha.strategyengine.model.OrderSignal;
+import com.mariaalpha.strategyengine.model.OrderType;
+import com.mariaalpha.strategyengine.model.Side;
+import com.mariaalpha.strategyengine.strategy.TradingStrategy;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Time-Weighted Average Price execution strategy.
+ *
+ * <p>Splits the trading window {@code [startTime, endTime)} into {@code numSlices} equal-duration
+ * intervals and distributes the parent quantity evenly across them. As the market clock (driven by
+ * tick timestamps, not the wall clock) crosses into each slice, a single LIMIT child order is
+ * emitted at the current best ask (buys) or best bid (sells). Any quantity still unexecuted when
+ * the window closes is swept with a final MARKET order.
+ *
+ * <p>This mirrors {@link com.mariaalpha.strategyengine.strategy.vwap.VwapStrategy} but replaces the
+ * historical volume profile with equal time slicing — see {@code docs/twap-strategy-explainer.md}.
+ */
+@Component
+public class TwapStrategy implements TradingStrategy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TwapStrategy.class);
+  private static final String NAME = "TWAP";
+  static final ZoneId MARKET_ZONE = ZoneId.of("America/New_York");
+  private static final int DEFAULT_NUM_SLICES = 12;
+
+  // Configuration parameters
+  private volatile int targetQuantity;
+  private Side side = Side.BUY;
+  private LocalTime startTime = LocalTime.of(9, 30);
+  private LocalTime endTime = LocalTime.of(16, 0);
+  private volatile int numSlices = DEFAULT_NUM_SLICES;
+
+  // Derived schedule: equal-duration slices spanning [startTime, endTime)
+  private final List<TwapSlice> slices = new ArrayList<>();
+
+  // Computed allocations: sliceIndex -> share count
+  private final List<Integer> sliceAllocations = new ArrayList<>();
+
+  // Execution state: tracks which slices have emitted signals (at-most-once)
+  private final ConcurrentHashMap<Integer, Boolean> sliceExecuted = new ConcurrentHashMap<>();
+  private volatile MarketTick latestTick;
+  private volatile boolean completed;
+
+  public TwapStrategy() {
+    rebuildSchedule();
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void onTick(MarketTick tick) {
+    this.latestTick = tick;
+  }
+
+  @Override
+  public Optional<OrderSignal> evaluate(String symbol) {
+    if (completed || latestTick == null || slices.isEmpty() || targetQuantity <= 0) {
+      return Optional.empty();
+    }
+
+    if (!symbol.equals(latestTick.symbol())) {
+      return Optional.empty();
+    }
+
+    var marketTime = latestTick.timestamp().atZone(MARKET_ZONE).toLocalTime();
+
+    if (marketTime.isBefore(startTime)) {
+      return Optional.empty();
+    }
+
+    // Past end time: sweep remaining quantity
+    if (!marketTime.isBefore(endTime)) {
+      return emitSweep(symbol);
+    }
+
+    // Find current slice
+    int sliceIndex = findSliceIndex(marketTime);
+    if (sliceIndex < 0) {
+      return Optional.empty();
+    }
+
+    // Check if current slice already executed (at-most-once)
+    if (sliceExecuted.putIfAbsent(sliceIndex, Boolean.TRUE) != null) {
+      return Optional.empty();
+    }
+
+    int qty = sliceAllocations.get(sliceIndex);
+    if (qty <= 0) {
+      return Optional.empty();
+    }
+
+    var limitPrice = resolveLimitPrice();
+    LOG.info(
+        "TWAP slice {} emitting {} {} {} shares at {}", sliceIndex, side, symbol, qty, limitPrice);
+
+    return Optional.of(
+        new OrderSignal(
+            symbol, side, qty, OrderType.LIMIT, limitPrice, NAME, latestTick.timestamp()));
+  }
+
+  @Override
+  public Map<String, Object> getParameters() {
+    return Map.of(
+        "targetQuantity", targetQuantity,
+        "side", side.name(),
+        "startTime", startTime.toString(),
+        "endTime", endTime.toString(),
+        "numSlices", numSlices,
+        "slices", List.copyOf(slices),
+        "executedSlices", sliceExecuted.size(),
+        "totalSlices", slices.size());
+  }
+
+  @Override
+  public void updateParameters(Map<String, Object> params) {
+    if (params.containsKey("targetQuantity")) {
+      this.targetQuantity = ((Number) params.get("targetQuantity")).intValue();
+    }
+    if (params.containsKey("side")) {
+      this.side = Side.valueOf((String) params.get("side"));
+    }
+    if (params.containsKey("startTime")) {
+      this.startTime = LocalTime.parse((String) params.get("startTime"));
+    }
+    if (params.containsKey("endTime")) {
+      this.endTime = LocalTime.parse((String) params.get("endTime"));
+    }
+    if (params.containsKey("numSlices")) {
+      this.numSlices = ((Number) params.get("numSlices")).intValue();
+    }
+    rebuildSchedule();
+    computeAllocations();
+    resetExecutionState();
+  }
+
+  /**
+   * Rebuilds the equal-duration slice schedule from {@code startTime}, {@code endTime}, and {@code
+   * numSlices}. Boundaries are computed in whole seconds from the window start so they never drift
+   * past {@code endTime}; the final boundary lands exactly on {@code endTime}. Produces no slices
+   * when the window is empty/inverted or {@code numSlices <= 0}.
+   */
+  private void rebuildSchedule() {
+    slices.clear();
+    long totalSeconds = Duration.between(startTime, endTime).getSeconds();
+    if (numSlices <= 0 || totalSeconds <= 0) {
+      return;
+    }
+    var boundary = startTime;
+    for (var i = 1; i <= numSlices; i++) {
+      long offsetSeconds = Math.round((double) i * totalSeconds / numSlices);
+      var nextBoundary = startTime.plusSeconds(offsetSeconds);
+      slices.add(new TwapSlice(boundary, nextBoundary));
+      boundary = nextBoundary;
+    }
+  }
+
+  /**
+   * Computes per-slice share allocations by dividing the target quantity equally. The last slice
+   * absorbs any rounding remainder so the allocations always sum to {@code targetQuantity}.
+   */
+  private void computeAllocations() {
+    sliceAllocations.clear();
+    if (slices.isEmpty() || targetQuantity <= 0) {
+      return;
+    }
+    int perSlice = (int) Math.round((double) targetQuantity / slices.size());
+    int allocated = 0;
+    for (var i = 0; i < slices.size() - 1; i++) {
+      sliceAllocations.add(perSlice);
+      allocated += perSlice;
+    }
+    sliceAllocations.add(targetQuantity - allocated);
+  }
+
+  /** Resets execution state for a fresh run. */
+  private void resetExecutionState() {
+    sliceExecuted.clear();
+    latestTick = null;
+    completed = false;
+  }
+
+  /** Resolves the limit price from the latest tick based on side. */
+  private BigDecimal resolveLimitPrice() {
+    if (side == Side.BUY) {
+      // buy at the ask
+      var ask = latestTick.askPrice();
+      return ask.compareTo(BigDecimal.ZERO) > 0 ? ask : latestTick.price();
+    }
+    // sell at the bid
+    var bid = latestTick.bidPrice();
+    return bid.compareTo(BigDecimal.ZERO) > 0 ? bid : latestTick.price();
+  }
+
+  /** Computes the total remaining (unexecuted) quantity. */
+  private int remainingQuantity() {
+    int executed = 0;
+    for (var entry : sliceExecuted.entrySet()) {
+      int idx = entry.getKey();
+      if (idx >= 0 && idx < sliceAllocations.size()) {
+        executed += sliceAllocations.get(idx);
+      }
+    }
+    return targetQuantity - executed;
+  }
+
+  /** Finds the slice index for the given market time. Returns -1 if not in any slice. */
+  private int findSliceIndex(LocalTime marketTime) {
+    for (var i = 0; i < slices.size(); i++) {
+      var slice = slices.get(i);
+      if (!marketTime.isBefore(slice.startTime()) && marketTime.isBefore(slice.endTime())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** Emits a MARKET sweep for any remaining unexecuted quantity. */
+  private Optional<OrderSignal> emitSweep(String symbol) {
+    if (completed) {
+      return Optional.empty();
+    }
+    int remaining = remainingQuantity();
+    if (remaining <= 0) {
+      completed = true;
+      return Optional.empty();
+    }
+    completed = true;
+    LOG.info("TWAP sweep: {} {} {} shares at MARKET", side, symbol, remaining);
+    return Optional.of(
+        new OrderSignal(
+            symbol, side, remaining, OrderType.MARKET, null, NAME, latestTick.timestamp()));
+  }
+}

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/consumer/TickConsumerIntegrationTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/consumer/TickConsumerIntegrationTest.java
@@ -144,4 +144,74 @@ public class TickConsumerIntegrationTest {
     assertThat(signal.side()).isEqualTo(Side.BUY);
     assertThat(signal.quantity()).isEqualTo(500);
   }
+
+  @Test
+  void twapTickPublishedToKafkaTriggersSignalOnStrategySignalsTopic() throws Exception {
+    // Configure TWAP: 300 shares, single full-day slice, so any trading-hours tick fires it.
+    var twapStrategy = strategyRegistry.get("TWAP").orElseThrow();
+    twapStrategy.updateParameters(
+        Map.of(
+            "targetQuantity", 300,
+            "side", "SELL",
+            "startTime", "09:30",
+            "endTime", "16:00",
+            "numSlices", 1));
+    router.setActiveStrategy("MSFT", "TWAP");
+
+    var ts =
+        ZonedDateTime.of(
+                LocalDate.of(2026, 3, 24), LocalTime.of(11, 0), ZoneId.of("America/New_York"))
+            .toInstant();
+    var tick =
+        new MarketTick(
+            "MSFT",
+            ts,
+            EventType.QUOTE,
+            BigDecimal.ZERO,
+            0L,
+            new BigDecimal("415.30"),
+            new BigDecimal("415.40"),
+            100L,
+            80L,
+            0L,
+            DataSource.ALPACA,
+            false);
+
+    var props = new HashMap<String, Object>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-twap-" + Instant.now().toEpochMilli());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+    var captured = new AtomicReference<OrderSignal>();
+
+    try (var consumer = new KafkaConsumer<String, String>(props)) {
+      consumer.subscribe(List.of("strategy.signals"));
+
+      kafkaTemplate.send("market-data.ticks", "MSFT", objectMapper.writeValueAsString(tick)).get();
+
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .pollInterval(Duration.ofMillis(500))
+          .until(
+              () -> {
+                var records = consumer.poll(Duration.ofMillis(200));
+                for (var record : records) {
+                  var signal = objectMapper.readValue(record.value(), OrderSignal.class);
+                  if ("MSFT".equals(signal.symbol())) {
+                    captured.set(signal);
+                    return true;
+                  }
+                }
+                return false;
+              });
+    }
+
+    var signal = captured.get();
+    assertThat(signal.symbol()).isEqualTo("MSFT");
+    assertThat(signal.side()).isEqualTo(Side.SELL);
+    assertThat(signal.quantity()).isEqualTo(300);
+    assertThat(signal.strategyName()).isEqualTo("TWAP");
+  }
 }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategyTest.java
@@ -1,0 +1,341 @@
+package com.mariaalpha.strategyengine.strategy.twap;
+
+import static com.mariaalpha.strategyengine.strategy.twap.TwapStrategy.MARKET_ZONE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mariaalpha.strategyengine.model.DataSource;
+import com.mariaalpha.strategyengine.model.EventType;
+import com.mariaalpha.strategyengine.model.MarketTick;
+import com.mariaalpha.strategyengine.model.OrderSignal;
+import com.mariaalpha.strategyengine.model.OrderType;
+import com.mariaalpha.strategyengine.model.Side;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TwapStrategyTest {
+
+  private static final String AAPL = "AAPL";
+
+  // Standard test window: 09:30-13:30, four equal one-hour slices.
+  //   slice 0: 09:30-10:30, slice 1: 10:30-11:30, slice 2: 11:30-12:30, slice 3: 12:30-13:30
+  private static final LocalTime WINDOW_START = LocalTime.of(9, 30);
+  private static final LocalTime WINDOW_END = LocalTime.of(13, 30);
+  private static final int FOUR_SLICES = 4;
+
+  private TwapStrategy strategy;
+
+  @BeforeEach
+  void setUp() {
+    strategy = new TwapStrategy();
+  }
+
+  @Test
+  void nameReturnsTwap() {
+    assertThat(strategy.name()).isEqualTo("TWAP");
+  }
+
+  @Test
+  void defaultScheduleSpansTwelveSlices() {
+    // Constructor builds the default 09:30-16:00 schedule with 12 slices.
+    var params = strategy.getParameters();
+    assertThat(params.get("totalSlices")).isEqualTo(12);
+    assertThat(params.get("numSlices")).isEqualTo(12);
+  }
+
+  @Test
+  void evaluateReturnsEmptyBeforeConfiguration() {
+    // Fresh strategy: schedule exists but targetQuantity is 0.
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
+  }
+
+  @Test
+  void evaluateReturnsEmptyBeforeStartTime() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(quoteTick(AAPL, etInstant(9, 0), "178.50", "178.54"));
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
+  }
+
+  @Test
+  void evaluateEmitsOrderInCorrectSlice() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    var orderSignal = signal.get();
+    assertThat(orderSignal.symbol()).isEqualTo(AAPL);
+    assertThat(orderSignal.side()).isEqualTo(Side.BUY);
+    assertThat(orderSignal.quantity()).isEqualTo(250);
+    assertThat(orderSignal.orderType()).isEqualTo(OrderType.LIMIT);
+    assertThat(orderSignal.limitPrice()).isEqualByComparingTo(new BigDecimal("178.54"));
+    assertThat(orderSignal.strategyName()).isEqualTo("TWAP");
+  }
+
+  @Test
+  void evaluateDoesNotReemitForSameSlice() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    strategy.evaluate(AAPL); // first call emits
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 15), "178.50", "178.54"));
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
+  }
+
+  @Test
+  void evaluateEmitsForNextSliceWhenTimeAdvances() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+
+    // Slice 0
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    strategy.evaluate(AAPL);
+
+    // Slice 1 (10:30-11:30)
+    strategy.onTick(quoteTick(AAPL, etInstant(11, 0), "179.00", "179.04"));
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    var orderSignal = signal.get();
+    assertThat(orderSignal.quantity()).isEqualTo(250);
+    assertThat(orderSignal.limitPrice()).isEqualByComparingTo(new BigDecimal("179.04"));
+  }
+
+  @Test
+  void evaluateEmitsMarketSweepAtEndTime() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+
+    // Execute only slice 0 (250 shares)
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    strategy.evaluate(AAPL);
+
+    // Jump past end time
+    strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
+
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    var orderSignal = signal.get();
+    assertThat(orderSignal.quantity()).isEqualTo(750);
+    assertThat(orderSignal.orderType()).isEqualTo(OrderType.MARKET);
+    assertThat(orderSignal.limitPrice()).isNull();
+  }
+
+  @Test
+  void sweepEmitsOnlyOnce() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
+    assertThat(strategy.evaluate(AAPL)).isPresent(); // sweep
+    strategy.onTick(quoteTick(AAPL, etInstant(13, 40), "180.00", "180.04"));
+    assertThat(strategy.evaluate(AAPL)).isEmpty(); // completed
+  }
+
+  @Test
+  void noSweepWhenFullyExecuted() {
+    // Single slice covering the whole window: it fully executes, so end-of-window has nothing left.
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, 1);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    assertThat(strategy.evaluate(AAPL)).get().extracting(OrderSignal::quantity).isEqualTo(1000);
+
+    strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
+  }
+
+  @Test
+  void evaluateIgnoresTicksForDifferentSymbol() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.52"));
+    assertThat(strategy.evaluate("MSFT")).isEmpty();
+  }
+
+  @Test
+  void tradePriceFallbackWhenNoQuote() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.52"));
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    assertThat(signal.get().limitPrice()).isEqualByComparingTo(new BigDecimal("178.52"));
+  }
+
+  @Test
+  void sellSideUsesBidPrice() {
+    configureStrategy(1000, Side.SELL, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    var orderSignal = signal.get();
+    assertThat(orderSignal.side()).isEqualTo(Side.SELL);
+    assertThat(orderSignal.limitPrice()).isEqualByComparingTo(new BigDecimal("178.50"));
+  }
+
+  @Test
+  void allocationRemainderGoesToLastSlice() {
+    // 1001 shares over 3 one-hour slices (09:30-12:30): 334, 334, 333.
+    configureStrategy(1001, Side.BUY, WINDOW_START, LocalTime.of(12, 30), 3);
+
+    int total = 0;
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    total += strategy.evaluate(AAPL).orElseThrow().quantity();
+    strategy.onTick(quoteTick(AAPL, etInstant(11, 0), "178.50", "178.54"));
+    total += strategy.evaluate(AAPL).orElseThrow().quantity();
+    strategy.onTick(quoteTick(AAPL, etInstant(12, 0), "178.50", "178.54"));
+    total += strategy.evaluate(AAPL).orElseThrow().quantity();
+
+    assertThat(total).isEqualTo(1001);
+  }
+
+  @Test
+  void fullTradingDaySimulation() {
+    // 10,000 shares, default 09:30-16:00 window, 13 thirty-minute slices.
+    configureStrategy(10000, Side.BUY, LocalTime.of(9, 30), LocalTime.of(16, 0), 13);
+    var signals = new ArrayList<OrderSignal>();
+
+    var baseDate = LocalDate.of(2026, 3, 24);
+    for (int hour = 9; hour <= 15; hour++) {
+      int startMin = (hour == 9) ? 30 : 0;
+      for (int min = startMin; min < 60; min += 15) {
+        var ts = ZonedDateTime.of(baseDate, LocalTime.of(hour, min), MARKET_ZONE).toInstant();
+        strategy.onTick(quoteTick(AAPL, ts, "178.50", "178.54"));
+        strategy.evaluate(AAPL).ifPresent(signals::add);
+      }
+    }
+
+    // EOD: tick at 16:00 triggers sweep if needed
+    var closeTs = ZonedDateTime.of(baseDate, LocalTime.of(16, 0), MARKET_ZONE).toInstant();
+    strategy.onTick(quoteTick(AAPL, closeTs, "178.50", "178.54"));
+    strategy.evaluate(AAPL).ifPresent(signals::add);
+
+    int totalQty = signals.stream().mapToInt(OrderSignal::quantity).sum();
+    assertThat(totalQty).isEqualTo(10000);
+
+    // All 13 slices fire as LIMIT orders; nothing left for the sweep.
+    var limitSignals = signals.stream().filter(s -> s.orderType() == OrderType.LIMIT).toList();
+    assertThat(limitSignals).hasSize(13);
+    assertThat(signals).allMatch(s -> s.symbol().equals(AAPL));
+    assertThat(signals).allMatch(s -> s.side() == Side.BUY);
+  }
+
+  @Test
+  void getParametersReturnsCurrentState() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    var params = strategy.getParameters();
+    assertThat(params.get("targetQuantity")).isEqualTo(1000);
+    assertThat(params.get("side")).isEqualTo("BUY");
+    assertThat(params.get("numSlices")).isEqualTo(4);
+    assertThat(params.get("totalSlices")).isEqualTo(4);
+    assertThat(params.get("executedSlices")).isEqualTo(0);
+
+    @SuppressWarnings("unchecked")
+    var slices = (List<TwapSlice>) params.get("slices");
+    assertThat(slices).hasSize(4);
+    assertThat(slices.getFirst().startTime()).isEqualTo(LocalTime.of(9, 30));
+    assertThat(slices.getLast().endTime()).isEqualTo(LocalTime.of(13, 30));
+  }
+
+  @Test
+  void executedSlicesCountTracksProgress() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    strategy.evaluate(AAPL);
+    assertThat(strategy.getParameters().get("executedSlices")).isEqualTo(1);
+  }
+
+  @Test
+  void updateParametersResetsState() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+
+    // Execute slice 0
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    assertThat(strategy.evaluate(AAPL)).isPresent();
+
+    // Reconfigure with a new target and side
+    configureStrategy(2000, Side.SELL, WINDOW_START, WINDOW_END, FOUR_SLICES);
+
+    // Slice 0 should fire again (state was reset) with the new allocation
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    var orderSignal = signal.get();
+    assertThat(orderSignal.quantity()).isEqualTo(500);
+    assertThat(orderSignal.side()).isEqualTo(Side.SELL);
+  }
+
+  @Test
+  void partialParameterUpdatePreservesOtherFields() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
+    // Update only the target quantity; window and slice count must be retained.
+    strategy.updateParameters(Map.of("targetQuantity", 800));
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    var signal = strategy.evaluate(AAPL);
+    assertThat(signal).isPresent();
+    assertThat(signal.get().quantity()).isEqualTo(200); // 800 / 4 slices
+  }
+
+  @Test
+  void invertedWindowProducesNoSchedule() {
+    configureStrategy(1000, Side.BUY, LocalTime.of(13, 30), LocalTime.of(9, 30), FOUR_SLICES);
+    assertThat(strategy.getParameters().get("totalSlices")).isEqualTo(0);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
+  }
+
+  @Test
+  void zeroSlicesProducesNoSchedule() {
+    configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, 0);
+    assertThat(strategy.getParameters().get("totalSlices")).isEqualTo(0);
+    strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
+  }
+
+  private static Instant etInstant(int hour, int minute) {
+    return ZonedDateTime.of(LocalDate.of(2026, 3, 24), LocalTime.of(hour, minute), MARKET_ZONE)
+        .toInstant();
+  }
+
+  private static MarketTick quoteTick(String symbol, Instant ts, String bid, String ask) {
+    return new MarketTick(
+        symbol,
+        ts,
+        EventType.QUOTE,
+        BigDecimal.ZERO,
+        0L,
+        new BigDecimal(bid),
+        new BigDecimal(ask),
+        100L,
+        80L,
+        0L,
+        DataSource.ALPACA,
+        false);
+  }
+
+  private static MarketTick tradeTick(String symbol, Instant ts, String price) {
+    return new MarketTick(
+        symbol,
+        ts,
+        EventType.TRADE,
+        new BigDecimal(price),
+        100L,
+        BigDecimal.ZERO,
+        BigDecimal.ZERO,
+        0L,
+        0L,
+        0L,
+        DataSource.ALPACA,
+        false);
+  }
+
+  private void configureStrategy(
+      int targetQty, Side side, LocalTime start, LocalTime end, int numSlices) {
+    var params = new HashMap<String, Object>();
+    params.put("targetQuantity", targetQty);
+    params.put("side", side.name());
+    params.put("startTime", start.toString());
+    params.put("endTime", end.toString());
+    params.put("numSlices", numSlices);
+    strategy.updateParameters(params);
+  }
+}


### PR DESCRIPTION
  **Summary**
     
  **Implementation (strategy-engine)**
  - strategy/twap/TwapStrategy.java — TradingStrategy impl, auto-registered as a Spring @Component, so StrategyRegistry discovers it with zero wiring changes (per the issue: "Register via StrategyRegistry").
  Divides [startTime, endTime) into numSlices equal intervals, allocates the parent quantity evenly (last slice absorbs rounding), emits one LIMIT child per slice at best ask/bid, and sweeps any remainder with
   a MARKET order at the deadline. Clock driven by tick timestamps in America/New_York, mirroring VWAP.
  - strategy/twap/TwapSlice.java — equal-duration interval record.
  
  **Tests — all green**                                                                                 
  - Unit TwapStrategyTest: 21/21 pass, 98% instruction / 83% branch coverage (clears the >80% bar).
  - Integration TickConsumerIntegrationTest: TWAP case added; 2/2 pass against a real Kafka Testcontainer (tick → TWAP signal on strategy.signals).
  - E2E SimulatedHappyPathE2ETest: MSFT → TWAP added through the full Docker Compose stack; 2/2 pass (7-min run, stack torn down clean). Relaxed the VWAP test's openPositions == 1 to >= 1 so both cases
  coexist.
  - Full :strategy-engine:check (Spotless, Checkstyle, SpotBugs, tests) BUILD SUCCESSFUL.

  **Docs**
  - TDD §11: issue 2.1.5 marked ✅.
  - New docs/twap-strategy-explainer.md.
  - vwap-strategy-explainer.md: TWAP refs updated (diagram + §6 cross-link).
  - README: feature list, Phase-2 status line, and a TWAP curl example.
  
  The acceptance criteria (TDD-spec implementation, >80% unit coverage, integration tests, metrics) are all met — and TWAP signals flow through the existing ML veto/publish path and Prometheus metrics
  automatically via the strategy="TWAP" tag, no extra wiring.

Closes #57