### PR TITLE
Fix e2e: VWAP/RFQ AAPL order collision in SimulatedHappyPathE2ETest

### DIFF
--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
@@ -105,7 +105,10 @@ class SimulatedHappyPathE2ETest {
         assertThat(portfolio.get("openPositions").asInt()).isGreaterThanOrEqualTo(1);
         assertThat(portfolio.has("totalPnl")).isTrue();
 
-        var orders = httpGetAndCheck("/api/orders?symbol=AAPL");
+        // Filter by strategy=VWAP because rfqQuoteReturnsTwoWayBookAndAcceptPublishesOrderSignal
+        // also opens an AAPL order with strategy=RFQ; JUnit test order is not guaranteed and an
+        // unfiltered orders.get(0) can pick up the RFQ order instead of this test's VWAP fill.
+        var orders = httpGetAndCheck("/api/orders?symbol=AAPL&strategy=VWAP");
         assertThat(orders.isArray()).isTrue();
         assertThat(orders.size()).isGreaterThanOrEqualTo(1);
         var order = orders.get(0);


### PR DESCRIPTION
## Summary
- \`simulatedTickReachesPositionWithFillAndPnl\` reads \`/api/orders?symbol=AAPL\` and asserts \`orders.get(0).strategy == \"VWAP\"\`, but \`rfqQuoteReturnsTwoWayBookAndAcceptPublishesOrderSignal\` also opens an AAPL order (\`strategy=RFQ\`) in the same stack lifecycle.
- JUnit method order isn't guaranteed; on the failing main-branch run the RFQ test ran first, so the unfiltered query returned the RFQ order and the VWAP assertion failed (\`expected: \"VWAP\" but was: \"RFQ\"\`).
- Scope the query to \`strategy=VWAP\`, matching the pattern the \`NVDA/CLOSE\` (line 188) and \`TSLA/POV\` (line 216) tests in this same class already use.

## Test plan
- [x] CI runs \`:e2e-tests:test\` against the simulated stack with all 6 test methods green, regardless of execution order.
- [x] No other tests touched; this is a one-file, scoped-query change.