### PR TITLE
2.7.4 Distributed Caching & 2.7.5 Bruno Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Phase 1 is complete. MariaAlpha ships as a working, end-to-end algorithmic tradi
 
 The Phase 1 acceptance test — `SimulatedHappyPathE2ETest` — boots the full Docker Compose stack (15 long-running services + a one-shot Kafka topics initializer) and traverses the complete Tick-to-Trade pipeline on every CI run. See [`docs/phase-1-completion.md`](docs/phase-1-completion.md) for the full record of what was built.
 
-Phase 2 work has begun landing on `main`: the Smart Order Router (issue 2.1.1), the advanced order-type handlers IOC / FOK / GTC / Iceberg (2.1.3, 2.1.4), the TWAP execution strategy (2.1.5), the Momentum / trend-following strategy (2.1.6), the Implementation Shortfall execution strategy (2.1.7), the POV (Percentage of Volume) execution strategy (2.1.8), the Close (Market-on-Close) execution strategy (2.1.9), the internal crossing / internalization engine (2.1.10), the sector / beta / ADV pre-trade risk checks (2.2.1 / 2.2.2 / 2.2.3), the Analytics Service with flow-toxicity / PnL attribution / axe matcher (2.2.4 / 2.2.5 / 2.2.6), and the umbrella Helm chart for Kubernetes deployment (2.7.1) are all shipped. Remaining Phase 2 items — the Redis distributed position cache, regime classifier, Playwright UI e2e tests, and the docker image publish workflow — are tracked in [§11 of the Technical Design Document](docs/technical-design-document.md#phase-2-full-desk-workflows--sor--rich-analytics).
+Phase 2 work has begun landing on `main`: the Smart Order Router (issue 2.1.1), the advanced order-type handlers IOC / FOK / GTC / Iceberg (2.1.3, 2.1.4), the TWAP execution strategy (2.1.5), the Momentum / trend-following strategy (2.1.6), the Implementation Shortfall execution strategy (2.1.7), the POV (Percentage of Volume) execution strategy (2.1.8), the Close (Market-on-Close) execution strategy (2.1.9), the internal crossing / internalization engine (2.1.10), the sector / beta / ADV pre-trade risk checks (2.2.1 / 2.2.2 / 2.2.3), the Analytics Service with flow-toxicity / PnL attribution / axe matcher (2.2.4 / 2.2.5 / 2.2.6), the umbrella Helm chart for Kubernetes deployment (2.7.1), the docker image publish workflow (2.7.2), mutation testing in CI (2.7.3), the **Redis distributed position cache (2.7.4)**, and the **Bruno API collection (2.7.5, in [`api-collection/`](api-collection/))** are all shipped. See [§11 of the Technical Design Document](docs/technical-design-document.md#phase-2-full-desk-workflows--sor--rich-analytics) for the full Phase 2 roadmap.
 
 ## Prerequisites
 
@@ -286,6 +286,7 @@ docker compose down -v
 | --- | --- | --- |
 | PostgreSQL 16 | 5432 | Credentials via `.env` |
 | Kafka (KRaft) | 9092 | Single-node, no ZooKeeper |
+| Redis 7 | 6379 | Phase-2 (issue 2.7.4) position cache; `allkeys-lru` eviction |
 | Prometheus | 9090 | Metrics storage, remote-write enabled |
 | Grafana | 3001 | Dashboards — anonymous admin access |
 | Alloy | 12345 | Telemetry collector UI; OTLP on 4317/4318 |

--- a/api-collection/00 - Health/Gateway Health.bru
+++ b/api-collection/00 - Health/Gateway Health.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Gateway Health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/actuator/health
+  body: none
+  auth: none
+}
+
+headers {
+  ~X-API-Key: {{apiKey}}
+}
+
+docs {
+  Liveness + readiness aggregated. Returns 200 with JSON body. The `/actuator/**`
+  prefix is on the excluded-paths allowlist so no API key is required here.
+}

--- a/api-collection/00 - Health/Gateway Liveness.bru
+++ b/api-collection/00 - Health/Gateway Liveness.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Gateway Liveness
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/actuator/health/liveness
+  body: none
+  auth: none
+}

--- a/api-collection/00 - Health/Gateway Prometheus.bru
+++ b/api-collection/00 - Health/Gateway Prometheus.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Gateway Prometheus Metrics
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/actuator/prometheus
+  body: none
+  auth: none
+}

--- a/api-collection/00 - Health/Gateway Readiness.bru
+++ b/api-collection/00 - Health/Gateway Readiness.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Gateway Readiness
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/actuator/health/readiness
+  body: none
+  auth: none
+}

--- a/api-collection/01 - Strategies/Active Strategy For Symbol.bru
+++ b/api-collection/01 - Strategies/Active Strategy For Symbol.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Active Strategy For Symbol
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/strategies/AAPL/active
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Returns the currently active strategy name for a single symbol. 404 if no
+  strategy is bound to the symbol yet.
+}

--- a/api-collection/01 - Strategies/Get Strategy Parameters.bru
+++ b/api-collection/01 - Strategies/Get Strategy Parameters.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Strategy Parameters
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/strategies/VWAP/parameters
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  VWAP parameters are keyed by ISO-8601 instants for the start/end window plus a
+  target volume fraction (see [[vwap_strategy_params]] memory). The shape varies
+  per strategy — TWAP exposes `sliceCount` and `interval`, MOMENTUM exposes
+  `lookbackBars` and `signalThreshold`, etc.
+}

--- a/api-collection/01 - Strategies/List Strategies.bru
+++ b/api-collection/01 - Strategies/List Strategies.bru
@@ -1,0 +1,20 @@
+meta {
+  name: List Strategies
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/strategies
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Returns the set of available strategy names (VWAP, TWAP, MOMENTUM,
+  IMPLEMENTATION_SHORTFALL, POV, CLOSE).
+}

--- a/api-collection/01 - Strategies/Set Active Strategy.bru
+++ b/api-collection/01 - Strategies/Set Active Strategy.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Set Active Strategy
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/api/strategies/AAPL
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "strategyName": "VWAP"
+  }
+}
+
+docs {
+  Binds a strategy to a symbol. Returns 200 on success, 400 if the strategy
+  name is unknown.
+}

--- a/api-collection/01 - Strategies/Strategy State.bru
+++ b/api-collection/01 - Strategies/Strategy State.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Strategy State (All Symbols)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/strategies/state
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Aggregated per-symbol state — active strategy + latest ML signal/regime
+  classification. Powers the UI Strategy Control page (issue 2.5.2). Add
+  `?symbol=AAPL` to filter.
+}

--- a/api-collection/01 - Strategies/Update Strategy Parameters.bru
+++ b/api-collection/01 - Strategies/Update Strategy Parameters.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Update Strategy Parameters
+  type: http
+  seq: 6
+}
+
+put {
+  url: {{baseUrl}}/api/strategies/VWAP/parameters
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "startTime": "09:30",
+    "endTime": "16:00",
+    "volumeFraction": 0.05
+  }
+}
+
+docs {
+  VWAP slicing window is Eastern time (the Strategy Engine converts internally —
+  do NOT send UTC). volumeFraction in [0,1] caps each slice as a fraction of
+  the symbol's historical traded volume.
+}

--- a/api-collection/02 - RFQ/Accept Quote.bru
+++ b/api-collection/02 - RFQ/Accept Quote.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Accept Quote
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/rfq/accept
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "quoteId": "{{lastQuoteId}}",
+    "side": "BUY",
+    "price": "{{lastQuoteAsk}}"
+  }
+}
+
+docs {
+  Accepts a previously issued quote. The price must match the quoted bid (for
+  SELL) or ask (for BUY) within $0.01. Returns 410 if expired, 409 if price
+  mismatched. On success an OrderSignal is published to the signals topic and
+  the response includes the signal payload.
+}

--- a/api-collection/02 - RFQ/Lookup Quote.bru
+++ b/api-collection/02 - RFQ/Lookup Quote.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Lookup Quote
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/rfq/quotes/{{lastQuoteId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Debug endpoint — returns whatever the in-memory store remembers about a
+  quote, active or expired. 404 if never issued.
+}

--- a/api-collection/02 - RFQ/Request Quote.bru
+++ b/api-collection/02 - RFQ/Request Quote.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Request Quote
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/rfq/quote
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "symbol": "AAPL",
+    "quantity": 1000
+  }
+}
+
+docs {
+  Inventory- and volatility-aware two-way quote (issues 2.4.1 / 2.4.2). Returns
+  `quoteId`, `bid`, `ask`, `validForMs`, `symbol`, `quantity`. Save the
+  `quoteId` to accept in the next request.
+}
+
+script:post-response {
+  if (res.status === 200 && res.body && res.body.quoteId) {
+    bru.setVar("lastQuoteId", res.body.quoteId);
+    bru.setVar("lastQuoteBid", res.body.bid);
+    bru.setVar("lastQuoteAsk", res.body.ask);
+  }
+}

--- a/api-collection/03 - Orders/Fills By Date.bru
+++ b/api-collection/03 - Orders/Fills By Date.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Fills By Date (Recon Source)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/orders/fills/by-date?date=2026-06-02
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  date: 2026-06-02
+}
+
+docs {
+  Powers the post-trade EOD reconciliation engine (issue 2.6.1). Each row is
+  enriched with the parent order's `clientOrderId` + `exchangeOrderId` so the
+  consumer can match against venue activity without a follow-up call.
+}

--- a/api-collection/03 - Orders/Get Order By Id.bru
+++ b/api-collection/03 - Orders/Get Order By Id.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get Order By Id
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/orders/{{orderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+vars:pre-request {
+  orderId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Returns the order with all its fills (filled-at ascending). Set the
+  `orderId` variable to a real UUID before calling.
+}

--- a/api-collection/03 - Orders/List Orders.bru
+++ b/api-collection/03 - Orders/List Orders.bru
@@ -1,0 +1,30 @@
+meta {
+  name: List Orders
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/orders?limit=50
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  limit: 50
+  ~symbol: AAPL
+  ~status: FILLED
+  ~strategy: VWAP
+  ~from: 2026-06-02T00:00:00Z
+  ~to: 2026-06-03T00:00:00Z
+}
+
+docs {
+  Lists orders with optional filters. `limit` is clamped to [1, 500]. Each
+  result is an OrderResponse with the parent order and (for /{orderId}) its
+  associated fills.
+}

--- a/api-collection/04 - Positions/Get Position For Symbol.bru
+++ b/api-collection/04 - Positions/Get Position For Symbol.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Position For Symbol
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/positions/AAPL
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Position for a single symbol. 404 if no position has ever been opened.
+}

--- a/api-collection/04 - Positions/List Positions.bru
+++ b/api-collection/04 - Positions/List Positions.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List Positions
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/positions
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Returns every position the order-manager has on file — long, short, or flat.
+  Phase-2 (issue 2.7.4) Redis cache duplicates each row at
+  `mariaalpha:position:<symbol>` for sub-millisecond cross-service reads by
+  the execution-engine's risk checks; this REST endpoint remains the
+  authoritative read-from-Postgres path.
+}

--- a/api-collection/05 - Portfolio/Portfolio Summary.bru
+++ b/api-collection/05 - Portfolio/Portfolio Summary.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Portfolio Summary
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/portfolio/summary
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Aggregate portfolio dashboard data: total value, cash, gross/net exposure,
+  realized + unrealized PnL, open position count. Refreshed on every fill.
+}

--- a/api-collection/06 - Execution/Cancel Order.bru
+++ b/api-collection/06 - Execution/Cancel Order.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Cancel Order
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/api/execution/orders/{{lastSubmittedOrderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Cancels a working order by id. Returns 204 NO CONTENT on success, 404 if
+  the order is unknown or already terminal.
+}

--- a/api-collection/06 - Execution/Iceberg Progress.bru
+++ b/api-collection/06 - Execution/Iceberg Progress.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Iceberg Progress
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/execution/orders/{{lastIcebergParentId}}/iceberg-progress
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Live slice progress for an ICEBERG parent — total qty, displayed qty,
+  remaining, child order ids. 404 if the parent never entered the coordinator
+  (e.g. it was rejected by risk).
+}

--- a/api-collection/06 - Execution/Internal Crossing Book.bru
+++ b/api-collection/06 - Execution/Internal Crossing Book.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Internal Crossing Book
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/api/execution/internal-crossing/book
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Live snapshot of per-symbol resting interest in the internal book.
+}

--- a/api-collection/06 - Execution/Internal Crossing Recent.bru
+++ b/api-collection/06 - Execution/Internal Crossing Recent.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Internal Crossing Recent Matches
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/api/execution/internal-crossing/recent
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Last N internal crosses (newest first), capped by the engine's internal
+  ring buffer.
+}

--- a/api-collection/06 - Execution/Internal Crossing Stats.bru
+++ b/api-collection/06 - Execution/Internal Crossing Stats.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Internal Crossing Stats
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/api/execution/internal-crossing/stats
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Aggregate stats for the internal crossing engine (issue 2.1.10): crosses,
+  shares matched, average spread captured, resting depth.
+}

--- a/api-collection/06 - Execution/Resume After Halt.bru
+++ b/api-collection/06 - Execution/Resume After Halt.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Resume After Halt
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/execution/resume
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Clears the trading-halt flag set by DailyLossLimitCheck. Daily PnL is NOT
+  reset by this call — that happens automatically at the next trading-day
+  boundary.
+}

--- a/api-collection/06 - Execution/Status.bru
+++ b/api-collection/06 - Execution/Status.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Execution Status
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/execution/status
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Returns `tradingHalted` boolean + current `dailyPnl`. Trading halts
+  automatically when DailyLossLimitCheck trips (TDD §7.6); use the Resume
+  request to clear the halt.
+}

--- a/api-collection/06 - Execution/Submit Order - Iceberg.bru
+++ b/api-collection/06 - Execution/Submit Order - Iceberg.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Submit Manual Order (ICEBERG)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/execution/orders
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "symbol": "AAPL",
+    "side": "BUY",
+    "orderType": "ICEBERG",
+    "quantity": 600,
+    "limitPrice": 175.50,
+    "displayQuantity": 100,
+    "tif": "DAY",
+    "clientOrderId": "iceberg-{{$randomUUID}}"
+  }
+}
+
+docs {
+  ICEBERG parent — the IcebergCoordinator slices into `displayQuantity`-sized
+  LIMIT children. Track per-slice progress with the Iceberg Progress request.
+}
+
+script:post-response {
+  if (res.status === 202 && res.body && res.body.orderId) {
+    bru.setVar("lastIcebergParentId", res.body.orderId);
+  }
+}

--- a/api-collection/06 - Execution/Submit Order - Limit.bru
+++ b/api-collection/06 - Execution/Submit Order - Limit.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Submit Manual Order (LIMIT)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/execution/orders
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "symbol": "AAPL",
+    "side": "BUY",
+    "orderType": "LIMIT",
+    "quantity": 100,
+    "limitPrice": 175.50,
+    "tif": "DAY",
+    "clientOrderId": "manual-{{$randomUUID}}"
+  }
+}
+
+docs {
+  Submits a manually-entered order through the same risk-check + SOR pipeline
+  as strategy-emitted signals. Returns 202 ACCEPTED with the assigned orderId.
+}
+
+script:post-response {
+  if (res.status === 202 && res.body && res.body.orderId) {
+    bru.setVar("lastSubmittedOrderId", res.body.orderId);
+  }
+}

--- a/api-collection/07 - Routing/Decision For Order.bru
+++ b/api-collection/07 - Routing/Decision For Order.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Decision For Order
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/routing/decisions/{{orderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+vars:pre-request {
+  orderId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Returns the SOR's last cached routing decision for a given orderId. 404 if
+  the order is older than the in-memory ring (default 1000 most-recent).
+}

--- a/api-collection/07 - Routing/List Venues.bru
+++ b/api-collection/07 - Routing/List Venues.bru
@@ -1,0 +1,20 @@
+meta {
+  name: List Venues
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/routing/venues
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Configured venues with their scoring inputs (latency, fees, leakage score,
+  fill rate, enabled flag).
+}

--- a/api-collection/07 - Routing/Score Order What-If.bru
+++ b/api-collection/07 - Routing/Score Order What-If.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Score Order (What-If)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/routing/score
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "symbol": "AAPL",
+    "side": "BUY",
+    "orderType": "LIMIT",
+    "quantity": 500,
+    "limitPrice": 175.50,
+    "stopPrice": null
+  }
+}
+
+docs {
+  Runs the SOR weighted-scoring across every enabled venue WITHOUT submitting
+  an order. Useful for debugging routing decisions and tuning weights. The
+  response includes per-venue score breakdown plus the recommended top venue.
+}

--- a/api-collection/07 - Routing/Venue Health.bru
+++ b/api-collection/07 - Routing/Venue Health.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Venue Health
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/routing/venues/PRIMARY/health
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Per-venue adapter health (UP/DOWN). Available venues match the
+  application.yml `execution-engine.sor.venues[].name` list (e.g.
+  PRIMARY, DARK_POOL_A, INTERNAL_CROSS).
+}

--- a/api-collection/08 - TCA/TCA For Order.bru
+++ b/api-collection/08 - TCA/TCA For Order.bru
@@ -1,0 +1,25 @@
+meta {
+  name: TCA For Order
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/tca/{{orderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+vars:pre-request {
+  orderId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Per-order TCA breakdown: arrival price, fill price, slippage bps, IS bps,
+  VWAP gap, spread cost. Computed by the post-trade service on every
+  completed order.
+}

--- a/api-collection/08 - TCA/TCA Summary.bru
+++ b/api-collection/08 - TCA/TCA Summary.bru
@@ -1,0 +1,20 @@
+meta {
+  name: TCA Summary
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/tca
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Aggregate TCA across all completed orders — slippage (bps), implementation
+  shortfall (bps), VWAP benchmark gap, spread cost.
+}

--- a/api-collection/09 - Recon/Breaks For Order.bru
+++ b/api-collection/09 - Recon/Breaks For Order.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Breaks For Order
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/recon/breaks/order/{{orderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+vars:pre-request {
+  orderId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  All breaks recorded against a given order id, across all dates.
+}

--- a/api-collection/09 - Recon/List Breaks.bru
+++ b/api-collection/09 - Recon/List Breaks.bru
@@ -1,0 +1,25 @@
+meta {
+  name: List Recon Breaks
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/recon/breaks
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  ~date: 2026-06-02
+}
+
+docs {
+  Reconciliation breaks for a date (defaults to today). Four types:
+  MISSING_FILL, EXTRA_FILL, QUANTITY_MISMATCH, PRICE_MISMATCH. Severity is
+  HIGH for notional ≥ $10k and CRITICAL for ≥ $100k.
+}

--- a/api-collection/09 - Recon/Recon Runs.bru
+++ b/api-collection/09 - Recon/Recon Runs.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Recon Runs
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/recon/runs
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Most recent reconciliation runs across dates. Useful for spotting failed
+  runs that need a re-trigger.
+}

--- a/api-collection/09 - Recon/Recon Summary.bru
+++ b/api-collection/09 - Recon/Recon Summary.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Recon Summary
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/recon/summary
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  ~date: 2026-06-02
+}
+
+docs {
+  Per-date summary (break count by type/severity, internal vs external fill
+  counts) plus the matching run record so the UI can render run status.
+}

--- a/api-collection/09 - Recon/Trigger Recon Run.bru
+++ b/api-collection/09 - Recon/Trigger Recon Run.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Trigger Recon Run
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/recon/run
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  ~date: 2026-06-02
+}
+
+docs {
+  Synchronously runs the EOD reconciliation engine for a date (defaults to
+  today). Idempotent — re-running for the same date wipes prior breaks first
+  (TDD §7.3). Two modes via `post-trade.recon.mode`: EXTERNAL (Alpaca HTTP)
+  or MIRROR (echoes internal fills for the local compose stack).
+}

--- a/api-collection/10 - Analytics/Axe Matches For Order.bru
+++ b/api-collection/10 - Analytics/Axe Matches For Order.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Axe Matches For Order
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/api/analytics/axes/matches/{{orderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+vars:pre-request {
+  orderId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Returns the ranked axe matches the matcher computed for a given submitted
+  order. 503 if the orders consumer is not running (analytics still booting).
+}

--- a/api-collection/10 - Analytics/Cancel Axe.bru
+++ b/api-collection/10 - Analytics/Cancel Axe.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Cancel Axe
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{baseUrl}}/api/analytics/axes/axe-id-here
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Cancel a previously-published axe by id. 204 on success, 404 if unknown.
+}

--- a/api-collection/10 - Analytics/Flow Toxicity.bru
+++ b/api-collection/10 - Analytics/Flow Toxicity.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Flow Toxicity
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/analytics/flow/toxicity
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  ~strategy: VWAP
+}
+
+docs {
+  Phase-2 (issue 2.2.4) adverse-selection detector — rolling markout in bps
+  at configurable horizons (default 60s/300s/1800s). Positive bps = adverse.
+  The gateway rewrites `/api/analytics/**` to `/v1/analytics/**`.
+}

--- a/api-collection/10 - Analytics/List Axes.bru
+++ b/api-collection/10 - Analytics/List Axes.bru
@@ -1,0 +1,25 @@
+meta {
+  name: List Axes
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/analytics/axes
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  ~symbol: AAPL
+  ~side: BUY
+}
+
+docs {
+  Snapshot of every active axe, optionally filtered by symbol and side. Each
+  row carries a refresh-derived confidence score that decays without renewal.
+}

--- a/api-collection/10 - Analytics/PnL Attribution For Order.bru
+++ b/api-collection/10 - Analytics/PnL Attribution For Order.bru
@@ -1,0 +1,24 @@
+meta {
+  name: PnL Attribution For Order
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/analytics/pnl/attribution/{{orderId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+vars:pre-request {
+  orderId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Per-order PnL attribution breakdown. 404 if no TCA has been seen for the
+  order yet.
+}

--- a/api-collection/10 - Analytics/PnL Attribution.bru
+++ b/api-collection/10 - Analytics/PnL Attribution.bru
@@ -1,0 +1,24 @@
+meta {
+  name: PnL Attribution
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/analytics/pnl/attribution
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+params:query {
+  ~strategy: VWAP
+}
+
+docs {
+  Phase-2 (issue 2.2.5) Kissell-Glantz decomposition: spread / market /
+  commission / timing / residual per parent order, aggregated daily.
+}

--- a/api-collection/10 - Analytics/PnL By Strategy.bru
+++ b/api-collection/10 - Analytics/PnL By Strategy.bru
@@ -1,0 +1,20 @@
+meta {
+  name: PnL Attribution By Strategy
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/analytics/pnl/attribution/by-strategy/VWAP
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Per-strategy distribution of PnL components — useful for spotting which
+  algos are spread-dominated vs market-impact-dominated.
+}

--- a/api-collection/10 - Analytics/Publish Axe.bru
+++ b/api-collection/10 - Analytics/Publish Axe.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Publish Axe
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/analytics/axes
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "axe_id": "axe-{{$randomUUID}}",
+    "client_id": "buy-side-client-42",
+    "symbol": "AAPL",
+    "side": "BUY",
+    "quantity": 2500,
+    "limit_price": 175.00,
+    "ttl_seconds": 300
+  }
+}
+
+docs {
+  Phase-2 (issue 2.2.6) — publish a client interest / axe. The matcher
+  surfaces overlapping interest for incoming SUBMITTED orders ranked by
+  `confidence × remaining_size`. Returns 201 with the persisted axe payload.
+}

--- a/api-collection/README.md
+++ b/api-collection/README.md
@@ -1,0 +1,81 @@
+# MariaAlpha API Collection (Bruno)
+
+Phase-2 deliverable for issue [2.7.5](https://github.com/drag0sd0g/MariaAlpha/issues/86):
+an in-repo Bruno collection covering every public REST endpoint exposed through
+the API Gateway plus a handful of direct-to-service requests for debugging.
+
+## Why Bruno?
+
+Bruno is a [Postman-style API client](https://www.usebruno.com/) that stores
+collections as plain `.bru` files in the repo — no proprietary export format, no
+cloud account, full diff/review in PRs. The TDD picks it over Postman in
+[§5.4](../docs/technical-design-document.md) precisely so this collection lives
+next to the code it tests.
+
+## Installing Bruno
+
+```bash
+brew install bruno          # macOS
+# or download a build from https://www.usebruno.com/downloads
+```
+
+The CLI runner — handy for smoke-testing requests from a script — is a separate
+npm package:
+
+```bash
+npm install -g @usebruno/cli
+```
+
+## Opening the collection
+
+1. Launch Bruno (the desktop app).
+2. **Collections → Open Collection** → pick this `api-collection/` directory.
+3. Select an environment from the top-right dropdown:
+   - **Local Docker Compose** — gateway at `http://localhost:8080`.
+   - **OrbStack Helm** — gateway at `http://api.mariaalpha.orb.local`.
+4. The `apiKey` variable defaults to `local-dev-key` (matching the docker-compose
+   `.env`). Override per environment as needed.
+
+Run a request with the Send button or with `Cmd-Enter`.
+
+## What's covered
+
+| Folder | Service | Routes |
+| --- | --- | --- |
+| `00 - Health` | API Gateway | actuator health, readiness, liveness, Prometheus |
+| `01 - Strategies` | Strategy Engine | list, state, get/set active, get/update parameters |
+| `02 - RFQ` | Strategy Engine | quote, accept, lookup (chained via `lastQuoteId` var) |
+| `03 - Orders` | Order Manager | list, by id, fills by date (recon source) |
+| `04 - Positions` | Order Manager | list, by symbol |
+| `05 - Portfolio` | Order Manager | aggregated summary |
+| `06 - Execution` | Execution Engine | status, resume, submit (LIMIT/ICEBERG), cancel, internal crossing |
+| `07 - Routing` | Execution Engine | venues, score what-if, decision, venue health |
+| `08 - TCA` | Post-Trade | summary, by order |
+| `09 - Recon` | Post-Trade | breaks, summary, runs, by order, manual run |
+| `10 - Analytics` | Analytics Service | toxicity, PnL attribution, axes (publish/list/cancel/match) |
+| `direct-services/` | various | direct (non-gateway) calls for debugging |
+
+The market-data-gateway intentionally has no REST surface — its public API is
+gRPC + WebSocket. Use the Strategy Control / Market Data UI pages to exercise it
+during manual testing.
+
+## Conventions
+
+- Every gateway-routed request sends `X-API-Key: {{apiKey}}` — the gateway
+  rejects anything without it (except `/actuator/**`).
+- Path/query variables that aren't useful by default are commented out with `~`
+  (Bruno's "disabled" prefix).
+- Requests that produce IDs export them as run-scoped variables (`lastQuoteId`,
+  `lastSubmittedOrderId`, `lastIcebergParentId`) so chained calls just work.
+- All bodies are JSON unless noted.
+
+## CLI smoke run
+
+Once the stack is up (`just run`), you can fire a single request from CI:
+
+```bash
+bru run --env "Local Docker Compose" "00 - Health/Gateway Health.bru"
+```
+
+Bruno's CLI returns non-zero on assertion failure, so it slots into a smoke-test
+gate without further plumbing.

--- a/api-collection/bruno.json
+++ b/api-collection/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "MariaAlpha API",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/api-collection/collection.bru
+++ b/api-collection/collection.bru
@@ -1,0 +1,24 @@
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+auth {
+  mode: none
+}
+
+docs {
+  # MariaAlpha API collection
+
+  This Bruno collection exercises every public REST endpoint exposed through the
+  API Gateway (port 8080). Every request reads the API key from the
+  `apiKey` environment variable and sends it as the `X-API-Key` header — the
+  gateway rejects anything else with HTTP 401.
+
+  Switch environments via the dropdown in the top-right corner:
+
+  - **Local Docker Compose**: gateway at http://localhost:8080, default API key `local-dev-key`.
+  - **OrbStack Helm**: gateway at http://api.mariaalpha.orb.local, override the API key per install.
+
+  Direct-to-service requests (bypassing the gateway) live under `direct-services/`
+  and are useful for debugging or when the gateway is unavailable.
+}

--- a/api-collection/direct-services/Analytics - Direct Health.bru
+++ b/api-collection/direct-services/Analytics - Direct Health.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Analytics Service Health (direct)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{analyticsServiceUrl}}/health
+  body: none
+  auth: none
+}
+
+docs {
+  Direct read of the analytics service health endpoint, bypassing the gateway.
+  Useful when the gateway is unreachable.
+}

--- a/api-collection/direct-services/Analytics - Ready.bru
+++ b/api-collection/direct-services/Analytics - Ready.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Analytics Service Ready
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{analyticsServiceUrl}}/ready
+  body: none
+  auth: none
+}
+
+docs {
+  Analytics service readiness — includes the pending toxicity-fill queue
+  depth and the count of symbols in the in-memory market-data cache. Both
+  useful for spotting backlog when the analytics service starts up.
+}

--- a/api-collection/direct-services/Execution Engine - Health.bru
+++ b/api-collection/direct-services/Execution Engine - Health.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Execution Engine Health (direct)
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{executionEngineUrl}}/actuator/health
+  body: none
+  auth: none
+}
+
+docs {
+  Direct execution-engine health. The Phase-2 (issue 2.7.4) Redis cache shows
+  up under `components.redis` — DOWN there does not fail readiness (cache is
+  non-critical).
+}

--- a/api-collection/direct-services/ML Signal - Health.bru
+++ b/api-collection/direct-services/ML Signal - Health.bru
@@ -1,0 +1,17 @@
+meta {
+  name: ML Signal Health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{mlSignalServiceUrl}}/health
+  body: none
+  auth: none
+}
+
+docs {
+  ML Signal Service (Python/FastAPI) liveness. The gRPC port is 50051; this
+  REST endpoint is for health and admin only — strategy engine consumes
+  signals over gRPC.
+}

--- a/api-collection/direct-services/ML Signal - Reload Models.bru
+++ b/api-collection/direct-services/ML Signal - Reload Models.bru
@@ -1,0 +1,17 @@
+meta {
+  name: ML Signal Reload Models
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{mlSignalServiceUrl}}/v1/models/reload
+  body: none
+  auth: none
+}
+
+docs {
+  Forces the ML Signal Service to reload the LightGBM signal model and the
+  Random Forest regime model from disk (issue 2.3.1). Useful when an offline
+  training run drops a new joblib into `ml-models/`.
+}

--- a/api-collection/direct-services/Order Manager - Health.bru
+++ b/api-collection/direct-services/Order Manager - Health.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Order Manager Health (direct)
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{orderManagerUrl}}/actuator/health
+  body: none
+  auth: none
+}
+
+docs {
+  Direct read of the order-manager's Spring Boot Actuator health endpoint —
+  no gateway, no API key.
+}

--- a/api-collection/environments/Local Docker Compose.bru
+++ b/api-collection/environments/Local Docker Compose.bru
@@ -1,0 +1,11 @@
+vars {
+  baseUrl: http://localhost:8080
+  apiKey: local-dev-key
+  marketDataUrl: http://localhost:8079
+  strategyEngineUrl: http://localhost:8082
+  executionEngineUrl: http://localhost:8084
+  orderManagerUrl: http://localhost:8086
+  postTradeUrl: http://localhost:8088
+  analyticsServiceUrl: http://localhost:8095
+  mlSignalServiceUrl: http://localhost:8090
+}

--- a/api-collection/environments/OrbStack Helm.bru
+++ b/api-collection/environments/OrbStack Helm.bru
@@ -1,0 +1,11 @@
+vars {
+  baseUrl: http://api.mariaalpha.orb.local
+  apiKey: local-dev-key
+  marketDataUrl: http://market-data-gateway.mariaalpha.svc.cluster.local:8079
+  strategyEngineUrl: http://strategy-engine.mariaalpha.svc.cluster.local:8082
+  executionEngineUrl: http://execution-engine.mariaalpha.svc.cluster.local:8084
+  orderManagerUrl: http://order-manager.mariaalpha.svc.cluster.local:8086
+  postTradeUrl: http://post-trade.mariaalpha.svc.cluster.local:8088
+  analyticsServiceUrl: http://analytics-service.mariaalpha.svc.cluster.local:8095
+  mlSignalServiceUrl: http://ml-signal-service.mariaalpha.svc.cluster.local:8090
+}

--- a/charts/mariaalpha/Chart.lock
+++ b/charts/mariaalpha/Chart.lock
@@ -32,6 +32,9 @@ dependencies:
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 30.1.8
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.13.4
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 65.8.1
@@ -53,5 +56,5 @@ dependencies:
 - name: sealed-secrets
   repository: https://bitnami-labs.github.io/sealed-secrets
   version: 2.18.6
-digest: sha256:50b84afc5de25e7c519995e0329b6c75bc6b51a2e295204b95aee664d051e457
-generated: "2026-05-21T22:02:57.191056+01:00"
+digest: sha256:8e2984b8f0770e519c46e12d5ee63efd68301c4d39b402423d4f5a4cc140db3e
+generated: "2026-06-02T19:55:26.201345+01:00"

--- a/charts/mariaalpha/Chart.yaml
+++ b/charts/mariaalpha/Chart.yaml
@@ -58,6 +58,11 @@ dependencies:
     version: "30.x.x"
     repository: https://charts.bitnami.com/bitnami
     condition: kafka.enabled
+  # Phase-2 (issue 2.7.4) — Redis distributed position cache.
+  - name: redis
+    version: "20.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
   - name: kube-prometheus-stack
     version: "65.x.x"
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/mariaalpha/README.md
+++ b/charts/mariaalpha/README.md
@@ -1,6 +1,6 @@
 # MariaAlpha Helm Chart
 
-Umbrella Helm chart that deploys the full MariaAlpha trading platform — 7 application services + UI + Postgres + Kafka + Prometheus/Grafana/Loki/Tempo/Alloy — on a Kubernetes cluster.
+Umbrella Helm chart that deploys the full MariaAlpha trading platform — 7 application services + UI + Postgres + Kafka + Redis + Prometheus/Grafana/Loki/Tempo/Alloy — on a Kubernetes cluster.
 
 `values.yaml` defaults are tuned for a single-node **OrbStack** cluster. Override with `-f values-<env>.yaml` for cloud targets.
 
@@ -81,7 +81,7 @@ Flip `secrets.useSealedSecrets: true` and enable the controller via `sealed-secr
 
 ## What is in scope
 
-This chart covers issue 2.7.1 — local Kubernetes deployability. CI/CD image-publishing automation lives in 2.7.2. NetworkPolicies, HPA tuning, PDBs, and TLS via cert-manager `ClusterIssuer` are deferred to follow-up tickets.
+This chart covers issue 2.7.1 — local Kubernetes deployability. CI/CD image-publishing automation lives in 2.7.2, mutation testing in 2.7.3, and the Bitnami Redis subchart wired into order-manager + execution-engine is the distributed position cache from issue 2.7.4 (cluster DNS: `redis-master.mariaalpha-data.svc.cluster.local:6379`, auth disabled for the local install). NetworkPolicies, HPA tuning, PDBs, and TLS via cert-manager `ClusterIssuer` are deferred to follow-up tickets.
 
 ## Layout
 

--- a/charts/mariaalpha/charts/execution-engine/templates/deployment.yaml
+++ b/charts/mariaalpha/charts/execution-engine/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
                   name: alpaca-credentials
                   key: ALPACA_API_SECRET_KEY
                   optional: true
+            # Phase-2 (issue 2.7.4) Redis position cache wiring
+            - { name: SPRING_DATA_REDIS_HOST, value: "redis-master.mariaalpha-data.svc.cluster.local" }
+            - { name: SPRING_DATA_REDIS_PORT, value: "6379" }
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/mariaalpha/charts/order-manager/templates/deployment.yaml
+++ b/charts/mariaalpha/charts/order-manager/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
                   name: postgres-app-credentials
                   key: postgres-password
             - { name: SPRING_LIQUIBASE_LIQUIBASE_SCHEMA, value: "liq_om" }
+            # Phase-2 (issue 2.7.4) Redis position cache wiring
+            - { name: SPRING_DATA_REDIS_HOST, value: "redis-master.mariaalpha-data.svc.cluster.local" }
+            - { name: SPRING_DATA_REDIS_PORT, value: "6379" }
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/mariaalpha/values.yaml
+++ b/charts/mariaalpha/values.yaml
@@ -160,6 +160,32 @@ postgresql:
           CREATE SCHEMA IF NOT EXISTS liq_om;
           CREATE SCHEMA IF NOT EXISTS liq_pt;
 
+## --- Redis (Bitnami) — Phase-2 (issue 2.7.4) distributed position cache -----
+redis:
+  enabled: true
+  fullnameOverride: redis
+  namespaceOverride: mariaalpha-data
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+  global:
+    security:
+      allowInsecureImages: true
+    redis:
+      password: ""
+  # Open-mode single-node — the cache is non-critical (Kafka remains the system
+  # of record) and binding to in-cluster traffic only makes the unauthenticated
+  # path acceptable for a local install. Production overlays should set auth.
+  auth:
+    enabled: false
+  architecture: standalone
+  master:
+    persistence:
+      size: 4Gi
+    resources:
+      requests: { cpu: 100m, memory: 128Mi }
+      limits:   { cpu: 500m, memory: 256Mi }
+
 ## --- Kafka (Bitnami, KRaft combined mode) -----------------------------------
 kafka:
   enabled: true

--- a/config/spotbugs/exclude-filter.xml
+++ b/config/spotbugs/exclude-filter.xml
@@ -77,6 +77,19 @@
         <Class name="com.mariaalpha.strategyengine.metrics.StrategyMetrics"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
+    <!-- Phase-2 (issue 2.7.4): Redis position cache infrastructure -->
+    <Match>
+        <Class name="com.mariaalpha.executionengine.cache.RedisPositionCacheClient"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="com.mariaalpha.executionengine.cache.RedisPositionCacheClient$PubSubHandler"/>
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
+    </Match>
+    <Match>
+        <Class name="com.mariaalpha.ordermanager.cache.RedisPositionCachePublisher"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
     <Match>
         <Class name="com.mariaalpha.executionengine.model.ExecutionInstruction"/>
         <Bug pattern="EI_EXPOSE_REP"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,7 @@ services:
     build:
       context: .
       dockerfile: execution-engine/Dockerfile
+    image: mariaalpha/execution-engine:local
     ports:
       - "8084:8084"
       - "8085:8085"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,23 @@ services:
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka:9094
 
+  # Phase-2 (issue 2.7.4): Redis distributed position cache. Order-manager publishes
+  # position snapshots here on every fill alongside the Kafka positions.updates topic;
+  # execution-engine reads from it for sub-millisecond pre-trade risk checks.
+  redis:
+    image: redis:7.4-alpine
+    command: ["redis-server", "--appendonly", "yes", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
   prometheus:
     image: prom/prometheus:v3.2.1
     command:
@@ -268,6 +285,8 @@ services:
       SPRING_PROFILES_ACTIVE: ${EXECUTION_PROFILE:-simulated}
       ALPACA_API_KEY_ID: ${ALPACA_API_KEY_ID:-}
       ALPACA_API_SECRET_KEY: ${ALPACA_API_SECRET_KEY:-}
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
       # Phase-2 risk-check overrides — exposed so the Phase2RiskChecksE2ETest can tighten
       # thresholds at runtime. Defaults match application.yml.
       EXECUTION_ENGINE_RISK_MAX_ADV_PARTICIPATION: ${EXECUTION_ENGINE_RISK_MAX_ADV_PARTICIPATION:-0.10}
@@ -275,6 +294,8 @@ services:
       EXECUTION_ENGINE_RISK_DEFAULT_SECTOR_EXPOSURE_LIMIT: ${EXECUTION_ENGINE_RISK_DEFAULT_SECTOR_EXPOSURE_LIMIT:-1000000}
     depends_on:
       kafka:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8085/actuator/health/liveness" ]
@@ -293,6 +314,8 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-default}
       KAFKA_BOOTSTRAP_SERVERS: kafka:9094
@@ -302,6 +325,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-mariaalpha}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mariaalpha}
       SPRING_LIQUIBASE_LIQUIBASE_SCHEMA: liq_om
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
       MANAGEMENT_PORT: 8087
     ports:
       - "8086:8086"
@@ -421,3 +446,4 @@ volumes:
   loki-data:
   tempo-data:
   grafana-data:
+  redis-data:

--- a/docs/runbooks/helm-install.md
+++ b/docs/runbooks/helm-install.md
@@ -46,9 +46,18 @@ The `--wait` flag holds until every Deployment is Ready. First install takes 3â€
 
 ```bash
 kubectl -n mariaalpha get pods                  # all Running, all 1/1 Ready
-kubectl -n mariaalpha-data get pods              # postgresql, kafka
+kubectl -n mariaalpha-data get pods              # postgresql, kafka, redis-master (issue 2.7.4)
 kubectl -n mariaalpha-o11y get pods              # prometheus, grafana, loki, tempo, alloy
 helm test mariaalpha -n mariaalpha --logs       # actuator-health + iceberg e2e pods
+```
+
+To inspect the Phase-2 distributed position cache:
+
+```bash
+kubectl -n mariaalpha-data exec -it redis-master-0 -- redis-cli KEYS 'mariaalpha:position:*'
+kubectl -n mariaalpha-data exec -it redis-master-0 -- redis-cli GET 'mariaalpha:position:AAPL'
+# Watch live updates from the order-manager:
+kubectl -n mariaalpha-data exec -it redis-master-0 -- redis-cli SUBSCRIBE mariaalpha.positions.updates
 ```
 
 Browser:

--- a/docs/services/execution-engine.md
+++ b/docs/services/execution-engine.md
@@ -180,6 +180,8 @@ Computes `lastTradePrice × quantity` and rejects if it exceeds the configured l
 
 Looks up the current position notional for the symbol (tracked by `PositionTracker`) and adds the order's notional. If the projected total exceeds the per-symbol limit (default: $500,000), the order is rejected. This prevents concentration risk — even if each individual order is small, accumulated exposure to a single symbol can be dangerous.
 
+`PositionTracker` is hydrated from the **Redis position cache** (issue 2.7.4): on startup `RedisPositionCacheClient` scans every `mariaalpha:position:*` key and seeds the tracker; thereafter every `mariaalpha.positions.updates` pub/sub message from the order-manager refreshes the in-memory row in real time. A direct `fetch(symbol)` fallback covers the warm-up window. If Redis is unreachable the tracker degrades to an empty/last-known state and the check still runs — risk decisions never block on cache I/O. Disable with `execution-engine.redis.enabled=false`.
+
 #### Check 3: MaxPortfolioExposure (`@Order(3)`)
 
 Computes the total gross exposure across all symbols (sum of absolute position notionals) and adds the order's notional. If the projected total exceeds the portfolio limit (default: $2,000,000), the order is rejected. This is a portfolio-level guard that limits total market exposure regardless of how well diversified the positions are.

--- a/docs/services/order-manager.md
+++ b/docs/services/order-manager.md
@@ -235,6 +235,10 @@ Fired **once per successfully persisted fill**, keyed by symbol (guaranteeing pe
 
 Status-only lifecycle events (no fill) do **not** produce a position update — the position hasn't changed.
 
+### Redis position cache (issue 2.7.4)
+
+Alongside the Kafka publish, every persisted fill also writes the same `PositionSnapshot` JSON to Redis at key `mariaalpha:position:<symbol>` with a 24 h TTL and emits a pub/sub event on channel `mariaalpha.positions.updates`. The cache backs the execution-engine's pre-trade risk checks (sub-millisecond cross-service position lookup) without changing PostgreSQL's authoritative role. The publisher (`RedisPositionCachePublisher`) swallows Redis exceptions at WARN level — a Redis outage degrades the cross-service view but never blocks fill processing. Disable with `order-manager.redis.enabled=false`.
+
 ---
 
 ## The Two Consumers

--- a/docs/technical-design-document.md
+++ b/docs/technical-design-document.md
@@ -460,6 +460,8 @@ graph LR
         K -->|events| PT[Post-Trade & Recon]
         K -->|events| AN[Analytics Service]
         OM --> PG[(PostgreSQL)]
+        OM -->|position snapshots + pub/sub| RD[(Redis cache)]
+        RD -->|warm + pub/sub| EE
         PT --> PG
         AN --> PG
     end
@@ -627,7 +629,7 @@ public interface ExchangeAdapter {
 | **Framework** | Spring Boot 3 with Spring Data JPA |
 | **Role** | Persists orders and fills, maintains position book, computes real-time P&L |
 
-**Position Calculation:** On every fill: (1) adjust quantity and weighted avg entry price, (2) compute realized P&L on position-reducing fills, (3) mark-to-market open positions against latest tick, (4) publish updated snapshot to `positions.updates`.
+**Position Calculation:** On every fill: (1) adjust quantity and weighted avg entry price, (2) compute realized P&L on position-reducing fills, (3) mark-to-market open positions against latest tick, (4) publish updated snapshot to `positions.updates` (Kafka, authoritative async path) and to the **Redis position cache** introduced in issue 2.7.4 (key `mariaalpha:position:<symbol>` with a 24 h TTL, plus a pub/sub event on `mariaalpha.positions.updates` so subscribers can refresh without polling). Redis is a pure cache — PostgreSQL remains the system of record and Kafka is the durable event log; cache failures degrade gracefully (warn + continue) so a Redis outage never blocks fill processing.
 
 #### 5.2.6 Post-Trade and Reconciliation Engine
 
@@ -864,6 +866,36 @@ graph TB
 
 The Electronic Trading REST API (Phase 3) would expose endpoints for programmatic algo execution: `POST /api/v1/algo/vwap`, `POST /api/v1/algo/twap`, `POST /api/v1/algo/is`, etc. — each accepting order parameters and returning a tracking ID for monitoring execution progress via WebSocket. The FIX gateway (also Phase 3) would accept standard FIX 4.4 NewOrderSingle messages and route them through the same pipeline.
 
+#### 5.3.8 Distributed Position Cache (issue 2.7.4)
+
+Phase 2 introduces Redis as a **cache layer** for hot-path cross-service reads of the order-manager's authoritative position book. PostgreSQL remains the system of record and Kafka's `positions.updates` topic remains the durable event log; Redis adds sub-millisecond visibility for the pre-trade risk checks running inside the execution-engine.
+
+```mermaid
+sequenceDiagram
+    participant OM as Order Manager
+    participant PG as PostgreSQL
+    participant RD as Redis
+    participant K as Kafka
+    participant EE as Execution Engine
+
+    OM->>PG: persist fill + updated position
+    OM->>K: positions.updates (durable)
+    OM->>RD: SET mariaalpha:position:<symbol> (TTL 24h)
+    OM->>RD: PUBLISH mariaalpha.positions.updates
+    Note over EE: @PostConstruct: SCAN mariaalpha:position:* → seed PositionTracker
+    RD->>EE: pub/sub message → applyMessage()
+    EE->>EE: PositionTracker.updatePosition(symbol, notional)
+    EE->>EE: risk checks read in-process tracker
+```
+
+**Order-manager (writer):** `RedisPositionCachePublisher` writes the snapshot on every fill (after the existing Kafka publish) and emits a pub/sub event so any subscriber can refresh in-process state without polling. Failures are swallowed at WARN level so a Redis hiccup never blocks fill processing.
+
+**Execution-engine (reader):** `RedisPositionCacheClient` warms the in-process `PositionTracker` on startup by scanning every `mariaalpha:position:*` key, then subscribes to the pub/sub channel for incremental updates. A direct `fetch(symbol)` path exists as a fallback when the in-memory state is empty (e.g. between warm-up failure and the first pub/sub message).
+
+**Metrics:** `mariaalpha_position_cache_writes_total`, `mariaalpha_position_cache_write_failures_total`, `mariaalpha_position_cache_write_latency`, `mariaalpha_position_cache_hits_total`, `mariaalpha_position_cache_misses_total`, `mariaalpha_position_cache_pubsub_updates_total`, `mariaalpha_position_cache_read_failures_total`, `mariaalpha_position_cache_read_latency`. Both sides set `management.health.redis.enabled=true` so the Redis component shows up in `/actuator/health`, but Redis is **not** in the readiness group — the cache is non-critical and a transient outage must not flap pod readiness.
+
+**Configuration:** `order-manager.redis.enabled` and `execution-engine.redis.enabled` default to `true`. Set either to `false` (and exclude `RedisAutoConfiguration`) to run a minimal local stack without Redis; the in-memory `PositionTracker` remains usable. Docker Compose adds a `redis:7.4-alpine` service with `--maxmemory-policy allkeys-lru` and a persistent volume; the Helm chart adds Bitnami `redis@20` as a standalone (single-node) subchart, addressable in-cluster at `redis-master.mariaalpha-data.svc.cluster.local:6379`.
+
 ### 5.4 Data Model
 
 ```mermaid
@@ -1005,7 +1037,7 @@ All topics start with **1 partition** and **minimal retention** in the MVP. Part
 | Database migrations | Liquibase | Supports XML/YAML/JSON/SQL changelogs. Rollback support. Widely used in enterprise Java. Runs automatically on Spring Boot startup. |
 | Code formatting | Spotless (Google Java Format) | Gradle plugin that auto-formats Java source code to Google Java Style on build. Enforced via `spotlessCheck` in CI, auto-fixed via `spotlessApply` locally (`just format`). Complements Checkstyle (which checks but does not fix). |
 | Command runner | just | Modern alternative to Make. No tab-sensitivity issues, cleaner syntax, built-in argument passing, cross-platform. `justfile` replaces `Makefile`. |
-| API testing (Phase 2) | Bruno | Open-source API client. Collections stored as files in the repo. Replaces Postman. |
+| API testing (Phase 2) | Bruno | Open-source API client. Collection shipped in [`api-collection/`](../api-collection/) — issue 2.7.5; covers every gateway-routed REST endpoint plus direct-to-service health/admin calls. Collections stored as files in the repo. Replaces Postman. |
 | Stream processing (Phase 4) | Apache Flink (consideration) | Complex event processing for multi-symbol pattern detection, windowed portfolio-level VaR computation, and real-time aggregation across high-volume streams. Adds significant infrastructure complexity — justified only at scale beyond MVP. |
 
 ---
@@ -1179,6 +1211,14 @@ These are instrumented explicitly in application code:
 | `mariaalpha_recon_runs_total` | Counter | `status`, `source` | EOD reconciliation runs by status (SUCCESS/FAILED) and source (SCHEDULED/MANUAL) |
 | `mariaalpha_recon_duration_seconds` | Timer | — | Wall-clock duration of EOD reconciliation runs |
 | `mariaalpha_tca_slippage_bps` | Histogram | `strategy` | Slippage distribution |
+| `mariaalpha_position_cache_writes_total` | Counter | — | Redis position-cache writes (issue 2.7.4, order-manager) |
+| `mariaalpha_position_cache_write_failures_total` | Counter | — | Failed Redis position-cache writes |
+| `mariaalpha_position_cache_write_latency` | Histogram | — | Latency of Redis position-cache writes |
+| `mariaalpha_position_cache_hits_total` | Counter | — | Direct Redis fetch returned a snapshot (execution-engine) |
+| `mariaalpha_position_cache_misses_total` | Counter | — | Direct Redis fetch returned no snapshot |
+| `mariaalpha_position_cache_pubsub_updates_total` | Counter | — | Pub/sub messages applied to in-memory PositionTracker |
+| `mariaalpha_position_cache_read_failures_total` | Counter | — | Redis read errors swallowed by the cache client |
+| `mariaalpha_position_cache_read_latency` | Histogram | — | Latency of Redis position-cache reads |
 
 ### 8.3 Grafana Dashboards
 
@@ -1429,8 +1469,8 @@ _(Each row below is a GitHub Issue — descriptions follow the same pattern as P
 | [2.7.1](https://github.com/drag0sd0g/MariaAlpha/issues/82) ✅ | Create Helm charts for full Kubernetes deployment | Deployment |
 | [2.7.2](https://github.com/drag0sd0g/MariaAlpha/issues/83)✅ | Implement Docker image publish workflow | CI/CD |
 | [2.7.3](https://github.com/drag0sd0g/MariaAlpha/issues/84)✅ | Add mutation testing (PITest + mutmut) to CI | CI/CD |
-| [2.7.4](https://github.com/drag0sd0g/MariaAlpha/issues/85) | Introduce Redis for distributed position cache | Infrastructure |
-| [2.7.5](https://github.com/drag0sd0g/MariaAlpha/issues/86) | Create Bruno API collection with example requests | Developer Experience |
+| [2.7.4](https://github.com/drag0sd0g/MariaAlpha/issues/85)✅  | Introduce Redis for distributed position cache | Infrastructure |
+| [2.7.5](https://github.com/drag0sd0g/MariaAlpha/issues/86)✅  | Create Bruno API collection with example requests | Developer Experience |
 
 ### Phase 3: Derivatives + Tokyo Market + Program Tradingare
 | # | Issue Title | Component |

--- a/execution-engine/build.gradle.kts
+++ b/execution-engine/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation(libs.spring.kafka)
     implementation(libs.spring.boot.starter.actuator)

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/PositionSnapshot.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/PositionSnapshot.java
@@ -1,0 +1,37 @@
+package com.mariaalpha.executionengine.cache;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Phase-2 (issue 2.7.4) projection of the order-manager's PositionSnapshot that the
+ * execution-engine deserializes from the Redis cache. Mirrors the order-manager's wire format —
+ * extra fields are tolerated for forward compatibility.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PositionSnapshot(
+    String symbol,
+    BigDecimal netQuantity,
+    BigDecimal avgEntryPrice,
+    BigDecimal realizedPnl,
+    BigDecimal unrealizedPnl,
+    BigDecimal lastMarkPrice,
+    Instant timestamp) {
+
+  /**
+   * Notional exposure in dollars: {@code netQuantity × markPrice}, falling back to {@code
+   * netQuantity × avgEntryPrice} when no mark price has been captured yet. Returns ZERO when both
+   * prices are absent.
+   */
+  public BigDecimal notional() {
+    if (netQuantity == null) {
+      return BigDecimal.ZERO;
+    }
+    var price = lastMarkPrice != null ? lastMarkPrice : avgEntryPrice;
+    if (price == null) {
+      return BigDecimal.ZERO;
+    }
+    return netQuantity.multiply(price);
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClient.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClient.java
@@ -1,0 +1,212 @@
+package com.mariaalpha.executionengine.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mariaalpha.executionengine.config.RedisConfig;
+import com.mariaalpha.executionengine.service.PositionTracker;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.Topic;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase-2 (issue 2.7.4) — keeps the in-process {@link PositionTracker} in sync with the
+ * order-manager's authoritative position book via the Redis cache:
+ *
+ * <ul>
+ *   <li>Warms the tracker on startup by scanning {@code mariaalpha:position:*} keys.
+ *   <li>Subscribes to pub/sub channel {@code mariaalpha.positions.updates} for incremental updates
+ *       between fills.
+ *   <li>Falls back to a direct {@code GET} on cache miss so a risk check never sees stale in-memory
+ *       state.
+ * </ul>
+ *
+ * Redis is a cache, not a system of record — every method swallows {@link DataAccessException}
+ * after logging at WARN. A risk check whose lookup fails will see whatever the in-memory tracker
+ * holds, which is at worst the last known good snapshot.
+ */
+@Component
+@ConditionalOnProperty(prefix = "execution-engine.redis", name = "enabled", matchIfMissing = true)
+public class RedisPositionCacheClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RedisPositionCacheClient.class);
+
+  private final StringRedisTemplate redisTemplate;
+  private final RedisMessageListenerContainer listenerContainer;
+  private final ObjectMapper objectMapper;
+  private final RedisConfig config;
+  private final PositionTracker positionTracker;
+  private final Counter hitsTotal;
+  private final Counter missesTotal;
+  private final Counter pubSubUpdatesTotal;
+  private final Counter readFailuresTotal;
+  private final Timer readLatency;
+
+  private MessageListener pubSubListener;
+
+  public RedisPositionCacheClient(
+      StringRedisTemplate redisTemplate,
+      RedisMessageListenerContainer listenerContainer,
+      ObjectMapper objectMapper,
+      RedisConfig config,
+      PositionTracker positionTracker,
+      MeterRegistry meterRegistry) {
+    this.redisTemplate = redisTemplate;
+    this.listenerContainer = listenerContainer;
+    this.objectMapper = objectMapper;
+    this.config = config;
+    this.positionTracker = positionTracker;
+    this.hitsTotal =
+        Counter.builder("mariaalpha_position_cache_hits_total")
+            .description("Redis position-cache reads that returned a snapshot")
+            .register(meterRegistry);
+    this.missesTotal =
+        Counter.builder("mariaalpha_position_cache_misses_total")
+            .description("Redis position-cache reads that returned no snapshot")
+            .register(meterRegistry);
+    this.pubSubUpdatesTotal =
+        Counter.builder("mariaalpha_position_cache_pubsub_updates_total")
+            .description("Position-cache pub/sub messages applied to the in-memory tracker")
+            .register(meterRegistry);
+    this.readFailuresTotal =
+        Counter.builder("mariaalpha_position_cache_read_failures_total")
+            .description("Redis position-cache reads that failed with an error")
+            .register(meterRegistry);
+    this.readLatency =
+        Timer.builder("mariaalpha_position_cache_read_latency")
+            .description("Latency of Redis position-cache reads")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .register(meterRegistry);
+  }
+
+  @PostConstruct
+  public void start() {
+    warmFromRedis();
+    subscribe();
+  }
+
+  @PreDestroy
+  public void stop() {
+    if (pubSubListener != null) {
+      try {
+        listenerContainer.removeMessageListener(pubSubListener);
+      } catch (RuntimeException e) {
+        LOG.warn("Failed to remove Redis pub/sub listener: {}", e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Best-effort lookup that consults Redis directly. Used as a fallback when the in-memory tracker
+   * is empty (e.g. between cache warm-up failure and the first pub/sub message).
+   */
+  public PositionSnapshot fetch(String symbol) {
+    if (symbol == null || symbol.isBlank()) {
+      return null;
+    }
+    long start = System.nanoTime();
+    try {
+      var payload = redisTemplate.opsForValue().get(config.positionKeyPrefix() + symbol);
+      if (payload == null) {
+        missesTotal.increment();
+        return null;
+      }
+      var snapshot = objectMapper.readValue(payload, PositionSnapshot.class);
+      hitsTotal.increment();
+      return snapshot;
+    } catch (DataAccessException e) {
+      LOG.warn("Redis position cache read failed for {}: {}", symbol, e.getMessage());
+      readFailuresTotal.increment();
+      return null;
+    } catch (Exception e) {
+      LOG.warn("Failed to deserialize cached position for {}: {}", symbol, e.getMessage());
+      readFailuresTotal.increment();
+      return null;
+    } finally {
+      readLatency.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  void warmFromRedis() {
+    try {
+      Set<String> keys = redisTemplate.keys(config.positionKeyPrefix() + "*");
+      if (keys == null || keys.isEmpty()) {
+        LOG.info(
+            "Redis position cache: no warm-up keys found under '{}'", config.positionKeyPrefix());
+        return;
+      }
+      int seeded = 0;
+      for (String key : keys) {
+        var payload = redisTemplate.opsForValue().get(key);
+        if (payload == null) {
+          continue;
+        }
+        try {
+          var snapshot = objectMapper.readValue(payload, PositionSnapshot.class);
+          if (snapshot != null && snapshot.symbol() != null) {
+            positionTracker.updatePosition(snapshot.symbol(), snapshot.notional());
+            seeded++;
+          }
+        } catch (Exception e) {
+          LOG.warn("Skipping malformed cached position at key {}: {}", key, e.getMessage());
+        }
+      }
+      LOG.info("Redis position cache: warmed {} symbol(s) from Redis", seeded);
+    } catch (DataAccessException e) {
+      LOG.warn(
+          "Redis position cache warm-up failed: {}; continuing with empty in-memory tracker",
+          e.getMessage());
+      readFailuresTotal.increment();
+    }
+  }
+
+  void subscribe() {
+    try {
+      pubSubListener = new PubSubHandler();
+      Topic topic = new ChannelTopic(config.positionsPubSubChannel());
+      listenerContainer.addMessageListener(pubSubListener, topic);
+      LOG.info("Subscribed to Redis pub/sub channel '{}'", config.positionsPubSubChannel());
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "Failed to subscribe to Redis pub/sub channel '{}': {}; pub/sub updates will be skipped",
+          config.positionsPubSubChannel(),
+          e.getMessage());
+    }
+  }
+
+  void applyMessage(String payload) {
+    if (payload == null || payload.isBlank()) {
+      return;
+    }
+    try {
+      var snapshot = objectMapper.readValue(payload, PositionSnapshot.class);
+      if (snapshot != null && snapshot.symbol() != null) {
+        positionTracker.updatePosition(snapshot.symbol(), snapshot.notional());
+        pubSubUpdatesTotal.increment();
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to apply pub/sub position update: {}", e.getMessage());
+    }
+  }
+
+  private final class PubSubHandler implements MessageListener {
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+      applyMessage(new String(message.getBody(), StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisBeans.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisBeans.java
@@ -1,0 +1,21 @@
+package com.mariaalpha.executionengine.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/** Provides the pub/sub listener container the cache client subscribes through. */
+@Configuration
+@ConditionalOnProperty(prefix = "execution-engine.redis", name = "enabled", matchIfMissing = true)
+public class RedisBeans {
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory connectionFactory) {
+    var container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    return container;
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisConfig.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.mariaalpha.executionengine.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Phase-2 (issue 2.7.4) Redis client settings for the cross-service position cache. Mirrors the
+ * order-manager defaults so the key prefix and pub/sub channel match without manual wiring. Disable
+ * via {@code execution-engine.redis.enabled=false} when running in environments that have no Redis
+ * (the in-memory {@code PositionTracker} fallback continues to work).
+ */
+@ConfigurationProperties(prefix = "execution-engine.redis")
+public record RedisConfig(
+    boolean enabled, String positionKeyPrefix, String positionsPubSubChannel) {
+
+  public RedisConfig {
+    if (positionKeyPrefix == null || positionKeyPrefix.isBlank()) {
+      positionKeyPrefix = "mariaalpha:position:";
+    }
+    if (positionsPubSubChannel == null || positionsPubSubChannel.isBlank()) {
+      positionsPubSubChannel = "mariaalpha.positions.updates";
+    }
+  }
+}

--- a/execution-engine/src/main/resources/application.yml
+++ b/execution-engine/src/main/resources/application.yml
@@ -6,6 +6,12 @@ spring:
     name: execution-engine
   profiles:
     active: simulated
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+      timeout: 200ms
+      connect-timeout: 500ms
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
@@ -28,6 +34,13 @@ execution-engine:
     orders-lifecycle-topic: orders.lifecycle
     routing-decisions-topic: routing.decisions
     risk-alerts-topic: analytics.risk-alerts
+  # Phase-2 (issue 2.7.4) Redis position cache. Reader-side: warms PositionTracker on startup
+  # from Redis and applies pub/sub updates from order-manager. Disable to fall back to the
+  # in-memory tracker only (no cross-service position visibility).
+  redis:
+    enabled: true
+    position-key-prefix: "mariaalpha:position:"
+    positions-pub-sub-channel: "mariaalpha.positions.updates"
   risk:
     max-order-notional: 100000
     max-position-per-symbol: 500000
@@ -161,6 +174,9 @@ management:
           include: livenessState
   health:
     kafka:
+      enabled: true
+    # Redis cache is non-critical (in-memory PositionTracker stays usable on failure).
+    redis:
       enabled: true
   metrics:
     tags:

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/PositionSnapshotTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/PositionSnapshotTest.java
@@ -1,0 +1,74 @@
+package com.mariaalpha.executionengine.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class PositionSnapshotTest {
+
+  @Test
+  void notionalUsesMarkPriceWhenPresent() {
+    var snap =
+        new PositionSnapshot(
+            "AAPL",
+            BigDecimal.valueOf(10),
+            BigDecimal.valueOf(150),
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            BigDecimal.valueOf(200),
+            Instant.now());
+    assertThat(snap.notional()).isEqualByComparingTo("2000");
+  }
+
+  @Test
+  void notionalFallsBackToAvgEntryWhenMarkMissing() {
+    var snap =
+        new PositionSnapshot(
+            "MSFT",
+            BigDecimal.valueOf(5),
+            BigDecimal.valueOf(100),
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            null,
+            Instant.now());
+    assertThat(snap.notional()).isEqualByComparingTo("500");
+  }
+
+  @Test
+  void notionalIsZeroWhenAllPricesAbsent() {
+    var snap =
+        new PositionSnapshot(
+            "TSLA",
+            BigDecimal.valueOf(5),
+            null,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            null,
+            Instant.now());
+    assertThat(snap.notional()).isEqualByComparingTo("0");
+  }
+
+  @Test
+  void notionalIsZeroWhenQuantityNull() {
+    var snap =
+        new PositionSnapshot(
+            "NVDA", null, BigDecimal.TEN, null, null, BigDecimal.TEN, Instant.now());
+    assertThat(snap.notional()).isEqualByComparingTo("0");
+  }
+
+  @Test
+  void shortPositionsHaveNegativeNotional() {
+    var snap =
+        new PositionSnapshot(
+            "GOOG",
+            BigDecimal.valueOf(-3),
+            BigDecimal.valueOf(50),
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            BigDecimal.valueOf(60),
+            Instant.now());
+    assertThat(snap.notional()).isEqualByComparingTo("-180");
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClientTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClientTest.java
@@ -1,0 +1,132 @@
+package com.mariaalpha.executionengine.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.mariaalpha.executionengine.config.RedisConfig;
+import com.mariaalpha.executionengine.service.PositionTracker;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.Topic;
+
+@ExtendWith(MockitoExtension.class)
+class RedisPositionCacheClientTest {
+
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private ValueOperations<String, String> valueOps;
+  @Mock private RedisMessageListenerContainer listenerContainer;
+
+  private ObjectMapper objectMapper;
+  private SimpleMeterRegistry registry;
+  private PositionTracker tracker;
+  private RedisPositionCacheClient client;
+  private final RedisConfig config =
+      new RedisConfig(true, "mariaalpha:position:", "mariaalpha.positions.updates");
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    registry = new SimpleMeterRegistry();
+    tracker = new PositionTracker();
+    client =
+        new RedisPositionCacheClient(
+            redisTemplate, listenerContainer, objectMapper, config, tracker, registry);
+  }
+
+  @Test
+  void warmFromRedisSeedsTrackerFromAllKeys() {
+    when(redisTemplate.keys("mariaalpha:position:*"))
+        .thenReturn(Set.of("mariaalpha:position:AAPL", "mariaalpha:position:MSFT"));
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get("mariaalpha:position:AAPL")).thenReturn(snapshotJson("AAPL", 100, 150));
+    when(valueOps.get("mariaalpha:position:MSFT")).thenReturn(snapshotJson("MSFT", 50, 200));
+
+    client.warmFromRedis();
+
+    assertThat(tracker.getPositionNotional("AAPL")).isEqualByComparingTo("15000");
+    assertThat(tracker.getPositionNotional("MSFT")).isEqualByComparingTo("10000");
+  }
+
+  @Test
+  void fetchReturnsSnapshotOnHit() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get("mariaalpha:position:TSLA")).thenReturn(snapshotJson("TSLA", -25, 800));
+
+    var snap = client.fetch("TSLA");
+
+    assertThat(snap).isNotNull();
+    assertThat(snap.symbol()).isEqualTo("TSLA");
+    assertThat(snap.netQuantity()).isEqualByComparingTo("-25");
+    assertThat(registry.counter("mariaalpha_position_cache_hits_total").count()).isEqualTo(1.0);
+  }
+
+  @Test
+  void fetchRecordsMissWhenKeyAbsent() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get(anyString())).thenReturn(null);
+
+    var snap = client.fetch("NVDA");
+
+    assertThat(snap).isNull();
+    assertThat(registry.counter("mariaalpha_position_cache_misses_total").count()).isEqualTo(1.0);
+  }
+
+  @Test
+  void fetchSwallowsRedisErrors() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get(anyString())).thenThrow(new QueryTimeoutException("timeout"));
+
+    var snap = client.fetch("AMZN");
+
+    assertThat(snap).isNull();
+    assertThat(registry.counter("mariaalpha_position_cache_read_failures_total").count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void applyMessageUpdatesTrackerAndIncrementsCounter() {
+    client.applyMessage(snapshotJson("AAPL", 100, 150));
+
+    assertThat(tracker.getPositionNotional("AAPL")).isEqualByComparingTo("15000");
+    assertThat(registry.counter("mariaalpha_position_cache_pubsub_updates_total").count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void applyMessageIsRobustToMalformedPayload() {
+    client.applyMessage("not json");
+    client.applyMessage("");
+    client.applyMessage(null);
+    // No exception escapes; tracker still empty.
+    assertThat(tracker.getPositionNotional("AAPL")).isEqualByComparingTo("0");
+  }
+
+  @Test
+  void subscribeRegistersWithListenerContainer() {
+    client.subscribe();
+    verify(listenerContainer).addMessageListener(any(MessageListener.class), any(Topic.class));
+  }
+
+  private String snapshotJson(String sym, int qty, int price) {
+    return String.format(
+        "{\"symbol\":\"%s\",\"netQuantity\":%d,\"avgEntryPrice\":%d,\"realizedPnl\":0,"
+            + "\"unrealizedPnl\":0,\"lastMarkPrice\":%d,\"timestamp\":\"%s\"}",
+        sym, qty, price, price, Instant.parse("2026-06-02T12:00:00Z"));
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.mariaalpha.executionengine.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.mariaalpha.executionengine.config.RedisConfig;
+import com.mariaalpha.executionengine.service.PositionTracker;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Phase-2 (issue 2.7.4) integration test against a real Redis. Verifies the end-to-end flow: a
+ * producer writes a snapshot to Redis + publishes the pub/sub event; the cache client warms and
+ * applies updates onto {@link PositionTracker}.
+ */
+@Tag("integration")
+@Testcontainers
+class RedisPositionCacheIntegrationTest {
+
+  private static final GenericContainer<?> REDIS =
+      new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+
+  private static LettuceConnectionFactory connectionFactory;
+  private static StringRedisTemplate template;
+  private static RedisMessageListenerContainer listenerContainer;
+
+  @BeforeAll
+  static void startContainer() {
+    REDIS.start();
+    connectionFactory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getFirstMappedPort());
+    connectionFactory.afterPropertiesSet();
+    template = new StringRedisTemplate(connectionFactory);
+    template.afterPropertiesSet();
+    listenerContainer = new RedisMessageListenerContainer();
+    listenerContainer.setConnectionFactory(connectionFactory);
+    listenerContainer.afterPropertiesSet();
+    listenerContainer.start();
+  }
+
+  @AfterAll
+  static void stopContainer() throws Exception {
+    if (listenerContainer != null) {
+      listenerContainer.stop();
+      listenerContainer.destroy();
+    }
+    if (connectionFactory != null) {
+      connectionFactory.destroy();
+    }
+    REDIS.stop();
+  }
+
+  @AfterEach
+  void cleanRedis() {
+    var keys = template.keys("mariaalpha:position:*");
+    if (keys != null && !keys.isEmpty()) {
+      template.delete(keys);
+    }
+  }
+
+  @Test
+  void warmUpSeedsTrackerFromExistingKeys() {
+    template
+        .opsForValue()
+        .set(
+            "mariaalpha:position:AAPL",
+            "{\"symbol\":\"AAPL\",\"netQuantity\":100,\"avgEntryPrice\":150,"
+                + "\"realizedPnl\":0,\"unrealizedPnl\":0,\"lastMarkPrice\":155}");
+
+    var tracker = new PositionTracker();
+    var client = newClient(tracker);
+    client.start();
+
+    assertThat(tracker.getPositionNotional("AAPL")).isEqualByComparingTo("15500");
+    client.stop();
+  }
+
+  @Test
+  void pubSubMessagesUpdateTrackerInRealTime() {
+    var tracker = new PositionTracker();
+    var client = newClient(tracker);
+    client.start();
+
+    template.convertAndSend(
+        "mariaalpha.positions.updates",
+        "{\"symbol\":\"MSFT\",\"netQuantity\":50,\"avgEntryPrice\":200,"
+            + "\"realizedPnl\":0,\"unrealizedPnl\":0,\"lastMarkPrice\":210}");
+
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> assertThat(tracker.getPositionNotional("MSFT")).isEqualByComparingTo("10500"));
+    client.stop();
+  }
+
+  @Test
+  void fetchReadsLiveValueFromRedis() {
+    template
+        .opsForValue()
+        .set(
+            "mariaalpha:position:GOOG",
+            "{\"symbol\":\"GOOG\",\"netQuantity\":-10,\"avgEntryPrice\":2700,"
+                + "\"realizedPnl\":0,\"unrealizedPnl\":0,\"lastMarkPrice\":2800}");
+
+    var tracker = new PositionTracker();
+    var client = newClient(tracker);
+
+    var snap = client.fetch("GOOG");
+    assertThat(snap).isNotNull();
+    assertThat(snap.notional()).isEqualByComparingTo("-28000");
+  }
+
+  private RedisPositionCacheClient newClient(PositionTracker tracker) {
+    return new RedisPositionCacheClient(
+        template,
+        listenerContainer,
+        new ObjectMapper().registerModule(new JavaTimeModule()),
+        new RedisConfig(true, "mariaalpha:position:", "mariaalpha.positions.updates"),
+        tracker,
+        new SimpleMeterRegistry());
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/consumer/SignalConsumerIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/consumer/SignalConsumerIntegrationTest.java
@@ -45,6 +45,14 @@ class SignalConsumerIntegrationTest {
     registry.add("execution-engine.kafka.orders-lifecycle-topic", () -> "orders.lifecycle");
     registry.add("execution-engine.kafka.routing-decisions-topic", () -> "routing.decisions");
     registry.add("execution-engine.kafka.risk-alerts-topic", () -> "analytics.risk-alerts");
+    registry.add("execution-engine.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
   }
 
   @Test

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/crossing/InternalCrossingIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/crossing/InternalCrossingIntegrationTest.java
@@ -60,6 +60,14 @@ class InternalCrossingIntegrationTest {
     registry.add("execution-engine.internal-crossing.cross-probability-on-submit", () -> 0.0);
     registry.add("execution-engine.internal-crossing.match-probability-per-tick", () -> 0.0);
     registry.add("execution-engine.internal-crossing.seed", () -> 7L);
+    registry.add("execution-engine.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
   }
 
   @BeforeEach

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinatorIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinatorIntegrationTest.java
@@ -53,6 +53,14 @@ class IcebergCoordinatorIntegrationTest {
     registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
     // Make the simulator fill near-instantly so awaitility doesn't have to wait long
     registry.add("execution-engine.simulated.fill-latency-ms", () -> 5);
+    registry.add("execution-engine.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
   }
 
   @Test

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/Phase2RiskChainIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/Phase2RiskChainIntegrationTest.java
@@ -44,6 +44,15 @@ class Phase2RiskChainIntegrationTest {
   @DynamicPropertySource
   static void props(DynamicPropertyRegistry registry) {
     registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+    // No Redis container — the cache is exercised in RedisPositionCacheIntegrationTest.
+    registry.add("execution-engine.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
   }
 
   @Test

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/MultiVenueRoutingIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/MultiVenueRoutingIntegrationTest.java
@@ -61,6 +61,14 @@ class MultiVenueRoutingIntegrationTest {
     registry.add("execution-engine.dark-pool.match-probability-per-tick", () -> 1.0);
     registry.add("execution-engine.internal-crossing.seed", () -> 7L);
     registry.add("execution-engine.internal-crossing.cross-probability-on-submit", () -> 1.0);
+    registry.add("execution-engine.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
   }
 
   @BeforeAll

--- a/order-manager/build.gradle.kts
+++ b/order-manager/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/cache/RedisPositionCachePublisher.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/cache/RedisPositionCachePublisher.java
@@ -1,0 +1,89 @@
+package com.mariaalpha.ordermanager.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mariaalpha.ordermanager.config.RedisConfig;
+import com.mariaalpha.ordermanager.controller.dto.PositionSnapshot;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase-2 (issue 2.7.4) — writes the latest {@link PositionSnapshot} for each symbol into Redis
+ * (key {@code mariaalpha:position:<symbol>}) for sub-millisecond cross-service reads, and publishes
+ * a pub/sub event on {@code mariaalpha.positions.updates} so subscribers can invalidate any local
+ * cache without polling. Redis remains a pure cache; PostgreSQL is the system of record. Failures
+ * here never block fill processing — a warning is logged and processing continues.
+ */
+@Component
+@ConditionalOnProperty(prefix = "order-manager.redis", name = "enabled", matchIfMissing = true)
+public class RedisPositionCachePublisher {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RedisPositionCachePublisher.class);
+
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final RedisConfig config;
+  private final Counter writesTotal;
+  private final Counter writeFailuresTotal;
+  private final Timer writeLatency;
+
+  public RedisPositionCachePublisher(
+      StringRedisTemplate redisTemplate,
+      ObjectMapper objectMapper,
+      RedisConfig config,
+      MeterRegistry meterRegistry) {
+    this.redisTemplate = redisTemplate;
+    this.objectMapper = objectMapper;
+    this.config = config;
+    this.writesTotal =
+        Counter.builder("mariaalpha_position_cache_writes_total")
+            .description("Successful position-cache writes to Redis")
+            .register(meterRegistry);
+    this.writeFailuresTotal =
+        Counter.builder("mariaalpha_position_cache_write_failures_total")
+            .description("Failed position-cache writes to Redis")
+            .register(meterRegistry);
+    this.writeLatency =
+        Timer.builder("mariaalpha_position_cache_write_latency")
+            .description("Latency of position-cache writes to Redis")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .register(meterRegistry);
+  }
+
+  public void publish(PositionSnapshot snapshot) {
+    if (snapshot == null || snapshot.symbol() == null) {
+      return;
+    }
+    long start = System.nanoTime();
+    try {
+      var payload = objectMapper.writeValueAsString(snapshot);
+      var key = config.positionKeyPrefix() + snapshot.symbol();
+      redisTemplate.opsForValue().set(key, payload, config.positionTtl());
+      redisTemplate.convertAndSend(config.positionsPubSubChannel(), payload);
+      writesTotal.increment();
+    } catch (JsonProcessingException e) {
+      LOG.warn(
+          "Failed to serialize position snapshot for cache {}: {}",
+          snapshot.symbol(),
+          e.getMessage());
+      writeFailuresTotal.increment();
+    } catch (DataAccessException e) {
+      // Never let Redis hiccups fail a fill — Kafka is the authoritative path.
+      LOG.warn(
+          "Redis cache write failed for {}: {}; continuing without cache update",
+          snapshot.symbol(),
+          e.getMessage());
+      writeFailuresTotal.increment();
+    } finally {
+      writeLatency.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+}

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/config/RedisConfig.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.mariaalpha.ordermanager.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Phase-2 (issue 2.7.4) distributed position cache configuration. {@code enabled=false} disables
+ * publishing entirely so unit tests and minimal local stacks can run without a Redis instance.
+ */
+@ConfigurationProperties(prefix = "order-manager.redis")
+public record RedisConfig(
+    boolean enabled,
+    String positionKeyPrefix,
+    String positionsPubSubChannel,
+    Duration positionTtl) {
+
+  public RedisConfig {
+    if (positionKeyPrefix == null || positionKeyPrefix.isBlank()) {
+      positionKeyPrefix = "mariaalpha:position:";
+    }
+    if (positionsPubSubChannel == null || positionsPubSubChannel.isBlank()) {
+      positionsPubSubChannel = "mariaalpha.positions.updates";
+    }
+    if (positionTtl == null || positionTtl.isZero() || positionTtl.isNegative()) {
+      positionTtl = Duration.ofHours(24);
+    }
+  }
+}

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumer.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumer.java
@@ -1,6 +1,7 @@
 package com.mariaalpha.ordermanager.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mariaalpha.ordermanager.cache.RedisPositionCachePublisher;
 import com.mariaalpha.ordermanager.controller.dto.PositionSnapshot;
 import com.mariaalpha.ordermanager.model.OrderLifecycleEvent;
 import com.mariaalpha.ordermanager.publisher.PositionUpdatePublisher;
@@ -10,6 +11,7 @@ import java.time.Instant;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,16 +25,19 @@ public class OrderLifecycleConsumer {
   private final OrderPersistenceService persistenceService;
   private final PositionService positionService;
   private final PositionUpdatePublisher publisher;
+  private final ObjectProvider<RedisPositionCachePublisher> cachePublisher;
 
   public OrderLifecycleConsumer(
       ObjectMapper objectMapper,
       OrderPersistenceService persistenceService,
       PositionService positionService,
-      PositionUpdatePublisher publisher) {
+      PositionUpdatePublisher publisher,
+      ObjectProvider<RedisPositionCachePublisher> cachePublisher) {
     this.objectMapper = objectMapper;
     this.persistenceService = persistenceService;
     this.positionService = positionService;
     this.publisher = publisher;
+    this.cachePublisher = cachePublisher;
   }
 
   @KafkaListener(topics = "${order-manager.kafka.orders-lifecycle-topic}")
@@ -71,6 +76,7 @@ public class OrderLifecycleConsumer {
                   position.getLastMarkPrice(),
                   Instant.now());
           publisher.publish(positionSnapshot);
+          cachePublisher.ifAvailable(p -> p.publish(positionSnapshot));
         });
   }
 }

--- a/order-manager/src/main/resources/application.yml
+++ b/order-manager/src/main/resources/application.yml
@@ -4,6 +4,12 @@ server:
 spring:
   application:
     name: order-manager
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+      timeout: 200ms
+      connect-timeout: 500ms
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:mariaalpha}
     username: ${POSTGRES_USER:mariaalpha}
@@ -40,6 +46,13 @@ order-manager:
     positions-updates-topic: positions.updates
   portfolio:
     initial-cash: 1000000.00
+  # Phase-2 (issue 2.7.4) distributed position cache. Disable with order-manager.redis.enabled=false
+  # to run without a Redis instance — Kafka remains authoritative for downstream consumers.
+  redis:
+    enabled: true
+    position-key-prefix: "mariaalpha:position:"
+    positions-pub-sub-channel: "mariaalpha.positions.updates"
+    position-ttl: PT24H
 
 management:
   server:
@@ -60,6 +73,11 @@ management:
           include: livenessState
   health:
     kafka:
+      enabled: true
+    # Redis cache is non-critical (Kafka remains authoritative). Surface its status in
+    # /actuator/health but keep it out of the readiness probe so a momentary Redis hiccup
+    # does not flap pod readiness.
+    redis:
       enabled: true
   metrics:
     tags:

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/cache/RedisPositionCacheIntegrationTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/cache/RedisPositionCacheIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.mariaalpha.ordermanager.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.mariaalpha.ordermanager.config.RedisConfig;
+import com.mariaalpha.ordermanager.controller.dto.PositionSnapshot;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Phase-2 (issue 2.7.4) integration test that exercises the publisher against a real Redis,
+ * verifying the SET + TTL + PUBLISH path end-to-end.
+ */
+@Tag("integration")
+@Testcontainers
+class RedisPositionCacheIntegrationTest {
+
+  private static final GenericContainer<?> REDIS =
+      new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+
+  private static LettuceConnectionFactory connectionFactory;
+  private static StringRedisTemplate template;
+
+  @BeforeAll
+  static void startContainer() {
+    REDIS.start();
+    connectionFactory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getFirstMappedPort());
+    connectionFactory.afterPropertiesSet();
+    template = new StringRedisTemplate(connectionFactory);
+    template.afterPropertiesSet();
+  }
+
+  @AfterAll
+  static void stopContainer() {
+    if (connectionFactory != null) {
+      connectionFactory.destroy();
+    }
+    REDIS.stop();
+  }
+
+  @Test
+  void publishWritesKeyAndTtlInRealRedis() {
+    var config =
+        new RedisConfig(
+            true, "mariaalpha:position:", "mariaalpha.positions.updates", Duration.ofMinutes(30));
+    var publisher =
+        new RedisPositionCachePublisher(
+            template,
+            new ObjectMapper().registerModule(new JavaTimeModule()),
+            config,
+            new SimpleMeterRegistry());
+
+    publisher.publish(
+        new PositionSnapshot(
+            "AAPL",
+            BigDecimal.valueOf(100),
+            BigDecimal.valueOf(150),
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            BigDecimal.valueOf(155),
+            Instant.parse("2026-06-02T12:00:00Z")));
+
+    var raw = template.opsForValue().get("mariaalpha:position:AAPL");
+    assertThat(raw).isNotNull().contains("\"symbol\":\"AAPL\"").contains("\"netQuantity\":100");
+
+    var ttl = template.getExpire("mariaalpha:position:AAPL");
+    assertThat(ttl).isGreaterThan(0L).isLessThanOrEqualTo(30L * 60L);
+  }
+}

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/cache/RedisPositionCachePublisherTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/cache/RedisPositionCachePublisherTest.java
@@ -1,0 +1,94 @@
+package com.mariaalpha.ordermanager.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.mariaalpha.ordermanager.config.RedisConfig;
+import com.mariaalpha.ordermanager.controller.dto.PositionSnapshot;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisPositionCachePublisherTest {
+
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private ValueOperations<String, String> valueOps;
+
+  private ObjectMapper objectMapper;
+  private SimpleMeterRegistry registry;
+  private RedisPositionCachePublisher publisher;
+  private final RedisConfig config =
+      new RedisConfig(
+          true, "mariaalpha:position:", "mariaalpha.positions.updates", Duration.ofHours(1));
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    registry = new SimpleMeterRegistry();
+    publisher = new RedisPositionCachePublisher(redisTemplate, objectMapper, config, registry);
+  }
+
+  @Test
+  void publishWritesValueAndPublishesPubSub() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    var snap = snapshot("AAPL", 100, 150);
+
+    publisher.publish(snap);
+
+    verify(valueOps)
+        .set(eq("mariaalpha:position:AAPL"), any(String.class), eq(Duration.ofHours(1)));
+    verify(redisTemplate).convertAndSend(eq("mariaalpha.positions.updates"), any(String.class));
+    assertThat(registry.counter("mariaalpha_position_cache_writes_total").count()).isEqualTo(1.0);
+  }
+
+  @Test
+  void publishSwallowsRedisFailuresAndRecordsMetric() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    doThrow(new QueryTimeoutException("redis down"))
+        .when(valueOps)
+        .set(any(), any(), any(Duration.class));
+
+    publisher.publish(snapshot("MSFT", 50, 200));
+
+    assertThat(registry.counter("mariaalpha_position_cache_write_failures_total").count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void publishDropsNullSymbol() {
+    publisher.publish(null);
+    publisher.publish(
+        new PositionSnapshot(null, BigDecimal.ZERO, null, null, null, null, Instant.now()));
+
+    verify(redisTemplate, never()).opsForValue();
+    verify(redisTemplate, never()).convertAndSend(any(), any());
+  }
+
+  private static PositionSnapshot snapshot(String sym, int qty, int price) {
+    return new PositionSnapshot(
+        sym,
+        BigDecimal.valueOf(qty),
+        BigDecimal.valueOf(price),
+        BigDecimal.ZERO,
+        BigDecimal.ZERO,
+        BigDecimal.valueOf(price),
+        Instant.parse("2026-06-02T12:00:00Z"));
+  }
+}

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumerIntegrationTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumerIntegrationTest.java
@@ -68,6 +68,16 @@ class OrderLifecycleConsumerIntegrationTest {
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
     registry.add(
         "spring.liquibase.change-log", () -> "classpath:db/changelog/db.changelog-master.yaml");
+    // No Redis container here — the cache is exercised in
+    // RedisPositionCachePublisherIntegrationTest.
+    registry.add("order-manager.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
   }
 
   @Autowired private OrderRepository orderRepository;

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumerTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.mariaalpha.ordermanager.cache.RedisPositionCachePublisher;
 import com.mariaalpha.ordermanager.controller.dto.PositionSnapshot;
 import com.mariaalpha.ordermanager.entity.FillEntity;
 import com.mariaalpha.ordermanager.entity.OrderEntity;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 
 @ExtendWith(MockitoExtension.class)
 class OrderLifecycleConsumerTest {
@@ -37,6 +39,8 @@ class OrderLifecycleConsumerTest {
   @Mock private OrderPersistenceService persistenceService;
   @Mock private PositionService positionService;
   @Mock private PositionUpdatePublisher publisher;
+  @Mock private RedisPositionCachePublisher cachePublisher;
+  @Mock private ObjectProvider<RedisPositionCachePublisher> cacheProvider;
 
   private ObjectMapper objectMapper;
   private OrderLifecycleConsumer consumer;
@@ -45,7 +49,8 @@ class OrderLifecycleConsumerTest {
   void setUp() {
     objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
     consumer =
-        new OrderLifecycleConsumer(objectMapper, persistenceService, positionService, publisher);
+        new OrderLifecycleConsumer(
+            objectMapper, persistenceService, positionService, publisher, cacheProvider);
   }
 
   @Test


### PR DESCRIPTION
  **2.7.4 — Redis Distributed Position Cache**

  - Added Redis 7.4-alpine service to docker-compose.yml (with allkeys-lru eviction + persistent volume + healthcheck).
  - Added the Bitnami redis@20.x subchart to charts/mariaalpha/, single-node standalone, addressable at redis-master.mariaalpha-data.svc.cluster.local:6379.
  - Order Manager (writer): new RedisPositionCachePublisher writes the same PositionSnapshot JSON to mariaalpha:position:<symbol> (24 h TTL) and publishes on channel mariaalpha.positions.updates after every
  fill — alongside the existing Kafka positions.updates publish. Wired into OrderLifecycleConsumer via ObjectProvider (lazy/optional bean).
  - Execution Engine (reader): new RedisPositionCacheClient warms PositionTracker on startup by SCANning all keys, subscribes to the pub/sub channel for real-time updates, and exposes a direct fetch()
  fallback. A RedisBeans config provides the RedisMessageListenerContainer.
  - Both sides are guarded by *.redis.enabled=true (matchIfMissing) and gracefully degrade if Redis is unavailable (warn + continue; Kafka remains the durable path).
  - 8 new Prometheus metrics: mariaalpha_position_cache_{writes,write_failures,hits,misses,pubsub_updates,read_failures}_total plus _latency histograms.
  - Tests: unit tests + Testcontainers integration tests on both sides; existing integration tests touched up to disable Redis auto-config where not needed.

  **2.7.5 — Bruno API Collection**

  - Created api-collection/ directory with bruno.json, root collection.bru (auth + docs), and per-environment files for Local Docker Compose and OrbStack Helm.
  - 47 .bru request files organized into folders: Health, Strategies, RFQ, Orders, Positions, Portfolio, Execution, Routing, TCA, Recon, Analytics, plus direct-services/.
  - All gateway requests send X-API-Key: {{apiKey}}. Multi-step flows (e.g. RFQ quote → accept) chain via run-scoped variables (lastQuoteId, lastSubmittedOrderId, lastIcebergParentId).
  - README explains install + CLI smoke run via bru run --env "Local Docker Compose" "00 - Health/...".

Closes #85
Closes #86