### PR TITLE
documentation uplift

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,26 @@ Full-stack algorithmic trading engine — see [Technical Design Document](docs/t
 MariaAlpha is a working, end-to-end algorithmic trading engine:
 
 - **Live market data ingestion** — simulated CSV replay (default) or Alpaca IEX WebSocket, with auto-reconnect and per-symbol in-memory order book.
-- **Six execution algorithms + RFQ pricing** — VWAP, TWAP, Momentum/trend-following, Implementation Shortfall, POV (Percentage of Volume), Close (Market-on-Close benchmark), and a two-way RFQ engine with inventory-skewed, vol- and ADV-relative pricing. Every signal is gated by an ML confirm/veto (LightGBM signal model + Random Forest regime classifier called over gRPC with a Resilience4j circuit breaker). Strategy hot-swap at runtime via REST.
-- **Eight pre-trade risk checks** — max notional, max position, max portfolio exposure, max open orders, daily loss limit, plus sector / beta / ADV-participation checks driven by per-symbol reference data. Composable chain that short-circuits on first failure; daily-loss trip halts trading and is resumable via REST.
+- **Six execution algorithms + RFQ pricing** — VWAP, TWAP, Momentum/trend-following, Implementation Shortfall, POV (Percentage of Volume), Close (Market-on-Close benchmark), and a two-way RFQ engine with inventory-skewed, vol- and ADV-relative pricing. Every signal is gated by an ML confirm/veto (LightGBM signal model + Random Forest regime classifier called over gRPC with a Resilience4j circuit breaker). Strategy hot-swap at runtime via REST, plus a programmatic [algo execution API](docs/strategies/algo-execution-api.md) (`POST /api/algo/orders` + `/ws/algo` progress WebSocket) for external clients.
+- **Multi-market trading hours** — per-market session calendars (NYSE/NASDAQ, TSE with lunch break, holidays) gate strategy evaluation so closed-market ticks never pollute indicator state.
+- **Options pricing** — Black-Scholes-Merton pricer with full Greeks (delta, gamma, vega, theta, rho) and an implied-volatility solver, exposed over REST and a dedicated UI page.
+- **Ten pre-trade risk checks** — max notional, max position, max portfolio exposure, max open orders, daily loss limit, sector / beta / ADV-participation checks driven by per-symbol reference data, plus [intraday parametric VaR](docs/strategies/intraday-var.md) and [correlated-position cluster limits](docs/strategies/correlated-positions.md). Composable chain that short-circuits on first failure; daily-loss trip halts trading and is resumable via REST.
 - **Smart Order Router** with scored multi-criteria venue selection across LIT, DARK, and INTERNAL venues, plus an in-process **internal crossing engine** that matches offsetting BUY/SELL interest at the NBBO midpoint.
-- **Seven order types** — MARKET, LIMIT, STOP, IOC, FOK, GTC, Iceberg (with a dedicated coordinator that slices parents into LIMIT children).
+- **Eight order types** — MARKET, LIMIT, STOP, IOC, FOK, GTC, Iceberg (with a dedicated coordinator that slices parents into LIMIT children), and [Pegged](docs/strategies/pegged-orders.md) (midpoint/primary/market peg that re-prices its working child as the NBBO moves).
 - **Dual exchange routing** — simulated exchange (configurable fill latency + slippage) or Alpaca paper trading (REST + `trade_updates` WebSocket with reconnect), switchable via `EXECUTION_PROFILE`.
-- **Real-time position and P&L tracking** — mark-to-market unrealized P&L, portfolio aggregates, fill history persisted in PostgreSQL with a Redis hot-path cache for sub-millisecond pre-trade reads.
+- **Real-time position and P&L tracking** — mark-to-market unrealized P&L, portfolio aggregates, [per-currency exposure](docs/strategies/currency-exposure.md), fill history persisted in PostgreSQL with a Redis hot-path cache for sub-millisecond pre-trade reads.
 - **Transaction Cost Analysis + PnL attribution + flow toxicity + axe matching** — slippage, implementation shortfall, VWAP benchmark, spread cost per order; Kissell-Glantz five-component PnL decomposition; per-counterparty markout-based toxicity; client-interest axe matcher.
+- **Trade allocation** — post-trade splitting of filled parents across sub-accounts (pro-rata with remainder handling, or FIFO waterfall), persisted as the per-account book of record.
 - **End-of-day reconciliation** — scheduled comparison of internal fills against the external venue's activity log, with four break categories (MISSING / EXTRA / QUANTITY / PRICE) published to `analytics.risk-alerts`.
-- **React UI** — Dashboard, Order Entry, RFQ, Strategy Control, Analytics, Reconciliation, all driven by live WebSocket streams. Served via nginx in Docker Compose; via an init-container config-render under Helm.
+- **React UI** — Dashboard, Order Entry, RFQ, Options, Strategy Control, Analytics, Reconciliation, Allocations, all driven by live WebSocket streams. Served via nginx in Docker Compose; via an init-container config-render under Helm.
 - **Full observability** — Grafana LGTM stack (Alloy, Prometheus, Loki, Tempo, Grafana 11) with three provisioned dashboards: Trading Pipeline, Portfolio & Risk, Post-Trade & Quality.
 - **Production-grade CI** — Spotless / Checkstyle / SpotBugs / ESLint / Prettier / ruff / mypy, JUnit unit + Testcontainers integration tests + Docker-Compose-driven end-to-end suite, mutation testing (PITest + mutmut), CodeQL and Snyk security scans, multi-arch Docker image publish, Helm lint + kubeconform.
 - **Two deployment targets** — Docker Compose for local development, an umbrella Helm chart for Kubernetes (validated against OrbStack, Docker Desktop, minikube, kind).
-- **Importable API collection** — [`api-collection/`](api-collection/) is a Bruno collection covering every gateway-routed REST endpoint plus direct-to-service health/admin calls.
+- **Importable API collection** — [`api-collection/`](api-collection/) is a Bruno collection covering the gateway-routed REST surface (health, strategies, RFQ, options, orders, positions, portfolio, execution, pegged, routing, TCA, recon, allocations, analytics) plus direct-to-service health/admin calls.
 
 The end-to-end acceptance suite under `e2e-tests/` boots the full Docker Compose stack and traverses the complete Tick-to-Trade pipeline on every CI run.
 
-See [§11 of the Technical Design Document](docs/technical-design-document.md#11-roadmap) for the roadmap of additional capabilities not yet built (multi-broker integration via IBKR, options/Greeks, Tokyo Stock Exchange microstructure, program/basket trading, FIX gateway, backtesting, OAuth/RBAC, ML-driven SOR, and others).
+See [§11 of the Technical Design Document](docs/technical-design-document.md#11-roadmap) for the roadmap of additional capabilities not yet built (backtesting, cloud deployment, multi-broker integration via IBKR, Tokyo Stock Exchange microstructure, program/basket trading, FIX gateway, OAuth/RBAC, ML-driven SOR, and others).
 
 ## Prerequisites
 
@@ -110,7 +113,7 @@ Polling /actuator/health on every service...
 
 ## Kubernetes Quickstart (Helm on OrbStack)
 
-An alternative to docker-compose: deploy the same stack to a local Kubernetes cluster via the umbrella Helm chart in [`charts/mariaalpha/`](charts/mariaalpha/README.md).
+An alternative to docker-compose: deploy the same stack (minus the analytics-service, which has no subchart yet) to a local Kubernetes cluster via the umbrella Helm chart in [`charts/mariaalpha/`](charts/mariaalpha/README.md).
 
 ```bash
 brew install helm                            # one-time
@@ -252,15 +255,36 @@ curl -X PUT -H "X-API-Key: local-dev-key" \
         }' \
     http://localhost:8080/api/strategies/CLOSE/parameters
 
+# Or skip the bind+configure two-step entirely: the algo execution API creates and
+# starts a parent algo order in one POST, returning a UUID you can poll, cancel,
+# and follow over the /ws/algo WebSocket. See docs/strategies/algo-execution-api.md.
+curl -X POST -H "X-API-Key: local-dev-key" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "symbol": "MSFT",
+          "side": "BUY",
+          "targetQuantity": 50,
+          "strategyName": "TWAP",
+          "parameters": {
+            "targetQuantity": 50,
+            "side": "BUY",
+            "startTime": "14:30:00",
+            "endTime": "16:00:00",
+            "numSlices": 6
+          }
+        }' \
+    http://localhost:8080/api/algo/orders
+
 # Place a manual LIMIT order.
 curl -X POST -H "X-API-Key: local-dev-key" \
     -H "Content-Type: application/json" \
     -d '{"symbol":"AAPL","side":"BUY","orderType":"LIMIT","quantity":10,"limitPrice":180.00}' \
     http://localhost:8080/api/execution/orders
 
-# Read positions and portfolio summary.
+# Read positions, portfolio summary, and per-currency exposure.
 curl -fsS -H "X-API-Key: local-dev-key" http://localhost:8080/api/positions
 curl -fsS -H "X-API-Key: local-dev-key" http://localhost:8080/api/portfolio/summary
+curl -fsS -H "X-API-Key: local-dev-key" http://localhost:8080/api/portfolio/currency-exposure
 ```
 
 ### 7. Tear down
@@ -329,7 +353,7 @@ just run
 
 ### React UI (port 5173 in dev)
 
-The web UI is a Vite + React 18 + TypeScript single-page app with seven pages: Dashboard (live positions, P&L, exposure), Order Entry (manual order submission, active orders, fills), RFQ, Strategy Control, Analytics, Reconciliation, and a Market Data placeholder reserved for a future page.
+The web UI is a Vite + React 18 + TypeScript single-page app with nine pages: Dashboard (live positions, P&L, exposure), Order Entry (manual order submission, active orders, fills), RFQ, Options (Black-Scholes pricing + Greeks), Strategy Control, Analytics, Reconciliation, Allocations, and a Market Data placeholder reserved for a future page.
 
 #### Quickstart
 

--- a/api-collection/README.md
+++ b/api-collection/README.md
@@ -62,6 +62,12 @@ The market-data-gateway intentionally has no REST surface — its public API is
 gRPC + WebSocket. Use the Strategy Control / Market Data UI pages to exercise it
 during manual testing.
 
+**Not yet covered:** the algo execution API (`/api/algo/orders`, see
+[`docs/strategies/algo-execution-api.md`](../docs/strategies/algo-execution-api.md))
+and the currency-exposure read (`GET /api/portfolio/currency-exposure`, see
+[`docs/strategies/currency-exposure.md`](../docs/strategies/currency-exposure.md)).
+Both are exercised by curl examples in the root README until folders are added here.
+
 ## Conventions
 
 - Every gateway-routed request sends `X-API-Key: {{apiKey}}` — the gateway

--- a/charts/mariaalpha/README.md
+++ b/charts/mariaalpha/README.md
@@ -83,11 +83,13 @@ Flip `secrets.useSealedSecrets: true` and enable the controller via `sealed-secr
 
 This chart deploys MariaAlpha to a local Kubernetes cluster. The Bitnami Redis subchart wired into order-manager + execution-engine is the distributed position cache (cluster DNS: `redis-master.mariaalpha-data.svc.cluster.local:6379`, auth disabled for the local install). NetworkPolicies, HPA tuning, PDBs, and TLS via cert-manager `ClusterIssuer` are deferred to follow-up tickets.
 
+Note: the Python **analytics-service** is deployed by Docker Compose only — it has no subchart yet, so `/api/analytics/**` routes return errors on a Helm deployment until one is added.
+
 ## Layout
 
 ```
 charts/mariaalpha/
-├── Chart.yaml                       umbrella, declares 9 external deps
+├── Chart.yaml                       umbrella, declares 10 external deps
 ├── values.yaml                      local defaults
 ├── values-burst.yaml                load-test overlay
 ├── values-oci.yaml                  cloud overlay (placeholder)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,13 +33,13 @@ Each microservice has a dedicated explainer covering its architecture, data flow
 | Service | Explainer | Role |
 |---|---|---|
 | Market Data Gateway | *(deep-dive doc TBD — see TDD §5.2.1)* | Subscribes to Alpaca; normalises ticks to `market-data.ticks`; serves the live order book over gRPC. |
-| **Strategy Engine** | [`services/strategy-engine.md`](services/strategy-engine.md) | Hosts the strategy registry, the ML confirm/veto gate, and the RFQ pricing engine. |
+| **Strategy Engine** | [`services/strategy-engine.md`](services/strategy-engine.md) | Hosts the strategy registry, the ML confirm/veto gate, the RFQ pricing engine, the [options pricer](strategies/options-pricing.md), the [algo execution API](strategies/algo-execution-api.md), and [multi-market trading hours](strategies/multi-market-trading-hours.md). |
 | ML Signal Service | [`services/ml-signal-service.md`](services/ml-signal-service.md) | Python gRPC + FastAPI. LightGBM signal model + Random Forest regime classifier. |
-| Execution Engine | [`services/execution-engine.md`](services/execution-engine.md) | Order lifecycle, risk-check chain, exchange adapters, daily-loss kill-switch. |
+| Execution Engine | [`services/execution-engine.md`](services/execution-engine.md) | Order lifecycle, ten-check risk chain (incl. [intraday VaR](strategies/intraday-var.md) and [correlated positions](strategies/correlated-positions.md)), [pegged orders](strategies/pegged-orders.md), exchange adapters, daily-loss kill-switch. |
 | Smart Order Router | [`services/smart-order-router.md`](services/smart-order-router.md) | Scored multi-criteria venue selection (sub-component of Execution Engine). |
 | Internal Crossing Engine | [`services/internal-crossing-engine.md`](services/internal-crossing-engine.md) | In-process midpoint matching for desk-vs-desk flow (sub-component of Execution Engine). |
-| Order Manager | [`services/order-manager.md`](services/order-manager.md) | System of record for orders, fills, positions, portfolio P&L. |
-| Post-Trade | *(deep-dive doc TBD — see TDD §5.2.6)* | TCA computation, end-of-day reconciliation. |
+| Order Manager | [`services/order-manager.md`](services/order-manager.md) | System of record for orders, fills, positions, portfolio P&L, [currency exposure](strategies/currency-exposure.md). |
+| Post-Trade | *(deep-dive doc TBD — see TDD §5.2.6)* | TCA computation, end-of-day reconciliation, [trade allocation](strategies/trade-allocation.md). |
 | Analytics Service | [`services/analytics-service.md`](services/analytics-service.md) | Python FastAPI. Flow toxicity, PnL attribution, axe matcher. |
 | API Gateway | [`services/api-gateway.md`](services/api-gateway.md) | Unified REST + WebSocket entry point. API-key auth. |
 | React UI | [`services/ui.md`](services/ui.md) | TypeScript + Vite + Tailwind + Recharts. Dashboard, Order Entry, RFQ, etc. |
@@ -47,9 +47,11 @@ Each microservice has a dedicated explainer covering its architecture, data flow
 
 ---
 
-## Strategies
+## Strategies & trading features
 
-Each *execution* strategy implements `TradingStrategy` and registers with the Strategy Engine's `StrategyRegistry`. The RFQ engine is on this page too — it's a *pricing* algorithm rather than a `TradingStrategy`, but it shares the same engine and emits the same `OrderSignal`.
+Each *execution* strategy implements `TradingStrategy` and registers with the Strategy Engine's `StrategyRegistry`. The same folder also documents the pricing engines, risk checks, and trading features that ship alongside the strategies — they share the engine, the risk chain, or the order pipeline even though they aren't `TradingStrategy` implementations.
+
+### Execution strategies
 
 | Strategy | Explainer | Style |
 |---|---|---|
@@ -59,7 +61,30 @@ Each *execution* strategy implements `TradingStrategy` and registers with the St
 | Implementation Shortfall | [`strategies/implementation-shortfall.md`](strategies/implementation-shortfall.md) | Schedule: front-loaded along an Almgren–Chriss trajectory. |
 | POV | [`strategies/pov.md`](strategies/pov.md) | Reactive: participate as a fraction of traded volume. |
 | Close | [`strategies/close.md`](strategies/close.md) | Schedule: working-into-the-close + MOC clip. |
-| **RFQ pricing** | [`strategies/rfq-pricing.md`](strategies/rfq-pricing.md) | Pricing: inventory-skewed, vol- and ADV-relative two-way quote. |
+
+### Pricing engines
+
+| Feature | Explainer | What it does |
+|---|---|---|
+| RFQ pricing | [`strategies/rfq-pricing.md`](strategies/rfq-pricing.md) | Inventory-skewed, vol- and ADV-relative two-way quote. |
+| Options pricing | [`strategies/options-pricing.md`](strategies/options-pricing.md) | Black-Scholes-Merton pricing, Greeks, and implied-vol solver (Strategy Engine REST). |
+
+### Risk checks
+
+| Feature | Explainer | What it does |
+|---|---|---|
+| Intraday VaR | [`strategies/intraday-var.md`](strategies/intraday-var.md) | Pre-trade parametric VaR limit over the simulated post-trade portfolio. |
+| Correlated positions | [`strategies/correlated-positions.md`](strategies/correlated-positions.md) | Caps aggregate exposure across correlation clusters of symbols. |
+| Currency exposure | [`strategies/currency-exposure.md`](strategies/currency-exposure.md) | Read-side per-currency exposure and P&L aggregation in the Order Manager. |
+
+### Order handling & access
+
+| Feature | Explainer | What it does |
+|---|---|---|
+| Pegged orders | [`strategies/pegged-orders.md`](strategies/pegged-orders.md) | PEGGED order type: tracks midpoint / bid / ask, re-pricing as the NBBO moves. |
+| Trade allocation | [`strategies/trade-allocation.md`](strategies/trade-allocation.md) | Post-trade fill allocation across sub-accounts (pro-rata, FIFO). |
+| Algo execution API | [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md) | Programmatic REST + WebSocket surface for external algo clients. |
+| Multi-market trading hours | [`strategies/multi-market-trading-hours.md`](strategies/multi-market-trading-hours.md) | Session calendars gating strategy evaluation per listing market. |
 
 ---
 

--- a/docs/services/api-gateway.md
+++ b/docs/services/api-gateway.md
@@ -124,10 +124,10 @@ Five routes defined declaratively. Spring Cloud Gateway evaluates path predicate
 
 | Route ID | Paths | Downstream |
 |----------|-------|-----------|
-| `strategies` | `/api/strategies/**`, `/api/rfq/**` | `STRATEGY_ENGINE_URL` (default: `localhost:8082`) |
+| `strategies` | `/api/strategies/**`, `/api/rfq/**`, `/api/options/**`, `/api/algo/**` | `STRATEGY_ENGINE_URL` (default: `localhost:8082`) |
 | `orders` | `/api/orders/**`, `/api/positions/**`, `/api/portfolio/**` | `ORDER_MANAGER_URL` (default: `localhost:8086`) |
 | `execution` | `/api/execution/**`, `/api/routing/**` | `EXECUTION_ENGINE_URL` (default: `localhost:8084`) |
-| `post-trade` | `/api/tca/**`, `/api/recon/**` | `POST_TRADE_URL` (default: `localhost:8088`) |
+| `post-trade` | `/api/tca/**`, `/api/recon/**`, `/api/allocations/**` | `POST_TRADE_URL` (default: `localhost:8088`) |
 | `market-data` | `/api/market-data/**` | `MARKET_DATA_GATEWAY_URL` (default: `localhost:8079`) |
 
 Paths are forwarded as-is. The HTTP client uses a 2-second connect timeout and 10-second response
@@ -149,6 +149,8 @@ prefix before forwarding.
 ```
 /api/strategies/**    →  strategy-engine:8082
 /api/rfq/**           →  strategy-engine:8082
+/api/options/**       →  strategy-engine:8082
+/api/algo/**          →  strategy-engine:8082
 /api/orders/**        →  order-manager:8086
 /api/positions/**     →  order-manager:8086
 /api/portfolio/**     →  order-manager:8086
@@ -156,12 +158,14 @@ prefix before forwarding.
 /api/routing/**       →  execution-engine:8084
 /api/tca/**           →  post-trade:8088
 /api/recon/**         →  post-trade:8088
+/api/allocations/**   →  post-trade:8088
 /api/market-data/**   →  market-data-gateway:8079
 /api/analytics/**     →  analytics-service:8095 (rewritten to /v1/analytics/**)
 /ws/market-data       →  KafkaTopicBroadcaster (market-data.ticks)
 /ws/positions         →  KafkaTopicBroadcaster (positions.updates)
 /ws/orders            →  KafkaTopicBroadcaster (orders.lifecycle)
 /ws/alerts            →  KafkaTopicBroadcaster (analytics.risk-alerts)
+/ws/algo              →  KafkaTopicBroadcaster (algo.progress)
 ```
 
 ---
@@ -186,7 +190,7 @@ KafkaTopicBroadcaster          (one Sinks.Many per topic, multicast)
 On startup (`@PostConstruct`) creates one `Sinks.Many<String>` per configured endpoint. Each sink
 is a multicast sink with a backpressure buffer of 1024 messages.
 
-Four `@KafkaListener` methods consume from one topic each:
+Five `@KafkaListener` methods consume from one topic each:
 
 | Listener method | Topic | Consumer group |
 |----------------|-------|----------------|
@@ -194,6 +198,7 @@ Four `@KafkaListener` methods consume from one topic each:
 | `onPositions` | `positions.updates` | `api-gateway-<uuid>-positions` |
 | `onOrders` | `orders.lifecycle` | `api-gateway-<uuid>-orders` |
 | `onAlerts` | `analytics.risk-alerts` | `api-gateway-<uuid>-alerts` |
+| `onAlgoProgress` | `algo.progress` | `api-gateway-<uuid>-algo` |
 
 Consumer group IDs use `${random.uuid}` so every gateway instance gets a unique group. This means
 **each instance receives all messages** rather than load-balancing them — appropriate for fan-out
@@ -233,6 +238,7 @@ The `filterKey` per endpoint (configured in `application.yml`):
 | `/ws/positions` | `positions.updates` | `symbol` |
 | `/ws/orders` | `orders.lifecycle` | `orderId` |
 | `/ws/alerts` | `analytics.risk-alerts` | `symbol` |
+| `/ws/algo` | `algo.progress` | `algoOrderId` |
 
 ### `SymbolKeyExtractor`
 

--- a/docs/services/execution-engine.md
+++ b/docs/services/execution-engine.md
@@ -110,7 +110,7 @@ The `Order` class is intentionally mutable — it accumulates fills, tracks fill
 
 ### Stage 2: Order Type Validation
 
-The `OrderTypeHandlerRegistry` looks up the handler for the order's type. Seven order types are supported: **MARKET, LIMIT, STOP, IOC, FOK, GTC, ICEBERG**. If no handler is registered (e.g., a future PEGGED type), the order is rejected with `"Unsupported order type"`.
+The `OrderTypeHandlerRegistry` looks up the handler for the order's type. Eight order types are supported: **MARKET, LIMIT, STOP, IOC, FOK, GTC, ICEBERG, PEGGED**. If no handler is registered for a type, the order is rejected with `"Unsupported order type"`.
 
 Each handler performs type-specific validation:
 
@@ -149,11 +149,15 @@ Each handler performs type-specific validation:
 - The handler's `toExecutionInstruction` populates `ExecutionInstruction.displayQuantity` so the value flows downstream, but the parent order never reaches a venue adapter directly — see the iceberg dispatch below
 - Emits `TimeInForce.DAY` (TIF applies to each child slice individually)
 
-Wire-format translation lives in `AlpacaOrderTypeMapper`, which collapses IOC/FOK/GTC into Alpaca's `type=limit` with the appropriate `time_in_force` and explicitly rejects ICEBERG (the slicer is responsible for issuing the child LIMITs).
+**PeggedOrderHandler**:
+- `pegType` present (MIDPOINT / PRIMARY / MARKET), `pegOffsetBps` within `execution-engine.pegged.max-offset-bps`, market state present with a two-sided book, optional `limitPrice` price cap not absurdly far from the current reference
+- Like ICEBERG, the parent never reaches a venue adapter directly — `PeggedCoordinator` fronts it with a single re-pegging LIMIT child (see [`../strategies/pegged-orders.md`](../strategies/pegged-orders.md))
 
-The handler pattern remains extensible: adding a new order type (e.g. PEGGED, on the roadmap) only requires implementing the `OrderTypeHandler` interface and annotating with `@Component`. Spring auto-discovers it and the registry picks it up. No existing code changes.
+Wire-format translation lives in `AlpacaOrderTypeMapper`, which collapses IOC/FOK/GTC into Alpaca's `type=limit` with the appropriate `time_in_force` and explicitly rejects ICEBERG and PEGGED (their coordinators are responsible for issuing the child LIMITs).
 
-#### ICEBERG dispatch (special case)
+The handler pattern remains extensible: adding a new order type only requires implementing the `OrderTypeHandler` interface and annotating with `@Component`. Spring auto-discovers it and the registry picks it up. No existing code changes. PEGGED followed exactly this path (plus a coordinator for its stateful runtime) when it shipped in 3.2.3.
+
+#### ICEBERG and PEGGED dispatch (special cases)
 
 Immediately after validation + risk checks, `OrderExecutionService.processOrder` branches on `OrderType.ICEBERG` and hands the parent off to `IcebergCoordinator.onParentSubmit` *instead of* the normal venue-adapter call. The coordinator:
 
@@ -166,9 +170,11 @@ Subsequent slices are issued from `OrderExecutionService.onExecutionReport` via 
 
 A parent cancel (via `ManualOrderService.cancel`) cascades through `IcebergCoordinator.onParentCancelRequested`, which cancels the currently-active child at its venue and transitions the parent to CANCELLED with reason `iceberg-parent-cancelled`. Already-filled children are immutable; not-yet-submitted slices are simply never issued.
 
+PEGGED parents follow the same handler+coordinator split: `OrderExecutionService.processOrder` branches on `OrderType.PEGGED` and hands the parent to `PeggedCoordinator.onParentSubmit`, which keeps **one** LIMIT child working at the peg-derived price and cancels-and-resubmits it when the NBBO reference moves more than `repeg-threshold-bps`. Live progress is exposed at `GET /api/execution/orders/{parentId}/pegged-progress`. Full design in [`../strategies/pegged-orders.md`](../strategies/pegged-orders.md).
+
 ### Stage 3: Risk Check Chain
 
-The order passes through a composable chain of eight risk checks, executed in order. The chain **short-circuits** on the first failure — if check 2 fails, the remaining checks are never evaluated. This is a deliberate design choice: risk checks can involve lookups against position state and market data, so skipping unnecessary checks reduces latency.
+The order passes through a composable chain of ten risk checks, executed in order. The chain **short-circuits** on the first failure — if check 2 fails, the remaining checks are never evaluated. This is a deliberate design choice: risk checks can involve lookups against position state and market data, so skipping unnecessary checks reduces latency.
 
 Each check returns a `RiskCheckResult` with a boolean, the check name, and a human-readable reason. The reason is included in the Kafka rejection event, making it easy to diagnose why an order was blocked.
 
@@ -192,7 +198,7 @@ Counts the number of orders currently in SUBMITTED or PARTIALLY_FILLED status. I
 
 #### Check 5: DailyLossLimit (`@Order(5)`)
 
-Checks the `DailyLossMonitor.isTradingHalted()` flag. This is technically redundant with Stage 0, but it's included in the chain for completeness — if a loss breach occurs *between* Stage 0 and Stage 3 (due to concurrent fill processing), this check catches it. Since it's the cheapest check (a single boolean read), placing it last doesn't add meaningful latency.
+Checks the `DailyLossMonitor.isTradingHalted()` flag. This is technically redundant with Stage 0, but it's included in the chain for completeness — if a loss breach occurs *between* Stage 0 and Stage 3 (due to concurrent fill processing), this check catches it. It's the cheapest check in the chain (a single boolean read), so its position adds no meaningful latency.
 
 #### Check 6: SectorExposure (`@Order(6)`)
 
@@ -205,6 +211,14 @@ Caps |Σ position_notional × beta| in dollars. Catches the case where MaxPortfo
 #### Check 8: AdvParticipation (`@Order(8)`)
 
 Rejects parents whose share count exceeds `max-adv-participation × ADV(symbol)`. Runs against the **parent** quantity, not the first slice — the intent is to refuse parents that are too large to source liquidly regardless of how they'd be chopped by VWAP/TWAP/POV/etc. Refuses any order on a symbol with missing reference data (the conservative default ADV of 0) to fail safe before reference rows are added.
+
+#### Check 9: IntradayVar (`@Order(9)`)
+
+Pre-trade parametric Gaussian VaR. Projects the portfolio's one-day VaR as if the order filled — per-position VaR is `|position_notional| × σ_ann / √trading-days × z(confidence)`, aggregated as a sum of absolutes (conservative: no diversification credit) — and rejects when the projection exceeds `max-intraday-var`. Self-disables when the limit is 0. Full design in [`../strategies/intraday-var.md`](../strategies/intraday-var.md).
+
+#### Check 10: CorrelatedPositions (`@Order(10)`)
+
+Concentration check across operator-defined symbol clusters (`execution-engine.risk.correlated-clusters[]` — a named symbol list with a gross-$ cap per cluster). Catches "same narrative, different sector" risk that the sector and beta checks miss — e.g. the AI trade across NVDA + MSFT + GOOGL. Orders that shrink a cluster's gross always pass. Full design in [`../strategies/correlated-positions.md`](../strategies/correlated-positions.md).
 
 ### Stage 4: Routing
 
@@ -219,7 +233,7 @@ The handler builds an `ExecutionInstruction` from the order (a typed `TimeInForc
 - **Accepted**: The order transitions to `SUBMITTED` and the exchange order ID is stored on the order for fill correlation.
 - **Rejected**: The order transitions to `REJECTED` with the adapter's rejection reason.
 
-For ICEBERG parents this stage is bypassed (see "ICEBERG dispatch" above) — the coordinator owns submission and lifecycle for the parent.
+For ICEBERG and PEGGED parents this stage is bypassed (see the dispatch section above) — the coordinators own submission and lifecycle for the parent.
 
 ---
 
@@ -543,7 +557,7 @@ All settings live under the `execution-engine.*` namespace and are overridable v
 
 The execution engine needs `OrderSignal`, `Side`, and `OrderType` — models that also exist in the strategy engine. Rather than creating a shared-models library, these are replicated locally under `com.mariaalpha.executionengine.model`. This avoids coupling two independently deployable services. The field names match exactly, so Kafka JSON deserialisation works without mapping. A shared-models module will be introduced when a third consumer needs the same types.
 
-The execution engine's `OrderType` enum is the richest copy in the system: MARKET, LIMIT, STOP, IOC, FOK, GTC, ICEBERG. The order-manager `OrderType` mirrors it. The strategy-engine `OrderType` deliberately stays at MARKET/LIMIT — strategies only emit those two; richer types arrive through the manual REST API. Post-trade additionally enumerates `STOP_LIMIT` and `PEGGED` so its TCA pipeline can accept those types without a schema bump when they're added.
+The execution engine's `OrderType` enum is the richest copy in the system: MARKET, LIMIT, STOP, IOC, FOK, GTC, ICEBERG, PEGGED. The order-manager `OrderType` mirrors it. The strategy-engine `OrderType` deliberately stays at MARKET/LIMIT — strategies only emit those two; richer types arrive through the manual REST API. Post-trade additionally enumerates `STOP_LIMIT` so its TCA pipeline can accept that type without a schema bump when it's added.
 
 The execution engine's `OrderSignal` adds `stopPrice` (not present in the strategy engine's copy), plus the Phase-2 fields `displayQuantity`, `tif`, and `parentOrderId`. `OrderSignal` retains a backwards-compatible 8-arg constructor so existing strategy-engine + test call sites compile unchanged. Jackson ignores unknown properties by default, so strategy engine signals deserialise correctly — the missing fields are simply `null`.
 

--- a/docs/services/order-manager.md
+++ b/docs/services/order-manager.md
@@ -10,7 +10,7 @@ The service has two HTTP interfaces:
 
 | Interface | Port | Protocol | Purpose |
 |-----------|------|----------|---------|
-| REST API | 8086 | HTTP/1.1 + JSON | `/api/orders`, `/api/positions`, `/api/portfolio/summary` |
+| REST API | 8086 | HTTP/1.1 + JSON | `/api/orders`, `/api/positions`, `/api/portfolio/summary`, `/api/portfolio/currency-exposure` |
 | Actuator | 8087 | HTTP/1.1 + JSON | `/actuator/health`, `/actuator/prometheus` — ops and observability |
 
 ---
@@ -383,7 +383,7 @@ The check in `OrderPersistenceService.upsertOrder()` is intentionally lenient fo
 
 ## REST API
 
-All five endpoints live under `/api/*`. They are read-only; the Order Manager offers no mutating routes.
+All six endpoints live under `/api/*`. They are read-only; the Order Manager offers no mutating routes.
 
 ### `GET /api/orders`
 
@@ -411,6 +411,10 @@ Returns a single `PositionResponse`. 404 if the symbol has never had a position 
 ### `GET /api/portfolio/summary`
 
 Returns the aggregated `PortfolioSummaryResponse` described above. Always 200 — an empty portfolio returns zeros plus the initial cash.
+
+### `GET /api/portfolio/currency-exposure`
+
+Read-side aggregation of open-position exposure and realized/unrealized P&L grouped by ISO-4217 currency. Symbol → currency resolution uses `order-manager.currency.overrides` with a `default-currency` fallback (the simulator universe is USD-only, so the default response has a single row). Flat positions contribute realized P&L but not exposure; positions without a mark fall back to `avgEntryPrice`, the same convention as `/api/portfolio/summary`. Full design in [`../strategies/currency-exposure.md`](../strategies/currency-exposure.md).
 
 ---
 
@@ -462,13 +466,16 @@ All configuration lives in `application.yml` or environment variables (`POSTGRES
 | `order-manager.kafka.positions-updates-topic` | `positions.updates` | Outbound position events |
 | `order-manager.portfolio.initial-cash` | `1000000.00` | Starting cash balance |
 | `order-manager.mark-to-market.interval-ms` | `1000` | Mark-to-market frequency |
+| `order-manager.currency.default-currency` | `USD` | Fallback currency for symbols without an override |
+| `order-manager.currency.overrides` | `{}` | Per-symbol currency map for `/api/portfolio/currency-exposure` |
 
-Two `@ConfigurationProperties` records hold the domain-specific config:
+Three `@ConfigurationProperties` records hold the domain-specific config:
 
 - `KafkaConfig` (`order-manager.kafka.*`) — topic names only.
 - `PortfolioConfig` (`order-manager.portfolio.*`) — `initialCash`.
+- `CurrencyConfig` (`order-manager.currency.*`) — `defaultCurrency`, `known`, `overrides`.
 
-Both are injected by constructor into the services that need them.
+All are injected by constructor into the services that need them.
 
 ---
 

--- a/docs/services/strategy-engine.md
+++ b/docs/services/strategy-engine.md
@@ -2,20 +2,23 @@
 
 ## Overview
 
-The Strategy Engine is the Java 21 / Spring Boot 3 microservice that sits **between** the Market Data Gateway (upstream, via Kafka) and the Execution Engine (downstream, via Kafka). It is the brain that turns ticks into trading intent. Three jobs live here:
+The Strategy Engine is the Java 21 / Spring Boot 3 microservice that sits **between** the Market Data Gateway (upstream, via Kafka) and the Execution Engine (downstream, via Kafka). It is the brain that turns ticks into trading intent. Six jobs live here:
 
 1. **Run execution strategies** — VWAP, TWAP, Momentum, Implementation Shortfall, POV, Close — through a pluggable `TradingStrategy` interface and a `StrategyRegistry`. Each strategy decides whether the current tick warrants emitting an order, and the engine publishes the resulting `OrderSignal` to `strategy.signals` on Kafka.
 2. **Confirm or veto signals against the ML model** — the `MlSignalGate` calls the ML Signal Service over gRPC for every signal a strategy produces and applies the FR-12 / TDD §5.2.2 policy: high-confidence agreement confirms (and optionally scales) the trade, high-confidence contradiction suppresses it, low confidence is a pass-through.
 3. **Price two-way RFQ quotes** — the `RfqPricingEngine` builds an inventory-aware, volatility-adjusted, size-relative-to-ADV two-way quote on demand from the React UI, and on accept publishes an `OrderSignal` with `strategyName="RFQ"` so the same execution pipeline picks it up.
+4. **Price options** — the stateless `OptionPricingService` answers Black-Scholes-Merton fair value, Greeks, and implied-vol queries under `/api/options/**`. See [`../strategies/options-pricing.md`](../strategies/options-pricing.md).
+5. **Serve programmatic algo orders** — `AlgoOrderService` backs `POST/GET/DELETE /api/algo/orders`, binding a strategy and applying its parameters in one call and publishing lifecycle/signal events to `algo.progress`. See [`../strategies/algo-execution-api.md`](../strategies/algo-execution-api.md).
+6. **Gate ticks by trading hours** — `TradingHoursService` drops ticks for symbols whose resolved market (NYSE/NASDAQ, TSE, …) is closed at the tick's timestamp, so after-hours prints never pollute indicator state. See [`../strategies/multi-market-trading-hours.md`](../strategies/multi-market-trading-hours.md).
 
-The service has two HTTP interfaces and one Kafka consumer + producer pair:
+The service has two HTTP interfaces and one Kafka consumer + two producers:
 
 | Interface | Port | Protocol | Purpose |
 |---|---|---|---|
-| REST API | 8082 | HTTP/1.1 + JSON | `/api/strategies/**`, `/api/rfq/**` |
+| REST API | 8082 | HTTP/1.1 + JSON | `/api/strategies/**`, `/api/rfq/**`, `/api/options/**`, `/api/algo/**` |
 | Actuator | 8083 | HTTP/1.1 + JSON | `/actuator/health/{liveness,readiness}`, `/actuator/prometheus` |
 | Kafka consumer | — | — | `market-data.ticks` (group `strategy-engine`, earliest) |
-| Kafka producer | — | — | `strategy.signals` (key=symbol) |
+| Kafka producers | — | — | `strategy.signals` (key=symbol), `algo.progress` (key=algoOrderId) |
 | gRPC client | — | HTTP/2 | `SignalService.GetSignal(symbol)` on ML Signal Service :50051 |
 | HTTP client | — | HTTP/1.1 + JSON | `GET /api/positions/{symbol}` on Order Manager :8086 |
 
@@ -130,7 +133,7 @@ Note the two namespaces: bindings are keyed by **symbol** (`AAPL`), parameters a
 1. **Feed `MarketStateCache`** — every tick refreshes the per-symbol bid/ask/last/mid and pushes a new sample onto the rolling mid-price ring. This is what the RFQ engine and the volatility tracker read.
 2. **Hand off to `StrategyEvaluationService`** — drives the strategy-evaluation-then-ML-gate-then-publish pipeline.
 
-`StrategyEvaluationService.evaluate(tick)`:
+`StrategyEvaluationService.evaluate(tick)` first consults `TradingHoursService` — if the symbol's resolved market is closed at the tick's timestamp the tick is dropped (`mariaalpha_strategy_ticks_suppressed_total{reason="market_closed"}` increments) and the pipeline below never runs. See [`../strategies/multi-market-trading-hours.md`](../strategies/multi-market-trading-hours.md). For in-session ticks:
 
 ```java
 var strategy = router.getActiveStrategy(tick.symbol()).orElseThrow();
@@ -297,6 +300,10 @@ strategy-engine:
 | `POST /api/rfq/quote` `{"symbol","quantity"}` | Build a two-way quote. |
 | `POST /api/rfq/accept` `{"quoteId","side","price"}` | Accept a previously issued quote. Returns the published `OrderSignal`. |
 | `GET /api/rfq/quotes/{quoteId}` | Look up a previously issued quote (debug). |
+| `POST /api/options/price` / `greeks` / `implied-volatility` | Black-Scholes-Merton pricing, Greeks, IV solver — see [`../strategies/options-pricing.md`](../strategies/options-pricing.md). |
+| `POST /api/algo/orders` | Create + start a parent algo order in one call; returns a tracking UUID. |
+| `GET /api/algo/orders[/{id}]` | List / inspect algo orders. |
+| `DELETE /api/algo/orders/{id}` | Cancel an algo order (unbinds the strategy). See [`../strategies/algo-execution-api.md`](../strategies/algo-execution-api.md). |
 
 Status codes worth knowing for `/rfq`:
 
@@ -409,5 +416,6 @@ The umbrella chart at `charts/mariaalpha/` ships the strategy-engine as a single
 - **TDD:** [`technical-design-document.md`](../technical-design-document.md) — §3.2 (FR-7..12), §3.3 (FR-12 ML integration), §3.8 (FR-40 RFQ pricing), §5.2.2 (Strategy Engine), §5.3.1 (Strategy Registry), §5.4 (data model), §7 (resilience), §8.2 (metrics).
 - **Sibling explainers:** [`execution-engine.md`](execution-engine.md), [`ml-signal-service.md`](ml-signal-service.md), [`order-manager.md`](order-manager.md), [`api-gateway.md`](api-gateway.md).
 - **Per-strategy deep dives:** [`strategies/vwap.md`](../strategies/vwap.md), [`twap.md`](../strategies/twap.md), [`momentum.md`](../strategies/momentum.md), [`implementation-shortfall.md`](../strategies/implementation-shortfall.md), [`pov.md`](../strategies/pov.md), [`close.md`](../strategies/close.md), [`rfq-pricing.md`](../strategies/rfq-pricing.md).
+- **Feature deep dives:** [`options-pricing.md`](../strategies/options-pricing.md), [`algo-execution-api.md`](../strategies/algo-execution-api.md), [`multi-market-trading-hours.md`](../strategies/multi-market-trading-hours.md).
 - **Source root:** [strategy-engine/src/main/java/com/mariaalpha/strategyengine/](../../strategy-engine/src/main/java/com/mariaalpha/strategyengine/).
 - **Configuration:** [strategy-engine/src/main/resources/application.yml](../../strategy-engine/src/main/resources/application.yml).

--- a/docs/services/ui.md
+++ b/docs/services/ui.md
@@ -40,7 +40,7 @@ through the execution pipeline during development.
 
 | Story | Why it matters |
 |-------|----------------|
-| As a manual trader, I want to submit any of the seven supported order types (MARKET, LIMIT, STOP, IOC, FOK, GTC, ICEBERG) from the browser so that I can enter positions without using the API directly. | Direct REST calls require API key management and JSON construction; a form with validation is faster and safer for ad-hoc use. |
+| As a manual trader, I want to submit any of the eight supported order types (MARKET, LIMIT, STOP, IOC, FOK, GTC, ICEBERG, PEGGED) from the browser so that I can enter positions without using the API directly. | Direct REST calls require API key management and JSON construction; a form with validation is faster and safer for ad-hoc use. |
 | As a manual trader, I want client-side validation (symbol required, positive quantity, limit price required for LIMIT/IOC/FOK/GTC/ICEBERG, displayQuantity required and < quantity for ICEBERG) so that common mistakes are caught before the network round-trip. | Validation errors from the server surface as generic text; a specific field-level message is faster to act on. |
 | As a manual trader, I want the form to render the intrinsic time-in-force (IOC/FOK/GTC) and a `displayQuantity` input when ICEBERG is selected so that I don't need to guess which fields apply to which type. | Conditional fields prevent invalid submissions and make the type semantics visible without referring to the OpenAPI spec. |
 | As an operator, I want to see the iceberg slice progress for active ICEBERG parents (filled / total + percentage badge in the Active Orders table) so that I can tell at a glance how much of a sliced order has executed. | Iceberg parents have hidden state — only one child is on the wire at a time — so an explicit progress indicator is the only way to surface fill progress without drilling into individual children. |
@@ -125,12 +125,13 @@ Combines order submission with live order monitoring on one screen.
 - `DELETE /api/execution/orders/{id}` → cancel order (ICEBERG parent cancel cascades to the active child on the server side)
 - `GET /api/execution/orders/{parentId}/iceberg-progress` → live slice progress for an ICEBERG parent (polled at 1.5 s by `IcebergProgressBadge`; 404 once the parent is FILLED/CANCELLED)
 
-**OrderForm** is fully controlled. All seven order types are in the type dropdown. The conditional
+**OrderForm** is fully controlled. All eight order types are in the type dropdown. The conditional
 field set is:
 
-- **Limit Price** — rendered for LIMIT, IOC, FOK, GTC, ICEBERG
+- **Limit Price** — rendered for LIMIT, IOC, FOK, GTC, ICEBERG (and as the optional price cap for PEGGED)
 - **Stop Price** — rendered for STOP
 - **Display Quantity** — rendered for ICEBERG only (must be ≥ 1 and strictly < quantity)
+- **Peg Type / Peg Offset (bps)** — rendered for PEGGED only (MIDPOINT default; offset must be numeric)
 - **Intrinsic TIF hint** — a small grey label "Time-in-force: IOC/FOK/GTC (intrinsic to X)" shown for IOC/FOK/GTC, so the user doesn't have to guess what TIF the server will apply
 
 Client-side validation runs before any fetch (matching the server-side `@ValidSubmitOrderRequest`
@@ -165,9 +166,11 @@ a stable string key (`orderIds.sort().join(",")`) rather than comparing Map refe
 | `/` | Dashboard — live positions, portfolio P&L, exposure, fills history. |
 | `/orders` | Order Entry — submit manual orders, active-order blotter, recent fills. |
 | `/rfq` | Request-for-quote workflow: two-way pricing for block orders + acceptance flow. |
+| `/options` | Options pricing — Black-Scholes-Merton fair value, Greeks, and implied-vol solver forms against `/api/options/**`. |
 | `/strategies` | Strategy Control — enable/disable strategies per symbol, edit parameters, view regime classification. |
 | `/analytics` | TCA, PnL attribution (Kissell-Glantz components), flow toxicity, axe matcher visualisation. |
 | `/reconciliation` | End-of-day break review — internal vs. external fill comparison, severity breakdown. |
+| `/allocations` | Trade allocation — run PRO_RATA / FIFO allocation for a filled parent and review per-sub-account results. |
 | `/market-data` | Reserved placeholder — currently renders `<ComingSoon>`; intended for a live market tick viewer driven by `WS /ws/market-data`. |
 
 ---

--- a/docs/strategies/pegged-orders.md
+++ b/docs/strategies/pegged-orders.md
@@ -7,7 +7,7 @@
 
 A **pegged order** is an order whose working limit price is tied to a live market reference and re-prices itself when that reference moves. Pegging lets a trader express intent like *"sit at the midpoint"* or *"track the ask"* without manually cancelling and re-submitting on every NBBO tick — the execution engine does that for them.
 
-Pegged is the seventh order type to ship in MariaAlpha (after MARKET, LIMIT, STOP, IOC, FOK, GTC, and ICEBERG). Like ICEBERG, it does **not** map cleanly onto a single `OrderTypeHandler` instruction because the parent has to react to ongoing market events — so it follows the same handler+coordinator split: a thin `PeggedOrderHandler` validates the request and a `PeggedCoordinator` owns the runtime lifecycle.
+Pegged is the eighth order type to ship in MariaAlpha (after MARKET, LIMIT, STOP, IOC, FOK, GTC, and ICEBERG). Like ICEBERG, it does **not** map cleanly onto a single `OrderTypeHandler` instruction because the parent has to react to ongoing market events — so it follows the same handler+coordinator split: a thin `PeggedOrderHandler` validates the request and a `PeggedCoordinator` owns the runtime lifecycle.
 
 ## 2. Peg types
 

--- a/docs/strategies/rfq-pricing.md
+++ b/docs/strategies/rfq-pricing.md
@@ -214,7 +214,7 @@ The MVP intentionally stops here. Real desks layer more in:
 | Client tiering | Roadmap item 4.7.1. The accept endpoint already records the signal's source; once a client identity exists upstream the engine can multiply `baseSpreadBps` per client tier. | A per-client multiplier injected before step 3 of §2. |
 | Cross-asset / ETF arbitrage hedge | Out of scope for cash equities MVP. | A hedge stage between accept and publish that fans out additional `OrderSignal`s. |
 | Inventory aging | Long positions held overnight should skew further. | A timestamp on positions + a time-decay factor applied to `inventoryLambda`. |
-| Realised vs. implied vol | We don't subscribe to options data. | Roadmap derivatives work (issues 3.2.1–3.2.2). |
+| Realised vs. implied vol | We don't subscribe to live options-market data. The Black-Scholes pricer + IV solver shipped (see [`options-pricing.md`](options-pricing.md)), but a live implied-vol feed is still missing. | An IV input to `VolatilityTracker` replacing (or blending with) the realised-vol estimate. |
 
 ---
 

--- a/docs/strategies/vwap.md
+++ b/docs/strategies/vwap.md
@@ -144,7 +144,7 @@ MariaAlpha's VWAP strategy sits in the `strategy-engine` module and follows the 
 
 ### Data Flow
 
-1. **Tick ingestion** (1.3.3, future): Kafka consumer deserializes `MarketTick` JSON from `market-data.ticks` topic
+1. **Tick ingestion**: Kafka consumer deserializes `MarketTick` JSON from the `market-data.ticks` topic
 2. **Tick routing**: Each tick is passed to the active strategy for that symbol via `strategy.onTick(tick)`
 3. **Evaluation**: The strategy engine calls `strategy.evaluate(symbol)` after each tick
 4. **Signal emission**: If the VWAP algorithm determines it's time to trade (new time bin entered), it returns an `OrderSignal`

--- a/docs/technical-design-document.md
+++ b/docs/technical-design-document.md
@@ -314,6 +314,9 @@ sequenceDiagram
 | FR-10b | The system SHALL implement a Close execution algorithm that benchmarks against the closing-auction print: a configurable fraction of the parent is worked as equal-duration LIMIT slices through a pre-close window `[windowStart, mocCutoff)`, and the remainder fires as a single MARKET (Market-on-Close equivalent) child at `mocCutoff = closeTime − mocOffsetMinutes`. The algorithm SHALL handle the degenerate cases (zero pre-close fraction ⇒ pure MOC; full fraction ⇒ no MOC clip) and SHALL include a defensive post-close sweep for late-binding scenarios. |
 | FR-11 | The system SHALL allow runtime selection of the active strategy per symbol via the REST API and UI, without requiring a restart. |
 | FR-12 | The system SHALL consume real-time ML signals from the Signal Service via gRPC and incorporate them as an additional input to strategy decisions (e.g., adjusting urgency, confirming/vetoing signals). |
+| FR-12a | The system SHALL gate strategy evaluation by per-market trading-hours calendars (sessions, lunch breaks, holidays, weekends), dropping ticks for symbols whose resolved venue is closed at the tick's timestamp so closed-market prints never pollute indicator state. See [`strategies/multi-market-trading-hours.md`](strategies/multi-market-trading-hours.md). |
+| FR-12b | The system SHALL provide a stateless options-pricing module: Black-Scholes-Merton fair value, the five first-order Greeks, and an implied-volatility solver, exposed under `/api/options/{price,greeks,implied-volatility}`. See [`strategies/options-pricing.md`](strategies/options-pricing.md). |
+| FR-12c | The system SHALL provide a programmatic algo execution API: `POST /api/algo/orders` creates and starts a parent algo order in one call, returning a UUID that can be queried, listed, and cancelled over REST and followed in real time via the `/ws/algo` WebSocket (events fan out over the `algo.progress` Kafka topic). See [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md). |
 
 ### 3.3 ML Signal Service (Python)
 
@@ -333,9 +336,9 @@ sequenceDiagram
 | FR-19 | The Execution Engine SHALL accept order signals from the Strategy Engine and submit them to the configured exchange adapter (Alpaca or simulated). |
 | FR-20 | The system SHALL implement an Alpaca exchange adapter using Alpaca's REST API (`POST /v2/orders`) for order submission and the WebSocket trade updates stream for fill notifications. |
 | FR-21 | The system SHALL implement a simulated exchange adapter with a basic price-time priority matching engine that fills orders against the current market data, simulating realistic latency and partial fills. |
-| FR-22 | The Execution Engine SHALL support order types MARKET, LIMIT, STOP, IOC, FOK, GTC, and Iceberg. Order type handling SHALL be implemented via an `OrderTypeHandler` interface with a registry, so that additional types (e.g. Pegged) can be added by implementing the interface and registering the handler — without modifying existing order processing logic. Iceberg is implemented via a dedicated `IcebergCoordinator` (sibling of the handler registry) that slices a parent into LIMIT children, rather than as a stateless handler. |
+| FR-22 | The Execution Engine SHALL support order types MARKET, LIMIT, STOP, IOC, FOK, GTC, Iceberg, and Pegged. Order type handling SHALL be implemented via an `OrderTypeHandler` interface with a registry, so that additional types can be added by implementing the interface and registering the handler — without modifying existing order processing logic. Iceberg and Pegged are implemented via dedicated coordinators (`IcebergCoordinator`, `PeggedCoordinator` — siblings of the handler registry) that manage parent state and emit LIMIT children, rather than as stateless handlers. |
 | FR-23 | The Execution Engine SHALL maintain the full order lifecycle state machine: NEW → SUBMITTED → PARTIALLY_FILLED → FILLED / CANCELLED / REJECTED, with all state transitions published to the `orders.lifecycle` Kafka topic. |
-| FR-24 | The Execution Engine SHALL enforce pre-trade risk checks before submitting any order via a composable `RiskCheck` chain. MVP checks include: maximum order notional value, maximum position size per symbol, and maximum total portfolio exposure. The chain is configured via `config/risk-limits.yml` and designed so that additional checks (sector exposure limits, beta limits, intraday VaR, ADV-relative sizing) can be added by implementing the `RiskCheck` interface and appending to the chain — without modifying existing checks. |
+| FR-24 | The Execution Engine SHALL enforce pre-trade risk checks before submitting any order via a composable `RiskCheck` chain, configured via `config/risk-limits.yml` and designed so that additional checks can be added by implementing the `RiskCheck` interface and appending to the chain — without modifying existing checks. Ten checks ship today: max order notional, max position per symbol, max portfolio exposure, max open orders, daily loss limit, sector exposure, beta exposure, ADV participation, [intraday VaR](strategies/intraday-var.md), and [correlated-position clusters](strategies/correlated-positions.md). |
 
 ### 3.5 Order Manager and Position Tracking
 
@@ -345,6 +348,7 @@ sequenceDiagram
 | FR-26 | The system SHALL maintain a real-time position book that updates on every fill event, tracking per-symbol: net quantity, average entry price, realized P&L, and unrealized P&L (mark-to-market against latest tick). |
 | FR-27 | The system SHALL compute portfolio-level aggregates in real time: total P&L, total exposure (gross and net), number of open positions, and cash balance. |
 | FR-28 | The system SHALL publish position and P&L updates to the `positions.updates` Kafka topic for consumption by the UI and analytics services. |
+| FR-28a | The system SHALL expose a read-side per-currency exposure aggregation (`GET /api/portfolio/currency-exposure`) that groups open-position exposure and realized/unrealized P&L by ISO-4217 currency, using per-symbol currency overrides with a configurable default. See [`strategies/currency-exposure.md`](strategies/currency-exposure.md). |
 
 ### 3.6 Post-Trade and Reconciliation
 
@@ -354,6 +358,7 @@ sequenceDiagram
 | FR-30 | The reconciliation process SHALL flag discrepancies (missing fills, price mismatches, quantity mismatches) and persist them to a `reconciliation_breaks` table in PostgreSQL. |
 | FR-31 | The system SHALL compute transaction cost analysis (TCA) for every completed order, measuring: slippage (fill price vs. arrival price), implementation shortfall, VWAP benchmark comparison, and spread cost. |
 | FR-32 | TCA results SHALL be published to the `analytics.tca` Kafka topic and persisted to PostgreSQL for historical analysis. |
+| FR-32a | The Post-Trade Service SHALL allocate filled parent orders across a configured roster of sub-accounts via `PRO_RATA` or `FIFO` algorithms, with `Σ allocations == parent_quantity` guaranteed, idempotent re-runs per order, and results persisted to the `allocations` table. See [`strategies/trade-allocation.md`](strategies/trade-allocation.md). |
 
 ### 3.7 Analytics Service (Python)
 
@@ -550,6 +555,10 @@ public interface TradingStrategy {
 
 **Options pricing module (roadmap 3.2.1 / 3.2.2 — delivered):** Black-Scholes-Merton fair value plus the five first-order Greeks (Δ, Γ, vega, θ, ρ) for a European option on a single underlying with a continuous dividend yield. Exposed under `/api/options/{price,greeks,implied-volatility}`; the implied-volatility endpoint inverts a market premium back to σ via Newton-Raphson with a bisection fallback. The module is stateless, lives alongside the equity strategies in `strategy-engine`, and does **not** implement `TradingStrategy` (it answers "what is this contract worth right now?", not "how do I work a parent over time?"). Full design is in [`strategies/options-pricing.md`](strategies/options-pricing.md).
 
+**Multi-market trading hours (roadmap 3.1.3 — delivered):** `TradingHoursService` sits in `StrategyEvaluationService` between the Kafka consumer and the strategy chain and drops ticks for symbols whose resolved market is closed at the tick's timestamp — sessions, lunch breaks (TSE), holidays, and weekends are all modelled per market under `strategy-engine.trading-hours`. Suppressed ticks increment `mariaalpha_strategy_ticks_suppressed_total{reason="market_closed"}`. Full design in [`strategies/multi-market-trading-hours.md`](strategies/multi-market-trading-hours.md).
+
+**Algo execution API (roadmap 3.4.4 / 3.4.5 — delivered):** `AlgoOrderService` + `AlgoOrderRegistry` provide the programmatic surface behind `POST/GET/DELETE /api/algo/orders` — one POST binds the strategy and applies its parameters in a single shot, returning a UUID. Lifecycle and signal events publish to the `algo.progress` Kafka topic, which the API Gateway fans out over the `/ws/algo` WebSocket. Full design in [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md).
+
 #### 5.2.3 ML Signal Service
 
 | Property | Value |
@@ -633,6 +642,8 @@ public interface ExchangeAdapter {
 
 **Position Calculation:** On every fill: (1) adjust quantity and weighted avg entry price, (2) compute realized P&L on position-reducing fills, (3) mark-to-market open positions against latest tick, (4) publish updated snapshot to `positions.updates` (Kafka, authoritative async path) and to the **Redis position cache** (key `mariaalpha:position:<symbol>` with a 24 h TTL, plus a pub/sub event on `mariaalpha.positions.updates` so subscribers can refresh without polling). Redis is a pure cache — PostgreSQL remains the system of record and Kafka is the durable event log; cache failures degrade gracefully (warn + continue) so a Redis outage never blocks fill processing.
 
+**Currency exposure tracking (roadmap 3.5.3 — delivered):** `CurrencyExposureService` provides a read-side aggregation over the position book — gross/net exposure and realized/unrealized P&L grouped by ISO-4217 currency, resolved via per-symbol `overrides` with a `default-currency` fallback. Exposed at `GET /api/portfolio/currency-exposure`. The simulator universe is USD-only so the live response has a single row by default; the mapping is pre-wired for the multi-currency symbols a Phase 3 IBKR/TSE rollout would add. Full design in [`strategies/currency-exposure.md`](strategies/currency-exposure.md).
+
 #### 5.2.6 Post-Trade and Reconciliation Engine
 
 | Property | Value |
@@ -670,9 +681,9 @@ Exposed Prometheus metrics: `mariaalpha_analytics_toxicity_markout_bps`, `mariaa
 | --- | --- |
 | **Language** | Java 21 |
 | **Framework** | Spring Cloud Gateway (reactive) |
-| **Role** | Unified REST + WebSocket entry point for the React UI, programmatic consumers, and (roadmap) external electronic trading clients via REST API + FIX gateway |
+| **Role** | Unified REST + WebSocket entry point for the React UI, programmatic consumers, and external algo clients (REST + WebSocket today; FIX gateway on the roadmap) |
 
-Routes: `/api/market-data/**`, `/api/strategies/**`, `/api/orders/**`, `/api/analytics/**`, `/api/recon/**`, `/api/routing/**`. WebSocket endpoints: `/ws/market-data`, `/ws/positions`, `/ws/orders`, `/ws/alerts`.
+Routes: `/api/market-data/**`, `/api/strategies/**`, `/api/rfq/**`, `/api/options/**`, `/api/algo/**`, `/api/orders/**`, `/api/positions/**`, `/api/portfolio/**`, `/api/execution/**`, `/api/routing/**`, `/api/analytics/**`, `/api/tca/**`, `/api/recon/**`, `/api/allocations/**`. WebSocket endpoints: `/ws/market-data`, `/ws/positions`, `/ws/orders`, `/ws/alerts`, `/ws/algo`.
 
 #### 5.2.9 React UI
 
@@ -682,7 +693,7 @@ Routes: `/api/market-data/**`, `/api/strategies/**`, `/api/orders/**`, `/api/ana
 | **Framework** | React 18 with Vite, TailwindCSS, Recharts |
 | **Role** | SPA for live risk monitoring, order management, RFQ pricing, and analytics |
 
-Pages: Dashboard, Market Data, Order Entry, RFQ, Strategy Control, Analytics, Reconciliation.
+Pages: Dashboard, Market Data (placeholder), Order Entry, RFQ, Options, Strategy Control, Analytics, Reconciliation, Allocations.
 
 ### 5.3 Extensibility Architecture
 
@@ -829,7 +840,7 @@ routed child order to the right adapter — the simulated profile ships a LIT ve
 `ALPACA`), a simulated dark venue, and an internal venue backed by the real midpoint crossing
 engine described below. ML-based adaptive scoring is on the roadmap (issue 4.8.1).
 
-#### 5.3.7 Internal Crossing Engine
+#### 5.3.6 Internal Crossing Engine
 
 `InternalCrossingEngine` is the in-process matching engine behind the `INTERNAL_CROSS` venue. It
 maintains a per-symbol, side-keyed FIFO book of resting orders and crosses offsetting BUY/SELL
@@ -867,23 +878,23 @@ The adapter dispatches `ExecutionReport` callbacks **asynchronously** through it
 `OrderExecutionService.processOrder` time to transition both orders to `SUBMITTED` before the
 `FILLED` events arrive.
 
-#### 5.3.6 Electronic Trading API (Roadmap)
+#### 5.3.7 Electronic Trading API
 
-The architecture decouples **inbound order channels** from the **execution pipeline**. In the MVP, orders originate exclusively from the React UI via the API Gateway. The same Strategy Engine → Risk Check Chain → SOR → Exchange Adapter pipeline processes all orders regardless of origin. This means adding new inbound channels requires **no changes to the execution pipeline** — only a new entry point that produces `OrderSignal` objects:
+The architecture decouples **inbound order channels** from the **execution pipeline**. The same Strategy Engine → Risk Check Chain → SOR → Exchange Adapter pipeline processes all orders regardless of origin, so adding a new inbound channel requires **no changes to the execution pipeline** — only a new entry point that produces `OrderSignal` objects:
 
 ```mermaid
 graph TB
     subgraph "Inbound Channels"
         UI[React UI] -->|REST/WS| GW[API Gateway]
+        REST[Algo Execution<br/>REST API + /ws/algo] -->|OpenAPI| GW
         FIX[FIX Gateway<br/>roadmap] -->|QuickFIX/J| GW
-        REST[Electronic Trading<br/>REST API<br/>roadmap] -->|OpenAPI| GW
     end
 
     GW --> SE[Strategy Engine<br/>+ Risk Checks<br/>+ SOR]
     SE --> EE[Exchange<br/>Adapter]
 ```
 
-The Electronic Trading REST API (roadmap items 3.4.4 / 3.4.5) would expose endpoints for programmatic algo execution: `POST /api/v1/algo/vwap`, `POST /api/v1/algo/twap`, `POST /api/v1/algo/is`, etc. — each accepting order parameters and returning a tracking ID for monitoring execution progress via WebSocket. The FIX gateway (roadmap item 3.4.3) would accept standard FIX 4.4 NewOrderSingle messages and route them through the same pipeline.
+The Electronic Trading REST API (roadmap items 3.4.4 / 3.4.5 — **delivered**) exposes programmatic algo execution as a single strategy-agnostic surface: `POST /api/algo/orders` accepts `{symbol, side, targetQuantity, strategyName, parameters}` and returns a tracking UUID; GET/DELETE manage the order's lifecycle; progress events flow over the `algo.progress` Kafka topic to the `/ws/algo` WebSocket (see §2.6.4 for the end-to-end sequence and [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md) for the full design). The FIX gateway (roadmap item 3.4.3) would accept standard FIX 4.4 NewOrderSingle messages and route them through the same pipeline.
 
 #### 5.3.8 Distributed Position Cache
 
@@ -1024,11 +1035,13 @@ All topics start with **1 partition** and **minimal retention** in the MVP. Part
 | Topic | Key | Value Schema | Initial Partitions | Initial Retention |
 | --- | --- | --- | --- | --- |
 | `market-data.ticks` | symbol | MarketTick JSON | 1 | 4 hours |
+| `strategy.signals` | symbol | OrderSignal JSON | 1 | 3 days |
 | `orders.lifecycle` | orderId | OrderEvent JSON | 1 | 3 days |
 | `positions.updates` | symbol | PositionSnapshot JSON | 1 | 3 days |
 | `analytics.tca` | orderId | TCA result JSON | 1 | 3 days |
 | `analytics.risk-alerts` | symbol | RiskAlert JSON | 1 | 3 days |
 | `routing.decisions` | orderId | SOR routing decision JSON | 1 | 3 days |
+| `algo.progress` | algoOrderId | AlgoProgressEvent JSON | 1 | 3 days |
 | `orders.dlq` | orderId | Error + original order JSON | 1 | 30 days |
 
 > **Rationale for non-zero retention:** Even in the MVP, consumers that crash and restart need to replay unprocessed messages from their last committed offset. Zero retention would cause data loss on restart. Market data ticks are high-volume with short-lived value (4 hours). Order/position topics are lower-volume with audit value (3 days). DLQ retains longer for manual inspection.
@@ -1445,13 +1458,15 @@ manual smoke runbook today.
 Broker integration with Interactive Brokers, options pricing, Japanese-market microstructure rules,
 and program/basket trading. These extend MariaAlpha beyond a single broker (Alpaca, US equities)
 into multi-asset, multi-region territory. **Deliberately deferred behind Phase 5** — there is no
-benefit to extending the asset-class surface before the existing one is validated.
+benefit to extending the asset-class surface before the existing one is validated. A number of
+3.x items were pulled forward and have already shipped (marked **delivered** below, each with a
+deep-dive under `docs/strategies/`); the remaining rows are open backlog.
 
 | # | Issue Title | Component |
 | --- | --- | --- |
 | [3.1.1](https://github.com/drag0sd0g/MariaAlpha/issues/87) | Implement IBKR `MarketDataAdapter` (TWS API) | Market Data GW |
 | [3.1.2](https://github.com/drag0sd0g/MariaAlpha/issues/88) | Implement IBKR `ExchangeAdapter` (TWS API) | Execution Engine |
-| [3.1.3](https://github.com/drag0sd0g/MariaAlpha/issues/89) | Implement multi-market trading hours support | Strategy Engine |
+| [3.1.3](https://github.com/drag0sd0g/MariaAlpha/issues/89) | Implement multi-market trading hours support — **delivered**, see [`strategies/multi-market-trading-hours.md`](strategies/multi-market-trading-hours.md) | Strategy Engine |
 | [3.2.1](https://github.com/drag0sd0g/MariaAlpha/issues/90) | Implement options pricing model (Black-Scholes) — **delivered**, see [`strategies/options-pricing.md`](strategies/options-pricing.md) | Strategy Engine |
 | [3.2.2](https://github.com/drag0sd0g/MariaAlpha/issues/91) | Implement Greeks computation (delta, gamma, vega, theta) — **delivered**, see [`strategies/options-pricing.md`](strategies/options-pricing.md) | Strategy Engine |
 | [3.2.3](https://github.com/drag0sd0g/MariaAlpha/issues/92) | Implement Pegged order type handler — **delivered**, see [`strategies/pegged-orders.md`](strategies/pegged-orders.md) | Execution Engine |
@@ -1462,11 +1477,11 @@ benefit to extending the asset-class surface before the existing one is validate
 | [3.4.1](https://github.com/drag0sd0g/MariaAlpha/issues/97) | Implement program / basket trading engine | Execution Engine |
 | [3.4.2](https://github.com/drag0sd0g/MariaAlpha/issues/98) | Implement trade allocation — **delivered**, see [`strategies/trade-allocation.md`](strategies/trade-allocation.md) | Post-Trade |
 | [3.4.3](https://github.com/drag0sd0g/MariaAlpha/issues/99) | Implement FIX protocol gateway (QuickFIX/J) for inbound algo orders | API Gateway |
-| [3.4.4](https://github.com/drag0sd0g/MariaAlpha/issues/100) | Implement Electronic Trading REST API for programmatic algo execution | API Gateway |
-| [3.4.5](https://github.com/drag0sd0g/MariaAlpha/issues/119) | Implement algo execution tracking and progress reporting via WebSocket | API Gateway |
+| [3.4.4](https://github.com/drag0sd0g/MariaAlpha/issues/100) | Implement Electronic Trading REST API for programmatic algo execution — **delivered**, see [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md) | API Gateway |
+| [3.4.5](https://github.com/drag0sd0g/MariaAlpha/issues/119) | Implement algo execution tracking and progress reporting via WebSocket — **delivered**, see [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md) | API Gateway |
 | [3.5.1](https://github.com/drag0sd0g/MariaAlpha/issues/101) | Implement intraday VaR risk check — **delivered**, see [`strategies/intraday-var.md`](strategies/intraday-var.md) | Execution Engine |
 | [3.5.2](https://github.com/drag0sd0g/MariaAlpha/issues/102) | Implement correlated position limits — **delivered**, see [`strategies/correlated-positions.md`](strategies/correlated-positions.md) | Execution Engine |
-| [3.5.3](https://github.com/drag0sd0g/MariaAlpha/issues/103) | Implement currency exposure tracking | Order Manager |
+| [3.5.3](https://github.com/drag0sd0g/MariaAlpha/issues/103) | Implement currency exposure tracking — **delivered**, see [`strategies/currency-exposure.md`](strategies/currency-exposure.md) | Order Manager |
 
 ### Phase 4: Advanced Platform Features (post-validation)
 

--- a/ml-signal-service/README.md
+++ b/ml-signal-service/README.md
@@ -161,7 +161,7 @@ cd ml-signal-service
 pytest tests/ -v
 ```
 
-All 40 tests cover: indicators (numerical correctness), feature engine (tick aggregation, bar building, feature computation), signal model (inference, thresholds, hot-reload), gRPC servicer (GetSignal, GetRegime, StreamSignals), and FastAPI endpoints (health, ready, metrics, reload).
+The test suite covers: indicators (numerical correctness), feature engine (tick aggregation, bar building, feature computation), signal model (inference, thresholds, hot-reload), gRPC servicer (GetSignal, GetRegime, StreamSignals), and FastAPI endpoints (health, ready, metrics, reload).
 
 ## Docker
 


### PR DESCRIPTION
 - docs/README.md (index) — the strategies table listed only 7 of 15 docs. Added the 8 missing entries (options pricing, pegged orders, intraday VaR, correlated positions, currency exposure, trade allocation,
  algo execution API, multi-market trading hours), organized into Execution strategies / Pricing engines / Risk checks / Order handling sections, and refreshed the service-role blurbs with cross-links.
  - Root README.md — "Eight pre-trade risk checks" → ten, "Seven order types" → eight (PEGGED), added bullets for options pricing, trading hours, trade allocation, and the algo execution API; added an
  algo-order curl example and the currency-exposure read to the Quickstart; removed options/Greeks from the "not yet built" roadmap line; UI page list now includes Options and Allocations; noted the Helm stack
  excludes analytics-service.
  - Technical Design Document — added FR rows for the six delivered features (FR-12a–c, FR-28a, FR-32a), rewrote FR-22/FR-24 to reflect shipped state, marked roadmap items 3.1.3, 3.4.4, 3.4.5, 3.5.3 as
  delivered (3.2.x/3.4.2/3.5.1/3.5.2 already were), fixed the §5.3.6/§5.3.7 ordering and rewrote the Electronic Trading API section as delivered, added strategy.signals and algo.progress to the Kafka topics
  table, and added trading-hours/algo/currency-exposure paragraphs to the service descriptions.
  - Service docs — execution-engine.md (PEGGED handler + coordinator dispatch, checks 9–10, enum comparison), strategy-engine.md (six jobs instead of three, trading-hours gate in the tick pipeline,
  options/algo REST endpoints), order-manager.md (currency-exposure endpoint + CurrencyConfig), api-gateway.md (route maps, fifth Kafka listener, /ws/algo), ui.md (eight order types, pegged form fields,
  Options/Allocations screens).
  - Genuine errors caught: pegged-orders.md called PEGGED "the seventh order type" while listing seven predecessors; the chart README said 9 external Helm deps (Chart.yaml declares 10); the ml-signal README
  claimed 40 tests (there are 69 — replaced the count with a description); vwap.md marked tick ingestion as "future"; rfq-pricing.md pointed to options work as roadmap.
  - Documented gaps honestly: the Bruno collection doesn't yet cover /api/algo/** or currency-exposure (noted in its README), and analytics-service has no Helm subchart so /api/analytics/** fails on Kubernetes
  (noted in both the chart README and root README).