### PR TITLE
3.4.1 — Program Trading / 3.4.3 — FIX Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ MariaAlpha is a working, end-to-end algorithmic trading engine:
 - **Smart Order Router** with scored multi-criteria venue selection across LIT, DARK, and INTERNAL venues, plus an in-process **internal crossing engine** that matches offsetting BUY/SELL interest at the NBBO midpoint.
 - **Eight order types** — MARKET, LIMIT, STOP, IOC, FOK, GTC, Iceberg (with a dedicated coordinator that slices parents into LIMIT children), and [Pegged](docs/strategies/pegged-orders.md) (midpoint/primary/market peg that re-prices its working child as the NBBO moves).
 - **Dual exchange routing** — simulated exchange (configurable fill latency + slippage) or Alpaca paper trading (REST + `trade_updates` WebSocket with reconnect), switchable via `EXECUTION_PROFILE`.
+- **Program/basket trading** — submit a multi-leg [basket](docs/strategies/program-basket-trading.md) in one call (`POST /api/execution/baskets`); every leg is fanned out through the full risk → SOR → venue pipeline and tracked as one aggregate with per-leg status.
+- **Inbound FIX gateway** — optional QuickFIX/J [FIX 4.4 acceptor](docs/strategies/fix-gateway.md) for programmatic order entry (`NewOrderSingle` / `OrderCancelRequest` → `ExecutionReport`), the protocol sibling of the REST order-entry path; disabled by default.
 - **Real-time position and P&L tracking** — mark-to-market unrealized P&L, portfolio aggregates, [per-currency exposure](docs/strategies/currency-exposure.md), fill history persisted in PostgreSQL with a Redis hot-path cache for sub-millisecond pre-trade reads.
 - **Transaction Cost Analysis + PnL attribution + flow toxicity + axe matching** — slippage, implementation shortfall, VWAP benchmark, spread cost per order; Kissell-Glantz five-component PnL decomposition; per-counterparty markout-based toxicity; client-interest axe matcher.
 - **Trade allocation** — post-trade splitting of filled parents across sub-accounts (pro-rata with remainder handling, or FIFO waterfall), persisted as the per-account book of record.
@@ -28,7 +30,7 @@ MariaAlpha is a working, end-to-end algorithmic trading engine:
 
 The end-to-end acceptance suite under `e2e-tests/` boots the full Docker Compose stack and traverses the complete Tick-to-Trade pipeline on every CI run.
 
-See [§11 of the Technical Design Document](docs/technical-design-document.md#11-roadmap) for the roadmap of additional capabilities not yet built (backtesting, multi-broker integration via IBKR, Tokyo Stock Exchange microstructure, program/basket trading, FIX gateway, OAuth/RBAC, ML-driven SOR, and others).
+See [§11 of the Technical Design Document](docs/technical-design-document.md#11-roadmap) for the roadmap of additional capabilities not yet built (backtesting, multi-broker integration via IBKR, Tokyo Stock Exchange microstructure, OAuth/RBAC, ML-driven SOR, and others).
 
 ## Prerequisites
 

--- a/analytics-service/src/analytics/__main__.py
+++ b/analytics-service/src/analytics/__main__.py
@@ -64,7 +64,6 @@ def main() -> None:
     orders_consumer = OrdersConsumer(settings, matcher)
     threading.Thread(target=orders_consumer.run, name="orders-consumer", daemon=True).start()
 
-    # Periodic tick of the toxicity detector so horizon-based markouts are evaluated.
     def _toxicity_loop() -> None:
         while True:
             try:

--- a/analytics-service/src/analytics/api/app.py
+++ b/analytics-service/src/analytics/api/app.py
@@ -45,7 +45,6 @@ def create_app(
         docs_url="/openapi.json",
     )
 
-    # --- platform endpoints ---------------------------------------------
 
     @app.get("/health")
     def health() -> dict[str, str]:
@@ -53,8 +52,6 @@ def create_app(
 
     @app.get("/actuator/health")
     def actuator_health() -> dict[str, str]:
-        # Mimic Spring Boot Actuator so the API Gateway's AggregateDownstreamHealthIndicator —
-        # which pings every downstream's ``/actuator/health`` — gets a recognised 200.
         return {"status": "UP"}
 
     @app.get("/ready")
@@ -72,7 +69,6 @@ def create_app(
             AXES_ACTIVE.labels(symbol=str(row["symbol"]), side=str(row["side"])).set(1)
         return generate_latest()
 
-    # --- 2.2.4 flow toxicity --------------------------------------------
 
     @app.get("/v1/analytics/flow/toxicity")
     def get_flow_toxicity(strategy: str | None = None) -> dict[str, Any]:
@@ -82,7 +78,6 @@ def create_app(
             "horizonsSeconds": list(settings.toxicity_horizons_seconds),
         }
 
-    # --- 2.2.5 PnL attribution ------------------------------------------
 
     @app.get("/v1/analytics/pnl/attribution")
     def get_pnl_attribution(strategy: str | None = None) -> dict[str, Any]:
@@ -101,7 +96,6 @@ def create_app(
     def get_strategy_distribution(strategy: str) -> dict[str, Any]:
         return attribution.strategy_distribution(strategy)
 
-    # --- 2.2.6 axe matching ---------------------------------------------
 
     @app.post("/v1/analytics/axes", status_code=201)
     def publish_axe(req: AxePublishRequest) -> dict[str, Any]:

--- a/analytics-service/src/analytics/axes/matcher.py
+++ b/analytics-service/src/analytics/axes/matcher.py
@@ -42,7 +42,7 @@ class Axe:
     axe_id: str
     client_id: str
     symbol: str
-    side: str  # "BUY" or "SELL"
+    side: str
     quantity: int
     remaining: int
     limit_price: float | None
@@ -73,7 +73,7 @@ class IncomingLeg:
 
     order_id: str
     symbol: str
-    side: str  # "BUY" or "SELL"
+    side: str
     quantity: int
 
 
@@ -94,13 +94,10 @@ class AxeMatcher:
             clock = time.time
         self._clock = clock
         self._lock = threading.RLock()
-        # Keyed by axe_id so the matcher is robust to multiple axes per client/symbol.
         self._axes: dict[str, Axe] = {}
-        # Refresh index keyed by (client_id, symbol, side) → axe_id for fast refresh lookup.
         self._refresh_index: dict[tuple[str, str, str], str] = {}
         self._matched_total = 0
 
-    # -- writers ----------------------------------------------------------
 
     def publish(
         self,
@@ -124,8 +121,6 @@ class AxeMatcher:
             existing_id = self._refresh_index.get(key)
             if existing_id is not None and existing_id in self._axes:
                 axe = self._axes[existing_id]
-                # Refresh: keep the existing axe_id alive, bump quantity to max, reset TTL,
-                # boost confidence back to 1.0.
                 axe.quantity = max(axe.quantity, quantity)
                 axe.remaining = max(axe.remaining, quantity)
                 axe.limit_price = limit_price
@@ -159,7 +154,6 @@ class AxeMatcher:
             self._refresh_index.pop((axe.client_id, axe.symbol, axe.side), None)
             return True
 
-    # -- matching ---------------------------------------------------------
 
     def match(self, leg: IncomingLeg) -> list[MatchSuggestion]:
         """Return ranked match suggestions for an incoming order leg.
@@ -180,14 +174,10 @@ class AxeMatcher:
                 for a in self._axes.values()
                 if a.symbol == leg.symbol and a.side == opposing_side and a.remaining > 0
             ]
-            # Refresh-decay confidence so older axes score lower at match time.
             for axe in candidates:
                 ttl_remaining = max(0.0, axe.expires_at - now)
                 ttl_total = max(1.0, axe.expires_at - axe.published_at)
                 axe.confidence = max(0.0, min(1.0, ttl_remaining / ttl_total))
-            # Rank by the spec product (confidence × remaining). Tie-breakers:
-            # more refreshes (proves it's actively maintained) then older
-            # published_at (FIFO among equally-scored axes).
             candidates.sort(
                 key=lambda a: (
                     -(a.confidence * a.remaining),
@@ -206,8 +196,6 @@ class AxeMatcher:
                 axe.remaining -= take
                 remaining_to_match -= take
                 self._matched_total += take
-                # Spec score = confidence × axe-remaining-before-this-match.
-                # Reported on the suggestion so the UI can sort/group identically.
                 score = axe.confidence * axe_remaining_before
                 suggestions.append(
                     MatchSuggestion(
@@ -223,12 +211,10 @@ class AxeMatcher:
                     )
                 )
                 if axe.remaining == 0:
-                    # Fully consumed — drop the axe and its refresh-index entry.
                     self._axes.pop(axe.axe_id, None)
                     self._refresh_index.pop((axe.client_id, axe.symbol, axe.side), None)
         return suggestions
 
-    # -- read-only --------------------------------------------------------
 
     def snapshot(
         self, symbol: str | None = None, side: str | None = None
@@ -270,7 +256,6 @@ class AxeMatcher:
                 "matchedTotalShares": self._matched_total,
             }
 
-    # -- internals --------------------------------------------------------
 
     def _expire_locked(self, now: float) -> None:
         expired = [a.axe_id for a in self._axes.values() if a.expires_at <= now]

--- a/analytics-service/src/analytics/config.py
+++ b/analytics-service/src/analytics/config.py
@@ -6,7 +6,6 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Loaded from environment variables prefixed with ``ANALYTICS_``."""
 
-    # Kafka
     kafka_bootstrap_servers: str = "localhost:9092"
     kafka_tca_topic: str = "analytics.tca"
     kafka_market_data_topic: str = "market-data.ticks"
@@ -14,19 +13,14 @@ class Settings(BaseSettings):
     kafka_risk_alerts_topic: str = "analytics.risk-alerts"
     kafka_consumer_group: str = "analytics-service"
 
-    # FastAPI
     api_port: int = 8095
 
-    # Toxicity detector — markout horizons in seconds and the toxicity threshold
-    # (negative markout above this magnitude in bps trips a risk alert).
     toxicity_horizons_seconds: tuple[int, ...] = (60, 300, 1800)
     toxicity_threshold_bps: float = 5.0
     toxicity_min_observations: int = 10
 
-    # PnL attribution — commission / hedging assumption (bps of notional).
     commission_bps: float = 0.5
 
-    # Axe matching — TTL for axes before they age out.
     axe_default_ttl_minutes: int = 60
     axe_match_min_quantity: int = 100
 

--- a/analytics-service/src/analytics/consumer/market_data.py
+++ b/analytics-service/src/analytics/consumer/market_data.py
@@ -22,15 +22,12 @@ class MarketDataCache:
     def __init__(self, max_history_per_symbol: int = 4096) -> None:
         self._max = max_history_per_symbol
         self._lock = threading.RLock()
-        # symbol → sorted list of (epoch_seconds, price)
         self._history: dict[str, list[tuple[float, float]]] = {}
 
     def record(self, symbol: str, ts_seconds: float, price: float) -> None:
         with self._lock:
             history = self._history.setdefault(symbol, [])
-            # Most ticks arrive in order; guard against minor reordering.
             if history and ts_seconds < history[-1][0]:
-                # Insert via binary search to keep the list ordered.
                 import bisect
 
                 idx = bisect.bisect_left(history, (ts_seconds, price))
@@ -38,7 +35,6 @@ class MarketDataCache:
             else:
                 history.append((ts_seconds, price))
             if len(history) > self._max:
-                # Drop the oldest 25 % to amortise the trim cost.
                 trim = self._max // 4
                 self._history[symbol] = history[trim:]
 
@@ -57,7 +53,6 @@ class MarketDataCache:
             history = self._history.get(symbol)
             if not history:
                 return None
-            # Binary search for the rightmost entry with ts ≤ requested.
             import bisect
 
             idx = bisect.bisect_right(history, (ts_seconds, float("inf"))) - 1
@@ -103,10 +98,8 @@ class MarketDataConsumer:
                 price = tick.get("price")
                 symbol = tick.get("symbol")
                 ts = tick.get("timestamp")
-                # QUOTE ticks carry price=0 — only positive trade prices belong in the cache.
                 if price is None or symbol is None or float(price) <= 0:
                     continue
-                # ts is ISO-8601; for ts-keyed lookups we use epoch seconds.
                 ts_seconds = _iso_to_epoch(ts) if isinstance(ts, str) else time.time()
                 self._cache.record(symbol, ts_seconds, float(price))
             except Exception:
@@ -121,7 +114,6 @@ def _iso_to_epoch(iso: str) -> float:
     from datetime import datetime
 
     try:
-        # market-data-gateway emits ISO-8601 with optional 'Z' or offset.
         if iso.endswith("Z"):
             iso = iso[:-1] + "+00:00"
         return datetime.fromisoformat(iso).timestamp()

--- a/analytics-service/src/analytics/consumer/orders_consumer.py
+++ b/analytics-service/src/analytics/consumer/orders_consumer.py
@@ -33,7 +33,6 @@ class OrdersConsumer:
         self._topic = settings.kafka_orders_lifecycle_topic
         self._matcher = matcher
         self._running = True
-        # Last-seen match suggestions for a given order_id, surfaced via REST.
         self._last_matches: dict[str, list[dict[str, object]]] = {}
 
     def run(self) -> None:

--- a/analytics-service/src/analytics/metrics.py
+++ b/analytics-service/src/analytics/metrics.py
@@ -2,9 +2,6 @@
 
 from prometheus_client import Counter, Gauge, Summary
 
-# 2.2.4 — flow toxicity.
-# Summary (not Histogram) because markouts are signed and prometheus_client 0.22 suppresses `_sum`
-# on Histograms whose buckets straddle zero — the Grafana mean-markout panel needs `_sum/_count`.
 TOXICITY_MARKOUT_BPS = Summary(
     "mariaalpha_analytics_toxicity_markout_bps",
     "Post-fill markout in bps, signed so positive = adverse selection",
@@ -16,15 +13,12 @@ TOXICITY_ALERTS = Counter(
     ["strategy", "horizon_seconds"],
 )
 
-# 2.2.5 — PnL attribution. Summary for the same reason as TOXICITY_MARKOUT_BPS: signed USD values
-# require `_sum` to be exposed so the stacked attribution panel can sum per component.
 PNL_ATTRIBUTION_USD = Summary(
     "mariaalpha_analytics_pnl_attribution_usd",
     "Per-order PnL attribution in USD, by component",
     ["strategy", "component"],
 )
 
-# 2.2.6 — axes
 AXES_ACTIVE = Gauge(
     "mariaalpha_analytics_axes_active",
     "Number of active (non-expired) axes",

--- a/analytics-service/src/analytics/pnl/attribution.py
+++ b/analytics-service/src/analytics/pnl/attribution.py
@@ -44,7 +44,7 @@ class TcaInput:
     order_id: str
     strategy: str
     symbol: str
-    side: str  # "BUY" or "SELL"
+    side: str
     quantity: float
     arrival_price: float
     realized_avg_price: float
@@ -52,7 +52,6 @@ class TcaInput:
     spread_cost_bps: float
     commission_total: float | None
     computed_at: datetime
-    # Optional decision-time mid for the timing component. None ⇒ timing contribution is 0.
     decision_mid_price: float | None = None
 
 
@@ -94,7 +93,6 @@ class PnlAttributionEngine:
         self._commission_bps = commission_bps
         self._lock = threading.RLock()
         self._rows: list[Attribution] = []
-        # (strategy, computed_at.date()) → component sum
         self._daily_totals: dict[tuple[str, date], dict[str, float]] = defaultdict(
             lambda: {
                 "spread": 0.0,
@@ -109,26 +107,18 @@ class PnlAttributionEngine:
 
     def attribute(self, tca: TcaInput) -> Attribution:
         signed_qty = tca.quantity if tca.side == "BUY" else -tca.quantity
-        # Spread cost is positive when we paid the bid/ask — by convention spread_cost_bps
-        # is reported as positive, so we negate it into "−" PnL (a cost).
         spread_usd = -(tca.spread_cost_bps / 10_000.0) * tca.arrival_price * tca.quantity
-        # Market drift between arrival and VWAP benchmark.
         market_usd = (tca.vwap_benchmark_price - tca.arrival_price) * signed_qty
-        # Timing: drift between decision-mid and arrival-mid, when available. Positive when
-        # the market moved with us between signal and execution-start.
         if tca.decision_mid_price is not None:
             timing_usd = (tca.arrival_price - tca.decision_mid_price) * signed_qty
         else:
             timing_usd = 0.0
-        # Commission: configurable bps haircut. Use the TCA-reported total when present;
-        # otherwise estimate.
         if tca.commission_total is not None:
             commission_usd = -abs(tca.commission_total)
         else:
             commission_usd = (
                 -(self._commission_bps / 10_000.0) * tca.realized_avg_price * tca.quantity
             )
-        # Realized PnL relative to VWAP benchmark (the desk benchmark we're attributing to).
         realized_pnl_usd = (tca.vwap_benchmark_price - tca.realized_avg_price) * signed_qty
         residual_usd = realized_pnl_usd - (spread_usd + timing_usd + market_usd + commission_usd)
 
@@ -159,7 +149,6 @@ class PnlAttributionEngine:
             totals["orders"] += 1
         return row
 
-    # -- snapshots --------------------------------------------------------
 
     def daily_summary(self, strategy: str | None = None) -> list[dict[str, object]]:
         """One row per (strategy, day) with summed component values."""

--- a/analytics-service/src/analytics/toxicity/detector.py
+++ b/analytics-service/src/analytics/toxicity/detector.py
@@ -49,7 +49,7 @@ class FillRecord:
     order_id: str
     strategy: str
     symbol: str
-    side: str  # "BUY" or "SELL"
+    side: str
     fill_price: float
     fill_ts_seconds: float
 
@@ -100,23 +100,17 @@ class FlowToxicityDetector:
         self._min_obs = min_observations
         self._price_lookup = price_lookup
         self._alert_publisher = alert_publisher
-        # Default to ``time.monotonic`` lazily so tests can inject a fake clock without
-        # importing ``time`` at module load.
         if clock is None:
             import time
 
             clock = time.monotonic
         self._clock = clock
         self._lock = threading.RLock()
-        # Pending fills awaiting horizon measurement, keyed by horizon.
         self._pending: dict[int, list[FillRecord]] = {h: [] for h in horizons_seconds}
-        # Rolling stats keyed by (strategy, horizon).
         self._stats: dict[tuple[str, int], StrategyStats] = {}
-        # Alert de-dup: only one alert per (strategy, horizon) inside a cooldown window.
         self._last_alert_ts: dict[tuple[str, int], float] = {}
         self._alert_cooldown_seconds = 60.0
 
-    # -- ingestion --------------------------------------------------------
 
     def on_fill(self, fill: FillRecord) -> None:
         """Register a fill for later markout measurement at each horizon."""
@@ -136,7 +130,6 @@ class FlowToxicityDetector:
         with self._lock:
             for horizon in self._horizons:
                 pending = self._pending[horizon]
-                # Walk from the head; the list is ordered by fill_ts (append-only).
                 drained: list[FillRecord] = []
                 remaining: list[FillRecord] = []
                 for fill in pending:
@@ -189,7 +182,6 @@ class FlowToxicityDetector:
             except Exception:
                 logger.exception("toxicity_alert_publish_failed", strategy=strategy)
 
-    # -- snapshots --------------------------------------------------------
 
     def snapshot(self, strategy: str | None = None) -> list[dict[str, object]]:
         """Return per-(strategy, horizon) toxicity rows, sorted by mean markout descending."""

--- a/analytics-service/tests/test_api.py
+++ b/analytics-service/tests/test_api.py
@@ -65,7 +65,6 @@ def client(
     matcher: AxeMatcher,
     cache: MarketDataCache,
 ) -> TestClient:
-    # Build an OrdersConsumer-shaped stub that just records matches without touching Kafka.
     class _StubOrdersConsumer:
         def __init__(self, m: AxeMatcher) -> None:
             self._matcher = m
@@ -93,12 +92,10 @@ def client(
 
     stub = _StubOrdersConsumer(matcher)
     app = create_app(settings, toxicity, attribution, matcher, cache, orders_consumer=stub)
-    # Attach so individual tests can drive the stub.
     app.state.stub_orders = stub  # type: ignore[attr-defined]
     return TestClient(app)
 
 
-# ── platform endpoints ──────────────────────────────────────────────────
 
 
 def test_health_endpoint_returns_healthy(client: TestClient):
@@ -125,11 +122,9 @@ def test_ready_endpoint_reports_counts(client: TestClient):
 def test_metrics_endpoint_returns_prometheus_exposition(client: TestClient):
     r = client.get("/metrics")
     assert r.status_code == 200
-    # Prometheus text format starts with `# HELP`.
     assert "# HELP" in r.text
 
 
-# ── 2.2.4 flow toxicity ─────────────────────────────────────────────────
 
 
 def test_flow_toxicity_endpoint_returns_empty_until_fills_arrive(client: TestClient):
@@ -148,7 +143,6 @@ def test_flow_toxicity_endpoint_returns_rows_after_tick(
 ):
     cache.record("AAPL", 60.0, 99.0)
     toxicity.on_fill(FillRecord("o1", "VWAP", "AAPL", "BUY", 100.0, 0.0))
-    # Drive detector forward so the fill is consumed.
     toxicity._clock = lambda: 70.0  # type: ignore[assignment]
     toxicity.tick()
     r = client.get("/v1/analytics/flow/toxicity?strategy=VWAP")
@@ -157,7 +151,6 @@ def test_flow_toxicity_endpoint_returns_rows_after_tick(
     assert body["rows"][0]["strategy"] == "VWAP"
 
 
-# ── 2.2.5 PnL attribution ───────────────────────────────────────────────
 
 
 def _tca(order_id: str = "o1") -> TcaInput:
@@ -219,7 +212,6 @@ def test_pnl_attribution_by_strategy_endpoint(
     assert "spread" in body["components"]
 
 
-# ── 2.2.6 axe matching ──────────────────────────────────────────────────
 
 
 def test_publish_axe_via_post_creates_axe(client: TestClient):
@@ -310,7 +302,6 @@ def test_axe_matches_endpoint_404_when_no_orders_seen(client: TestClient):
 
 
 def test_axe_matches_endpoint_returns_recorded_matches(client: TestClient):
-    # Publish a SELL axe, then route an opposing BUY order through the stub consumer.
     client.post(
         "/v1/analytics/axes",
         json={

--- a/analytics-service/tests/test_axes.py
+++ b/analytics-service/tests/test_axes.py
@@ -35,11 +35,9 @@ def test_publish_with_same_client_symbol_side_refreshes_instead_of_duplicating()
     m.publish("a1", "clientA", "AAPL", "BUY", 1000)
     clock[0] = 1500.0
     refreshed = m.publish("a-NEW", "clientA", "AAPL", "BUY", 2000)
-    # axe_id stays as the original; refresh_count bumped.
     assert refreshed.axe_id == "a1"
     assert refreshed.quantity == 2000
     assert refreshed.refresh_count == 1
-    # Snapshot should show exactly one entry.
     assert len(m.snapshot()) == 1
 
 
@@ -56,7 +54,6 @@ def test_cancel_removes_axe_and_refresh_index():
     m.publish("a1", "clientA", "AAPL", "BUY", 1000)
     assert m.cancel("a1") is True
     assert m.cancel("a1") is False
-    # Re-publishing must create a fresh axe (refresh index was cleared).
     fresh = m.publish("a2", "clientA", "AAPL", "BUY", 500)
     assert fresh.axe_id == "a2"
     assert fresh.refresh_count == 0
@@ -91,7 +88,6 @@ def test_fully_consumed_axe_is_removed():
     matches = m.match(IncomingLeg("o1", "AAPL", "BUY", 500))
     assert matches[0].matched_quantity == 500
     assert m.snapshot() == []
-    # Republishing for same client should now create a brand-new axe.
     fresh = m.publish("a2", "clientA", "AAPL", "SELL", 200)
     assert fresh.axe_id == "a2"
     assert fresh.refresh_count == 0
@@ -99,15 +95,11 @@ def test_fully_consumed_axe_is_removed():
 
 def test_match_ranks_by_confidence_then_remaining():
     m, clock = _matcher(default_ttl=1000)
-    # Old axe published at t=1000, fresh axe at t=1500. Both expire at +1000 from publish.
     m.publish("old", "C1", "AAPL", "SELL", 500)
     clock[0] = 1500.0
     m.publish("fresh", "C2", "AAPL", "SELL", 500)
-    # Match at t=1500: old has 500s of 1000 TTL remaining (conf=0.5);
-    # fresh has 1000s of 1000 TTL remaining (conf=1.0). Fresh should rank first.
     matches = m.match(IncomingLeg("o1", "AAPL", "BUY", 800))
     assert [s.axe_id for s in matches] == ["fresh", "old"]
-    # First fill: 500 from fresh; second: 300 from old.
     assert matches[0].matched_quantity == 500
     assert matches[1].matched_quantity == 300
 
@@ -120,13 +112,9 @@ def test_match_ranks_by_confidence_times_remaining_product():
     one when the product favours the larger axe.
     """
     m, clock = _matcher(default_ttl=1000)
-    # Big stale axe at t=1000, small fresh axe at t=1500.
     m.publish("big_stale", "C1", "AAPL", "SELL", 1000)
     clock[0] = 1500.0
     m.publish("small_fresh", "C2", "AAPL", "SELL", 100)
-    # At t=1500: big_stale conf=0.5 × remaining 1000 = 500 (product score).
-    #            small_fresh conf=1.0 × remaining 100 = 100.
-    # Spec ranking puts big_stale first despite its lower confidence.
     matches = m.match(IncomingLeg("o1", "AAPL", "BUY", 50))
     assert [s.axe_id for s in matches] == ["big_stale"]
 
@@ -134,7 +122,7 @@ def test_match_ranks_by_confidence_times_remaining_product():
 def test_expired_axe_is_dropped_at_match_time():
     m, clock = _matcher(default_ttl=100)
     m.publish("a1", "C1", "AAPL", "SELL", 500)
-    clock[0] = 1200.0  # 200s after publish → past TTL
+    clock[0] = 1200.0
     matches = m.match(IncomingLeg("o1", "AAPL", "BUY", 100))
     assert matches == []
     assert m.snapshot() == []
@@ -143,9 +131,7 @@ def test_expired_axe_is_dropped_at_match_time():
 def test_min_match_quantity_filters_tiny_orders():
     m, _ = _matcher(min_match=100)
     m.publish("a1", "C1", "AAPL", "SELL", 1000)
-    # Incoming below min_match → skipped entirely.
     assert m.match(IncomingLeg("o1", "AAPL", "BUY", 50)) == []
-    # Axe remaining is untouched.
     assert m.snapshot()[0]["remaining"] == 1000
 
 

--- a/analytics-service/tests/test_market_cache.py
+++ b/analytics-service/tests/test_market_cache.py
@@ -22,11 +22,8 @@ def test_price_at_finds_closest_prior_observation():
     c.record("AAPL", 100.0, 99.0)
     c.record("AAPL", 110.0, 99.5)
     c.record("AAPL", 120.0, 100.0)
-    # Exactly on a tick.
     assert c.price_at("AAPL", 110.0) == 99.5
-    # In-between → use prior.
     assert c.price_at("AAPL", 115.0) == 99.5
-    # Past the last tick → use latest.
     assert c.price_at("AAPL", 200.0) == 100.0
 
 
@@ -45,7 +42,6 @@ def test_record_handles_out_of_order_ticks():
     c = MarketDataCache()
     c.record("AAPL", 100.0, 99.0)
     c.record("AAPL", 110.0, 99.5)
-    # Late tick at t=105 should slot between.
     c.record("AAPL", 105.0, 99.2)
     assert c.price_at("AAPL", 105.0) == 99.2
     assert c.price_at("AAPL", 110.0) == 99.5
@@ -55,8 +51,5 @@ def test_record_trims_history_when_max_exceeded():
     c = MarketDataCache(max_history_per_symbol=10)
     for i in range(15):
         c.record("AAPL", float(i), 100.0 + i)
-    # After trim, oldest entries should be gone but recent ones retained.
     assert c.latest("AAPL") == 100.0 + 14
-    # The exact retention depends on the trim policy (drops 25% on overflow).
-    # The latest tick is always preserved.
     assert c.price_at("AAPL", 14.0) == 100.0 + 14

--- a/analytics-service/tests/test_pnl.py
+++ b/analytics-service/tests/test_pnl.py
@@ -43,22 +43,16 @@ def _tca(
 def test_buy_attribution_math_components_sum_to_realized():
     eng = PnlAttributionEngine(commission_bps=0.5)
     row = eng.attribute(_tca())
-    # Realized = (100.05 − 100.10) × +100 = −5.00.
     assert row.realized_pnl_usd == pytest.approx(-5.0)
-    # Spread = −(5/10000) × 100 × 100 = −5.00.
     assert row.spread_usd == pytest.approx(-5.0)
-    # Market = (100.05 − 100) × +100 = +5.00.
     assert row.market_usd == pytest.approx(5.0)
-    # Commission = −(0.5/10000) × 100.10 × 100 ≈ −0.5005.
     assert row.commission_usd == pytest.approx(-0.5005, rel=1e-4)
-    # Components must reconstruct realized (within float rounding).
     assert row.total() == pytest.approx(row.realized_pnl_usd, rel=1e-6, abs=1e-3)
 
 
 def test_sell_signed_quantity_flips_market_component_sign():
     eng = PnlAttributionEngine()
     row = eng.attribute(_tca(side="SELL"))
-    # For a sell with vwap > arrival, market drift hurts us → negative.
     assert row.market_usd == pytest.approx(-5.0)
 
 
@@ -66,7 +60,6 @@ def test_explicit_commission_total_overrides_bps_estimate():
     eng = PnlAttributionEngine(commission_bps=0.5)
     row = eng.attribute(_tca(commission_total=2.50))
     assert row.commission_usd == pytest.approx(-2.50)
-    # Sign forced negative even if caller passed positive number.
     row2 = eng.attribute(_tca(order_id="o2", commission_total=-7.0))
     assert row2.commission_usd == pytest.approx(-7.0)
 
@@ -90,7 +83,6 @@ def test_daily_summary_rolls_up_per_strategy_per_day():
     eng.attribute(_tca(order_id="o4", strategy="VWAP", computed_at=day2))
 
     rows = eng.daily_summary()
-    # 3 unique (strategy, day) buckets.
     assert len(rows) == 3
     vwap_d1 = next(r for r in rows if r["strategy"] == "VWAP" and r["date"] == "2026-05-30")
     assert vwap_d1["orders"] == 2
@@ -127,7 +119,6 @@ def test_strategy_distribution_empty_for_unknown_strategy():
 
 def test_strategy_distribution_reports_min_median_max_sum():
     eng = PnlAttributionEngine()
-    # Three different realized PnLs by varying vwap_benchmark vs realized.
     for i, vwap in enumerate([100.05, 100.10, 100.15]):
         eng.attribute(
             _tca(
@@ -141,7 +132,6 @@ def test_strategy_distribution_reports_min_median_max_sum():
     assert dist["orders"] == 3
     assert "realized" in dist["components"]
     realized = dist["components"]["realized"]
-    # min/median/max should be sorted (sums of 5/10/15 USD).
     assert realized["min"] == pytest.approx(5.0)
     assert realized["median"] == pytest.approx(10.0)
     assert realized["max"] == pytest.approx(15.0)
@@ -149,25 +139,19 @@ def test_strategy_distribution_reports_min_median_max_sum():
 
 
 def test_timing_is_zero_when_decision_mid_absent():
-    # No decision_mid_price → timing must collapse to 0 (legacy TCA rows).
     eng = PnlAttributionEngine()
     row = eng.attribute(_tca())
     assert row.timing_usd == pytest.approx(0.0)
 
 
 def test_timing_uses_decision_mid_when_present_buy():
-    # BUY 100 @ arrival=100.10, decision-mid=100.00 → market drifted up between decision
-    # and arrival → timing = (100.10 − 100.00) × +100 = +10.00 (favorable).
     eng = PnlAttributionEngine()
     row = eng.attribute(_tca(arrival_price=100.10, decision_mid_price=100.00))
     assert row.timing_usd == pytest.approx(10.0)
-    # Components must still reconstruct realized PnL (residual absorbs any drift).
     assert row.total() == pytest.approx(row.realized_pnl_usd, abs=1e-3)
 
 
 def test_timing_sign_flips_for_sell():
-    # SELL 100 @ arrival=99.90, decision-mid=100.00 → market dropped between decision
-    # and arrival → timing = (99.90 − 100.00) × −100 = +10.00 (favorable for a short).
     eng = PnlAttributionEngine()
     row = eng.attribute(_tca(side="SELL", arrival_price=99.90, decision_mid_price=100.00))
     assert row.timing_usd == pytest.approx(10.0)

--- a/analytics-service/tests/test_toxicity.py
+++ b/analytics-service/tests/test_toxicity.py
@@ -23,7 +23,6 @@ def _make_detector(
         return clock_value[0]
 
     def price_lookup(symbol: str, ts: float) -> float | None:
-        # Find the closest pre-recorded horizon price for this symbol/ts.
         return price_at_horizon.get((symbol, ts))
 
     det = FlowToxicityDetector(
@@ -44,7 +43,6 @@ def test_buy_followed_by_drop_is_adverse_selection_positive_markout():
     assert det.tick() == 1
     snap = det.snapshot()
     assert snap[0]["strategy"] == "VWAP"
-    # Buy at 100, price fell to 99 → markout = +100bps (we were picked off).
     assert snap[0]["meanMarkoutBps"] == pytest.approx(100.0)
     assert snap[0]["toxic"] is True
 
@@ -55,7 +53,6 @@ def test_sell_followed_by_rally_is_adverse_selection_positive_markout():
     clock[0] = 61.0
     det.tick()
     snap = det.snapshot()
-    # Sell at 100, price rose to 101 → markout = +100bps.
     assert snap[0]["meanMarkoutBps"] == pytest.approx(100.0)
 
 
@@ -65,7 +62,6 @@ def test_buy_followed_by_rally_is_favourable_negative_markout():
     clock[0] = 61.0
     det.tick()
     snap = det.snapshot()
-    # Buy at 100, price rose to 101 → markout = -100bps (favourable).
     assert snap[0]["meanMarkoutBps"] == pytest.approx(-100.0)
     assert snap[0]["toxic"] is False
 
@@ -73,7 +69,7 @@ def test_buy_followed_by_rally_is_favourable_negative_markout():
 def test_pending_fill_below_horizon_not_consumed():
     det, clock = _make_detector({("AAPL", 60.0): 99.0})
     det.on_fill(FillRecord("o1", "VWAP", "AAPL", "BUY", 100.0, 0.0))
-    clock[0] = 30.0  # not yet at the 60s horizon
+    clock[0] = 30.0
     assert det.tick() == 0
     assert det.pending_count() == 1
     clock[0] = 60.0
@@ -82,10 +78,10 @@ def test_pending_fill_below_horizon_not_consumed():
 
 
 def test_missing_horizon_price_skips_fill_silently():
-    det, clock = _make_detector({})  # no horizon price for anything
+    det, clock = _make_detector({})
     det.on_fill(FillRecord("o1", "VWAP", "AAPL", "BUY", 100.0, 0.0))
     clock[0] = 60.0
-    det.tick()  # should not raise; should not record a stat
+    det.tick()
     assert det.snapshot() == []
 
 
@@ -101,7 +97,6 @@ def test_alert_fires_when_threshold_breached_after_min_observations():
         det.on_fill(FillRecord(order_id, "VWAP", "AAPL", "BUY", 100.0, fill_ts))
     clock[0] = 100.0
     det.tick()
-    # 100bps mean markout, threshold 10bps → exactly one alert (cooldown blocks dupes).
     assert len(alerts) == 1
     assert alerts[0]["alertType"] == "FLOW_TOXICITY"
     assert alerts[0]["strategy"] == "VWAP"

--- a/api-collection/06 - Execution/Basket Progress.bru
+++ b/api-collection/06 - Execution/Basket Progress.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Basket Progress
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{baseUrl}}/api/execution/baskets/{{lastBasketId}}
+  body: none
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+}
+
+docs {
+  Returns the aggregate BasketView for a basket order (roadmap 3.4.1): overall
+  status (SUBMITTED / PARTIALLY_FILLED / FILLED / REJECTED), leg counts, target
+  vs filled quantity, and per-leg status. Run "Submit Program/Basket Order"
+  first to populate lastBasketId.
+}

--- a/api-collection/06 - Execution/Submit Basket.bru
+++ b/api-collection/06 - Execution/Submit Basket.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Submit Program/Basket Order
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{baseUrl}}/api/execution/baskets
+  body: json
+  auth: none
+}
+
+headers {
+  X-API-Key: {{apiKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "name": "rebalance-{{$randomUUID}}",
+    "legs": [
+      { "symbol": "AAPL", "side": "BUY",  "orderType": "LIMIT",  "quantity": 100, "limitPrice": 175.50 },
+      { "symbol": "MSFT", "side": "BUY",  "orderType": "MARKET", "quantity": 50 },
+      { "symbol": "TSLA", "side": "SELL", "orderType": "LIMIT",  "quantity": 25,  "limitPrice": 240.00 }
+    ]
+  }
+}
+
+docs {
+  Submits a multi-leg basket (roadmap 3.4.1). Each leg is fanned out through the
+  full risk -> SOR -> venue pipeline; the response is a 202 ACCEPTED BasketView
+  with a basketId and per-leg status. Poll progress with "Basket Progress".
+}
+
+script:post-response {
+  if (res.status === 202 && res.body && res.body.basketId) {
+    bru.setVar("lastBasketId", res.body.basketId);
+  }
+}

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -18,6 +18,10 @@ dependencies {
     implementation(libs.springdoc.openapi.webflux.ui)
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
+    // QuickFIX/J — inbound FIX 4.4 acceptor for programmatic order entry (roadmap 3.4.3).
+    implementation(libs.quickfixj.core)
+    implementation(libs.quickfixj.messages.fix44)
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation(libs.testcontainers.junit.jupiter)

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixApplication.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixApplication.java
@@ -1,0 +1,252 @@
+package com.mariaalpha.apigateway.fix;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import quickfix.FieldNotFound;
+import quickfix.IncorrectDataFormat;
+import quickfix.IncorrectTagValue;
+import quickfix.Message;
+import quickfix.Session;
+import quickfix.SessionID;
+import quickfix.SessionNotFound;
+import quickfix.UnsupportedMessageType;
+import quickfix.field.AvgPx;
+import quickfix.field.ClOrdID;
+import quickfix.field.CumQty;
+import quickfix.field.CxlRejResponseTo;
+import quickfix.field.ExecID;
+import quickfix.field.ExecType;
+import quickfix.field.LeavesQty;
+import quickfix.field.OrdStatus;
+import quickfix.field.OrderID;
+import quickfix.field.OrderQty;
+import quickfix.field.OrigClOrdID;
+import quickfix.field.Side;
+import quickfix.field.Text;
+import quickfix.field.TransactTime;
+import quickfix.fix44.ExecutionReport;
+import quickfix.fix44.NewOrderSingle;
+import quickfix.fix44.OrderCancelReject;
+import quickfix.fix44.OrderCancelRequest;
+
+/**
+ * QuickFIX/J {@link quickfix.Application} for the inbound FIX 4.4 gateway (roadmap 3.4.3). Cracks
+ * inbound application messages, forwards {@code NewOrderSingle}/{@code OrderCancelRequest} to
+ * execution-engine via {@link FixGatewayClient}, and replies with an {@code ExecutionReport} (or
+ * {@code OrderCancelReject}).
+ *
+ * <p>The message-handling logic lives in {@link #handleNewOrderSingle} / {@link
+ * #handleOrderCancelRequest}, which build and <em>return</em> the response message without touching
+ * a live session — so they are unit-testable by constructing FIX messages with a mocked client. The
+ * {@code onMessage} overrides are thin: handle, then {@link Session#sendToTarget}.
+ */
+@Component
+public class FixApplication extends quickfix.fix44.MessageCracker implements quickfix.Application {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FixApplication.class);
+
+  // FIX 4.4 wire values (kept as literals; see FixOrderTranslator for the rationale).
+  private static final char EXEC_NEW = '0';
+  private static final char EXEC_CANCELED = '4';
+  private static final char EXEC_REJECTED = '8';
+  private static final char ORD_NEW = '0';
+  private static final char ORD_CANCELED = '4';
+  private static final char ORD_REJECTED = '8';
+  private static final char CXL_REJ_RESPONSE_TO_CANCEL = '1';
+  private static final String NO_ORDER_ID = "NONE";
+
+  private final FixGatewayClient client;
+  private final FixGatewayMetrics metrics;
+  // ClOrdID → internal execution-engine order id, so an OrderCancelRequest (which carries the
+  // client's OrigClOrdID) can be resolved back to the downstream order to cancel.
+  private final Map<String, String> clOrdToDownstream = new ConcurrentHashMap<>();
+
+  public FixApplication(FixGatewayClient client, FixGatewayMetrics metrics) {
+    this.client = client;
+    this.metrics = metrics;
+  }
+
+  // ---- Application lifecycle (admin) ---------------------------------------------------------
+
+  @Override
+  public void onCreate(SessionID sessionId) {
+    LOG.info("FIX session created: {}", sessionId);
+  }
+
+  @Override
+  public void onLogon(SessionID sessionId) {
+    LOG.info("FIX client logged on: {}", sessionId);
+  }
+
+  @Override
+  public void onLogout(SessionID sessionId) {
+    LOG.info("FIX client logged out: {}", sessionId);
+  }
+
+  @Override
+  public void toAdmin(Message message, SessionID sessionId) {
+    // no-op
+  }
+
+  @Override
+  public void fromAdmin(Message message, SessionID sessionId) {
+    // no-op
+  }
+
+  @Override
+  public void toApp(Message message, SessionID sessionId) {
+    // no-op
+  }
+
+  @Override
+  public void fromApp(Message message, SessionID sessionId)
+      throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType {
+    crack(message, sessionId);
+  }
+
+  // ---- Cracked application messages ----------------------------------------------------------
+
+  @Override
+  public void onMessage(NewOrderSingle message, SessionID sessionId) {
+    send(handleNewOrderSingle(message, sessionId), sessionId);
+  }
+
+  @Override
+  public void onMessage(OrderCancelRequest message, SessionID sessionId) {
+    send(handleOrderCancelRequest(message, sessionId), sessionId);
+  }
+
+  // ---- Pure(ish) handlers — return the response message, no session I/O ----------------------
+
+  /** Translate, forward, and build the resulting {@code ExecutionReport}. */
+  public Message handleNewOrderSingle(NewOrderSingle nos, SessionID sessionId) {
+    String clOrdId = "UNKNOWN";
+    char sideChar = '1';
+    try {
+      clOrdId = nos.getClOrdID().getValue();
+      sideChar = nos.getSide().getValue();
+      var submission = FixOrderTranslator.translate(nos);
+      var result = client.submitOrder(submission);
+      if (!result.accepted()) {
+        metrics.recordRejected();
+        return executionReport(
+            clOrdId,
+            NO_ORDER_ID,
+            sideChar,
+            submission.quantity(),
+            EXEC_REJECTED,
+            ORD_REJECTED,
+            result.reason());
+      }
+      clOrdToDownstream.put(clOrdId, result.downstreamOrderId());
+      metrics.recordAccepted();
+      return executionReport(
+          clOrdId,
+          result.downstreamOrderId(),
+          sideChar,
+          submission.quantity(),
+          EXEC_NEW,
+          ORD_NEW,
+          null);
+    } catch (FieldNotFound e) {
+      metrics.recordRejected();
+      return executionReport(
+          clOrdId,
+          NO_ORDER_ID,
+          sideChar,
+          0,
+          EXEC_REJECTED,
+          ORD_REJECTED,
+          "missing required field: " + e.field);
+    } catch (IllegalArgumentException e) {
+      metrics.recordRejected();
+      return executionReport(
+          clOrdId, NO_ORDER_ID, sideChar, 0, EXEC_REJECTED, ORD_REJECTED, e.getMessage());
+    }
+  }
+
+  /** Resolve the original order, forward a cancel, and build the {@code ExecutionReport}/reject. */
+  public Message handleOrderCancelRequest(OrderCancelRequest ocr, SessionID sessionId) {
+    String clOrdId = "UNKNOWN";
+    String origClOrdId = "UNKNOWN";
+    char sideChar = '1';
+    try {
+      clOrdId = ocr.getClOrdID().getValue();
+      origClOrdId = ocr.getOrigClOrdID().getValue();
+      if (ocr.isSetSide()) {
+        sideChar = ocr.getSide().getValue();
+      }
+      var downstreamId = clOrdToDownstream.get(origClOrdId);
+      if (downstreamId == null) {
+        return orderCancelReject(clOrdId, origClOrdId, "unknown OrigClOrdID");
+      }
+      var result = client.cancelOrder(downstreamId);
+      if (!result.accepted()) {
+        return orderCancelReject(clOrdId, origClOrdId, result.reason());
+      }
+      clOrdToDownstream.remove(origClOrdId);
+      metrics.recordCancelled();
+      var er =
+          executionReport(clOrdId, downstreamId, sideChar, 0, EXEC_CANCELED, ORD_CANCELED, null);
+      ((ExecutionReport) er).set(new OrigClOrdID(origClOrdId));
+      return er;
+    } catch (FieldNotFound e) {
+      return orderCancelReject(clOrdId, origClOrdId, "missing required field: " + e.field);
+    }
+  }
+
+  // ---- Message builders ----------------------------------------------------------------------
+
+  private Message executionReport(
+      String clOrdId,
+      String orderId,
+      char sideChar,
+      int quantity,
+      char execType,
+      char ordStatus,
+      String reason) {
+    var report =
+        new ExecutionReport(
+            new OrderID(orderId),
+            new ExecID(UUID.randomUUID().toString()),
+            new ExecType(execType),
+            new OrdStatus(ordStatus),
+            new Side(sideChar),
+            new LeavesQty(execType == EXEC_NEW ? quantity : 0),
+            new CumQty(0),
+            new AvgPx(0));
+    report.set(new ClOrdID(clOrdId));
+    report.set(new OrderQty(quantity));
+    report.set(new TransactTime(LocalDateTime.now(ZoneOffset.UTC)));
+    if (reason != null) {
+      report.set(new Text(reason));
+    }
+    return report;
+  }
+
+  private Message orderCancelReject(String clOrdId, String origClOrdId, String reason) {
+    var reject =
+        new OrderCancelReject(
+            new OrderID(NO_ORDER_ID),
+            new ClOrdID(clOrdId),
+            new OrigClOrdID(origClOrdId),
+            new OrdStatus(ORD_REJECTED),
+            new CxlRejResponseTo(CXL_REJ_RESPONSE_TO_CANCEL));
+    reject.set(new Text(reason));
+    return reject;
+  }
+
+  private void send(Message message, SessionID sessionId) {
+    try {
+      Session.sendToTarget(message, sessionId);
+    } catch (SessionNotFound e) {
+      LOG.warn("Cannot send FIX response — session not found: {}", sessionId);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixApplication.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixApplication.java
@@ -28,6 +28,7 @@ import quickfix.field.OrderID;
 import quickfix.field.OrderQty;
 import quickfix.field.OrigClOrdID;
 import quickfix.field.Side;
+import quickfix.field.Symbol;
 import quickfix.field.Text;
 import quickfix.field.TransactTime;
 import quickfix.fix44.ExecutionReport;
@@ -60,6 +61,9 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
   private static final char ORD_REJECTED = '8';
   private static final char CXL_REJ_RESPONSE_TO_CANCEL = '1';
   private static final String NO_ORDER_ID = "NONE";
+  // Fallback Symbol (tag 55) for reject reports built before the order's symbol could be read;
+  // ExecutionReport requires tag 55, so a placeholder keeps the message dictionary-valid.
+  private static final String NO_SYMBOL = "UNKNOWN";
 
   private final FixGatewayClient client;
   private final FixGatewayMetrics metrics;
@@ -127,17 +131,23 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
   /** Translate, forward, and build the resulting {@code ExecutionReport}. */
   public Message handleNewOrderSingle(NewOrderSingle nos, SessionID sessionId) {
     String clOrdId = "UNKNOWN";
+    String symbol = NO_SYMBOL;
     char sideChar = '1';
     try {
       clOrdId = nos.getClOrdID().getValue();
       sideChar = nos.getSide().getValue();
+      if (nos.isSetSymbol()) {
+        symbol = nos.getSymbol().getValue();
+      }
       var submission = FixOrderTranslator.translate(nos);
+      symbol = submission.symbol();
       var result = client.submitOrder(submission);
       if (!result.accepted()) {
         metrics.recordRejected();
         return executionReport(
             clOrdId,
             NO_ORDER_ID,
+            symbol,
             sideChar,
             submission.quantity(),
             EXEC_REJECTED,
@@ -149,6 +159,7 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
       return executionReport(
           clOrdId,
           result.downstreamOrderId(),
+          symbol,
           sideChar,
           submission.quantity(),
           EXEC_NEW,
@@ -159,6 +170,7 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
       return executionReport(
           clOrdId,
           NO_ORDER_ID,
+          symbol,
           sideChar,
           0,
           EXEC_REJECTED,
@@ -167,7 +179,7 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
     } catch (IllegalArgumentException e) {
       metrics.recordRejected();
       return executionReport(
-          clOrdId, NO_ORDER_ID, sideChar, 0, EXEC_REJECTED, ORD_REJECTED, e.getMessage());
+          clOrdId, NO_ORDER_ID, symbol, sideChar, 0, EXEC_REJECTED, ORD_REJECTED, e.getMessage());
     }
   }
 
@@ -175,12 +187,16 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
   public Message handleOrderCancelRequest(OrderCancelRequest ocr, SessionID sessionId) {
     String clOrdId = "UNKNOWN";
     String origClOrdId = "UNKNOWN";
+    String symbol = NO_SYMBOL;
     char sideChar = '1';
     try {
       clOrdId = ocr.getClOrdID().getValue();
       origClOrdId = ocr.getOrigClOrdID().getValue();
       if (ocr.isSetSide()) {
         sideChar = ocr.getSide().getValue();
+      }
+      if (ocr.isSetSymbol()) {
+        symbol = ocr.getSymbol().getValue();
       }
       var downstreamId = clOrdToDownstream.get(origClOrdId);
       if (downstreamId == null) {
@@ -193,7 +209,8 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
       clOrdToDownstream.remove(origClOrdId);
       metrics.recordCancelled();
       var er =
-          executionReport(clOrdId, downstreamId, sideChar, 0, EXEC_CANCELED, ORD_CANCELED, null);
+          executionReport(
+              clOrdId, downstreamId, symbol, sideChar, 0, EXEC_CANCELED, ORD_CANCELED, null);
       ((ExecutionReport) er).set(new OrigClOrdID(origClOrdId));
       return er;
     } catch (FieldNotFound e) {
@@ -206,6 +223,7 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
   private Message executionReport(
       String clOrdId,
       String orderId,
+      String symbol,
       char sideChar,
       int quantity,
       char execType,
@@ -221,6 +239,7 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
             new LeavesQty(execType == EXEC_NEW ? quantity : 0),
             new CumQty(0),
             new AvgPx(0));
+    report.set(new Symbol(symbol));
     report.set(new ClOrdID(clOrdId));
     report.set(new OrderQty(quantity));
     report.set(new TransactTime(LocalDateTime.now(ZoneOffset.UTC)));

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixApplication.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixApplication.java
@@ -36,23 +36,11 @@ import quickfix.fix44.NewOrderSingle;
 import quickfix.fix44.OrderCancelReject;
 import quickfix.fix44.OrderCancelRequest;
 
-/**
- * QuickFIX/J {@link quickfix.Application} for the inbound FIX 4.4 gateway (roadmap 3.4.3). Cracks
- * inbound application messages, forwards {@code NewOrderSingle}/{@code OrderCancelRequest} to
- * execution-engine via {@link FixGatewayClient}, and replies with an {@code ExecutionReport} (or
- * {@code OrderCancelReject}).
- *
- * <p>The message-handling logic lives in {@link #handleNewOrderSingle} / {@link
- * #handleOrderCancelRequest}, which build and <em>return</em> the response message without touching
- * a live session — so they are unit-testable by constructing FIX messages with a mocked client. The
- * {@code onMessage} overrides are thin: handle, then {@link Session#sendToTarget}.
- */
 @Component
 public class FixApplication extends quickfix.fix44.MessageCracker implements quickfix.Application {
 
   private static final Logger LOG = LoggerFactory.getLogger(FixApplication.class);
 
-  // FIX 4.4 wire values (kept as literals; see FixOrderTranslator for the rationale).
   private static final char EXEC_NEW = '0';
   private static final char EXEC_CANCELED = '4';
   private static final char EXEC_REJECTED = '8';
@@ -61,22 +49,16 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
   private static final char ORD_REJECTED = '8';
   private static final char CXL_REJ_RESPONSE_TO_CANCEL = '1';
   private static final String NO_ORDER_ID = "NONE";
-  // Fallback Symbol (tag 55) for reject reports built before the order's symbol could be read;
-  // ExecutionReport requires tag 55, so a placeholder keeps the message dictionary-valid.
   private static final String NO_SYMBOL = "UNKNOWN";
 
   private final FixGatewayClient client;
   private final FixGatewayMetrics metrics;
-  // ClOrdID → internal execution-engine order id, so an OrderCancelRequest (which carries the
-  // client's OrigClOrdID) can be resolved back to the downstream order to cancel.
   private final Map<String, String> clOrdToDownstream = new ConcurrentHashMap<>();
 
   public FixApplication(FixGatewayClient client, FixGatewayMetrics metrics) {
     this.client = client;
     this.metrics = metrics;
   }
-
-  // ---- Application lifecycle (admin) ---------------------------------------------------------
 
   @Override
   public void onCreate(SessionID sessionId) {
@@ -94,27 +76,19 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
   }
 
   @Override
-  public void toAdmin(Message message, SessionID sessionId) {
-    // no-op
-  }
+  public void toAdmin(Message message, SessionID sessionId) {}
 
   @Override
-  public void fromAdmin(Message message, SessionID sessionId) {
-    // no-op
-  }
+  public void fromAdmin(Message message, SessionID sessionId) {}
 
   @Override
-  public void toApp(Message message, SessionID sessionId) {
-    // no-op
-  }
+  public void toApp(Message message, SessionID sessionId) {}
 
   @Override
   public void fromApp(Message message, SessionID sessionId)
       throws FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType {
     crack(message, sessionId);
   }
-
-  // ---- Cracked application messages ----------------------------------------------------------
 
   @Override
   public void onMessage(NewOrderSingle message, SessionID sessionId) {
@@ -126,9 +100,6 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
     send(handleOrderCancelRequest(message, sessionId), sessionId);
   }
 
-  // ---- Pure(ish) handlers — return the response message, no session I/O ----------------------
-
-  /** Translate, forward, and build the resulting {@code ExecutionReport}. */
   public Message handleNewOrderSingle(NewOrderSingle nos, SessionID sessionId) {
     String clOrdId = "UNKNOWN";
     String symbol = NO_SYMBOL;
@@ -183,7 +154,6 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
     }
   }
 
-  /** Resolve the original order, forward a cancel, and build the {@code ExecutionReport}/reject. */
   public Message handleOrderCancelRequest(OrderCancelRequest ocr, SessionID sessionId) {
     String clOrdId = "UNKNOWN";
     String origClOrdId = "UNKNOWN";
@@ -217,8 +187,6 @@ public class FixApplication extends quickfix.fix44.MessageCracker implements qui
       return orderCancelReject(clOrdId, origClOrdId, "missing required field: " + e.field);
     }
   }
-
-  // ---- Message builders ----------------------------------------------------------------------
 
   private Message executionReport(
       String clOrdId,

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixDownstreamResult.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixDownstreamResult.java
@@ -1,12 +1,5 @@
 package com.mariaalpha.apigateway.fix;
 
-/**
- * Outcome of forwarding a translated FIX order (or cancel) to a downstream MariaAlpha service.
- *
- * @param accepted whether the downstream accepted the request
- * @param downstreamOrderId the internal order id returned by the downstream (null on rejection)
- * @param reason human-readable rejection reason (null when accepted)
- */
 public record FixDownstreamResult(boolean accepted, String downstreamOrderId, String reason) {
 
   public static FixDownstreamResult accepted(String downstreamOrderId) {

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixDownstreamResult.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixDownstreamResult.java
@@ -1,0 +1,19 @@
+package com.mariaalpha.apigateway.fix;
+
+/**
+ * Outcome of forwarding a translated FIX order (or cancel) to a downstream MariaAlpha service.
+ *
+ * @param accepted whether the downstream accepted the request
+ * @param downstreamOrderId the internal order id returned by the downstream (null on rejection)
+ * @param reason human-readable rejection reason (null when accepted)
+ */
+public record FixDownstreamResult(boolean accepted, String downstreamOrderId, String reason) {
+
+  public static FixDownstreamResult accepted(String downstreamOrderId) {
+    return new FixDownstreamResult(true, downstreamOrderId, null);
+  }
+
+  public static FixDownstreamResult rejected(String reason) {
+    return new FixDownstreamResult(false, null, reason);
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayClient.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayClient.java
@@ -8,12 +8,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-/**
- * Forwards translated FIX orders to execution-engine over HTTP. Called from QuickFIX/J worker
- * threads, so the reactive {@link WebClient} calls are {@code block()}ed (never on a Netty event
- * loop). execution-engine sits behind the api-gateway's auth at the edge; these are internal
- * service-to-service calls and carry no API key.
- */
 @Component
 public class FixGatewayClient {
 
@@ -25,7 +19,6 @@ public class FixGatewayClient {
     this.webClient = builder.baseUrl(properties.executionEngineUrl()).build();
   }
 
-  /** Submit a plain order to {@code POST /api/execution/orders}. */
   public FixDownstreamResult submitOrder(FixOrderSubmission order) {
     var body = new HashMap<String, Object>();
     body.put("symbol", order.symbol());
@@ -70,7 +63,6 @@ public class FixGatewayClient {
     }
   }
 
-  /** Cancel a previously-submitted order via {@code DELETE /api/execution/orders/{id}}. */
   public FixDownstreamResult cancelOrder(String downstreamOrderId) {
     try {
       webClient

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayClient.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayClient.java
@@ -1,0 +1,90 @@
+package com.mariaalpha.apigateway.fix;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * Forwards translated FIX orders to execution-engine over HTTP. Called from QuickFIX/J worker
+ * threads, so the reactive {@link WebClient} calls are {@code block()}ed (never on a Netty event
+ * loop). execution-engine sits behind the api-gateway's auth at the edge; these are internal
+ * service-to-service calls and carry no API key.
+ */
+@Component
+public class FixGatewayClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FixGatewayClient.class);
+
+  private final WebClient webClient;
+
+  public FixGatewayClient(WebClient.Builder builder, FixGatewayProperties properties) {
+    this.webClient = builder.baseUrl(properties.executionEngineUrl()).build();
+  }
+
+  /** Submit a plain order to {@code POST /api/execution/orders}. */
+  public FixDownstreamResult submitOrder(FixOrderSubmission order) {
+    var body = new HashMap<String, Object>();
+    body.put("symbol", order.symbol());
+    body.put("side", order.side());
+    body.put("orderType", order.orderType());
+    body.put("quantity", order.quantity());
+    body.put("clientOrderId", order.clOrdId());
+    if (order.limitPrice() != null) {
+      body.put("limitPrice", order.limitPrice());
+    }
+    if (order.stopPrice() != null) {
+      body.put("stopPrice", order.stopPrice());
+    }
+    if (order.timeInForce() != null) {
+      body.put("tif", order.timeInForce());
+    }
+    try {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> response =
+          webClient
+              .post()
+              .uri("/api/execution/orders")
+              .bodyValue(body)
+              .retrieve()
+              .bodyToMono(Map.class)
+              .block();
+      if (response == null) {
+        return FixDownstreamResult.rejected("empty response from execution-engine");
+      }
+      var orderId = String.valueOf(response.get("orderId"));
+      var status = String.valueOf(response.get("status"));
+      if ("REJECTED".equals(status)) {
+        return FixDownstreamResult.rejected("rejected by execution-engine");
+      }
+      return FixDownstreamResult.accepted(orderId);
+    } catch (WebClientResponseException e) {
+      LOG.warn("execution-engine rejected FIX order {}: {}", order.clOrdId(), e.getStatusCode());
+      return FixDownstreamResult.rejected("execution-engine HTTP " + e.getStatusCode().value());
+    } catch (RuntimeException e) {
+      LOG.error("Failed to forward FIX order {} to execution-engine", order.clOrdId(), e);
+      return FixDownstreamResult.rejected("execution-engine unavailable");
+    }
+  }
+
+  /** Cancel a previously-submitted order via {@code DELETE /api/execution/orders/{id}}. */
+  public FixDownstreamResult cancelOrder(String downstreamOrderId) {
+    try {
+      webClient
+          .delete()
+          .uri("/api/execution/orders/{id}", downstreamOrderId)
+          .retrieve()
+          .toBodilessEntity()
+          .block();
+      return FixDownstreamResult.accepted(downstreamOrderId);
+    } catch (WebClientResponseException.NotFound e) {
+      return FixDownstreamResult.rejected("unknown or already-terminal order");
+    } catch (RuntimeException e) {
+      LOG.error("Failed to cancel order {} at execution-engine", downstreamOrderId, e);
+      return FixDownstreamResult.rejected("execution-engine unavailable");
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayMetrics.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayMetrics.java
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
-/** Counters for the inbound FIX gateway, scraped by Alloy at the api-gateway metrics endpoint. */
 @Component
 public class FixGatewayMetrics {
 

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayMetrics.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayMetrics.java
@@ -1,0 +1,38 @@
+package com.mariaalpha.apigateway.fix;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/** Counters for the inbound FIX gateway, scraped by Alloy at the api-gateway metrics endpoint. */
+@Component
+public class FixGatewayMetrics {
+
+  private final Counter accepted;
+  private final Counter rejected;
+  private final Counter cancelled;
+
+  public FixGatewayMetrics(MeterRegistry registry) {
+    this.accepted =
+        Counter.builder("mariaalpha.fix.orders.total")
+            .tag("outcome", "accepted")
+            .register(registry);
+    this.rejected =
+        Counter.builder("mariaalpha.fix.orders.total")
+            .tag("outcome", "rejected")
+            .register(registry);
+    this.cancelled = Counter.builder("mariaalpha.fix.cancels.total").register(registry);
+  }
+
+  public void recordAccepted() {
+    accepted.increment();
+  }
+
+  public void recordRejected() {
+    rejected.increment();
+  }
+
+  public void recordCancelled() {
+    cancelled.increment();
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayProperties.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayProperties.java
@@ -2,22 +2,6 @@ package com.mariaalpha.apigateway.fix;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Configuration for the inbound FIX 4.4 acceptor (roadmap 3.4.3).
- *
- * <p>Disabled by default — the acceptor opens a TCP listen socket, which we never want to do in
- * unit tests or CI. The message-translation and message-handling logic is exercised directly in
- * tests without starting the socket; flip {@code mariaalpha.fix.enabled=true} (e.g. in
- * docker-compose) to actually listen.
- *
- * @param enabled whether to start the FIX acceptor socket
- * @param host bind address for the acceptor
- * @param port listen port for the acceptor
- * @param senderCompId our SenderCompID (the venue side of the session)
- * @param targetCompId the expected client TargetCompID
- * @param heartbeatSeconds session heartbeat interval
- * @param executionEngineUrl base URL of execution-engine for order submission/cancel
- */
 @ConfigurationProperties(prefix = "mariaalpha.fix")
 public record FixGatewayProperties(
     boolean enabled,

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayProperties.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayProperties.java
@@ -1,0 +1,42 @@
+package com.mariaalpha.apigateway.fix;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for the inbound FIX 4.4 acceptor (roadmap 3.4.3).
+ *
+ * <p>Disabled by default — the acceptor opens a TCP listen socket, which we never want to do in
+ * unit tests or CI. The message-translation and message-handling logic is exercised directly in
+ * tests without starting the socket; flip {@code mariaalpha.fix.enabled=true} (e.g. in
+ * docker-compose) to actually listen.
+ *
+ * @param enabled whether to start the FIX acceptor socket
+ * @param host bind address for the acceptor
+ * @param port listen port for the acceptor
+ * @param senderCompId our SenderCompID (the venue side of the session)
+ * @param targetCompId the expected client TargetCompID
+ * @param heartbeatSeconds session heartbeat interval
+ * @param executionEngineUrl base URL of execution-engine for order submission/cancel
+ */
+@ConfigurationProperties(prefix = "mariaalpha.fix")
+public record FixGatewayProperties(
+    boolean enabled,
+    String host,
+    int port,
+    String senderCompId,
+    String targetCompId,
+    int heartbeatSeconds,
+    String executionEngineUrl) {
+
+  public FixGatewayProperties {
+    host = host == null || host.isBlank() ? "0.0.0.0" : host;
+    port = port == 0 ? 9878 : port;
+    senderCompId = senderCompId == null || senderCompId.isBlank() ? "MARIAALPHA" : senderCompId;
+    targetCompId = targetCompId == null || targetCompId.isBlank() ? "CLIENT" : targetCompId;
+    heartbeatSeconds = heartbeatSeconds == 0 ? 30 : heartbeatSeconds;
+    executionEngineUrl =
+        executionEngineUrl == null || executionEngineUrl.isBlank()
+            ? "http://localhost:8084"
+            : executionEngineUrl;
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayServer.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayServer.java
@@ -15,13 +15,6 @@ import quickfix.SessionID;
 import quickfix.SessionSettings;
 import quickfix.SocketAcceptor;
 
-/**
- * Starts and stops the QuickFIX/J {@link SocketAcceptor} as part of the Spring lifecycle. No-op
- * when {@code mariaalpha.fix.enabled=false} (the default) — so unit tests and CI never open a
- * listen socket. Session settings are built programmatically (no .cfg file); the FIX 4.4 data
- * dictionary is loaded from the {@code quickfixj-messages-fix44} jar on the classpath. Uses an
- * in-memory message store (no disk).
- */
 @Component
 public class FixGatewayServer implements SmartLifecycle {
 

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayServer.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixGatewayServer.java
@@ -1,0 +1,100 @@
+package com.mariaalpha.apigateway.fix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+import quickfix.Acceptor;
+import quickfix.DefaultMessageFactory;
+import quickfix.LogFactory;
+import quickfix.MemoryStoreFactory;
+import quickfix.MessageFactory;
+import quickfix.MessageStoreFactory;
+import quickfix.SLF4JLogFactory;
+import quickfix.SessionID;
+import quickfix.SessionSettings;
+import quickfix.SocketAcceptor;
+
+/**
+ * Starts and stops the QuickFIX/J {@link SocketAcceptor} as part of the Spring lifecycle. No-op
+ * when {@code mariaalpha.fix.enabled=false} (the default) — so unit tests and CI never open a
+ * listen socket. Session settings are built programmatically (no .cfg file); the FIX 4.4 data
+ * dictionary is loaded from the {@code quickfixj-messages-fix44} jar on the classpath. Uses an
+ * in-memory message store (no disk).
+ */
+@Component
+public class FixGatewayServer implements SmartLifecycle {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FixGatewayServer.class);
+
+  private final FixGatewayProperties properties;
+  private final FixApplication application;
+  private volatile Acceptor acceptor;
+  private volatile boolean running;
+
+  public FixGatewayServer(FixGatewayProperties properties, FixApplication application) {
+    this.properties = properties;
+    this.application = application;
+  }
+
+  @Override
+  public void start() {
+    if (!properties.enabled()) {
+      LOG.info("FIX gateway disabled (mariaalpha.fix.enabled=false)");
+      return;
+    }
+    try {
+      SessionSettings settings = buildSettings();
+      MessageStoreFactory storeFactory = new MemoryStoreFactory();
+      LogFactory logFactory = new SLF4JLogFactory(settings);
+      MessageFactory messageFactory = new DefaultMessageFactory();
+      acceptor =
+          new SocketAcceptor(application, storeFactory, settings, logFactory, messageFactory);
+      acceptor.start();
+      running = true;
+      LOG.info(
+          "FIX 4.4 acceptor listening on {}:{} (SenderCompID={})",
+          properties.host(),
+          properties.port(),
+          properties.senderCompId());
+    } catch (Exception e) {
+      LOG.error("Failed to start FIX acceptor on {}:{}", properties.host(), properties.port(), e);
+    }
+  }
+
+  @Override
+  public void stop() {
+    if (acceptor != null) {
+      acceptor.stop();
+      running = false;
+      LOG.info("FIX acceptor stopped");
+    }
+  }
+
+  @Override
+  public boolean isRunning() {
+    return running;
+  }
+
+  private SessionSettings buildSettings() {
+    SessionSettings settings = new SessionSettings();
+    settings.setString("ConnectionType", "acceptor");
+    settings.setString("SocketAcceptHost", properties.host());
+    settings.setLong("SocketAcceptPort", properties.port());
+    settings.setString("StartTime", "00:00:00");
+    settings.setString("EndTime", "00:00:00");
+
+    SessionID sessionId =
+        new SessionID("FIX.4.4", properties.senderCompId(), properties.targetCompId());
+    settings.setString(sessionId, "BeginString", "FIX.4.4");
+    settings.setString(sessionId, "SenderCompID", properties.senderCompId());
+    settings.setString(sessionId, "TargetCompID", properties.targetCompId());
+    settings.setString(sessionId, "ConnectionType", "acceptor");
+    settings.setString(sessionId, "StartTime", "00:00:00");
+    settings.setString(sessionId, "EndTime", "00:00:00");
+    settings.setLong(sessionId, "HeartBtInt", properties.heartbeatSeconds());
+    settings.setLong(sessionId, "SocketAcceptPort", properties.port());
+    settings.setString(sessionId, "DataDictionary", "FIX44.xml");
+    return settings;
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderSubmission.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderSubmission.java
@@ -1,0 +1,24 @@
+package com.mariaalpha.apigateway.fix;
+
+import java.math.BigDecimal;
+
+/**
+ * Normalised, broker-neutral view of an inbound FIX {@code NewOrderSingle (35=D)} after
+ * translation, ready to be forwarded to execution-engine's {@code POST /api/execution/orders}.
+ *
+ * <p>The gateway maps plain order types (MARKET / LIMIT / STOP / IOC / FOK / GTC). Algorithmic
+ * parent orders (VWAP/TWAP/POV/…) are intentionally <em>not</em> driven from FIX here: their
+ * per-strategy parameter shapes (volume profiles, participation rates, slice windows) are not
+ * expressible in standard FIX tags, so the REST {@code /api/algo/orders} surface remains the algo
+ * entry point. {@code side} / {@code orderType} / {@code timeInForce} are the MariaAlpha enum names
+ * so the value serialises straight into {@code SubmitOrderRequest}.
+ */
+public record FixOrderSubmission(
+    String clOrdId,
+    String symbol,
+    String side,
+    String orderType,
+    int quantity,
+    BigDecimal limitPrice,
+    BigDecimal stopPrice,
+    String timeInForce) {}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderSubmission.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderSubmission.java
@@ -2,17 +2,6 @@ package com.mariaalpha.apigateway.fix;
 
 import java.math.BigDecimal;
 
-/**
- * Normalised, broker-neutral view of an inbound FIX {@code NewOrderSingle (35=D)} after
- * translation, ready to be forwarded to execution-engine's {@code POST /api/execution/orders}.
- *
- * <p>The gateway maps plain order types (MARKET / LIMIT / STOP / IOC / FOK / GTC). Algorithmic
- * parent orders (VWAP/TWAP/POV/…) are intentionally <em>not</em> driven from FIX here: their
- * per-strategy parameter shapes (volume profiles, participation rates, slice windows) are not
- * expressible in standard FIX tags, so the REST {@code /api/algo/orders} surface remains the algo
- * entry point. {@code side} / {@code orderType} / {@code timeInForce} are the MariaAlpha enum names
- * so the value serialises straight into {@code SubmitOrderRequest}.
- */
 public record FixOrderSubmission(
     String clOrdId,
     String symbol,

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderTranslator.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderTranslator.java
@@ -1,0 +1,80 @@
+package com.mariaalpha.apigateway.fix;
+
+import java.math.BigDecimal;
+import quickfix.FieldNotFound;
+import quickfix.fix44.NewOrderSingle;
+
+/**
+ * Pure translator from a FIX 4.4 {@code NewOrderSingle} to a {@link FixOrderSubmission}. No I/O, no
+ * QuickFIX session state — every branch is unit-testable by constructing a {@code NewOrderSingle}.
+ *
+ * <p>Throws {@link IllegalArgumentException} for FIX values MariaAlpha does not support (unknown
+ * side, unsupported order type / TIF, missing required price), which the caller turns into a
+ * rejecting {@code ExecutionReport}.
+ */
+public final class FixOrderTranslator {
+
+  private FixOrderTranslator() {}
+
+  public static FixOrderSubmission translate(NewOrderSingle order) throws FieldNotFound {
+    var clOrdId = order.getClOrdID().getValue();
+    var symbol = order.getSymbol().getValue();
+    var side = mapSide(order.getSide().getValue());
+    var orderType = mapOrdType(order.getOrdType().getValue());
+    var quantity = (int) order.getOrderQty().getValue();
+    if (quantity <= 0) {
+      throw new IllegalArgumentException("OrderQty must be positive");
+    }
+
+    BigDecimal limitPrice = null;
+    if ("LIMIT".equals(orderType)) {
+      if (!order.isSetPrice()) {
+        throw new IllegalArgumentException("LIMIT order requires Price (44)");
+      }
+      limitPrice = BigDecimal.valueOf(order.getPrice().getValue());
+    }
+
+    BigDecimal stopPrice = null;
+    if ("STOP".equals(orderType)) {
+      if (!order.isSetStopPx()) {
+        throw new IllegalArgumentException("STOP order requires StopPx (99)");
+      }
+      stopPrice = BigDecimal.valueOf(order.getStopPx().getValue());
+    }
+
+    String tif = order.isSetTimeInForce() ? mapTif(order.getTimeInForce().getValue()) : null;
+
+    return new FixOrderSubmission(
+        clOrdId, symbol, side, orderType, quantity, limitPrice, stopPrice, tif);
+  }
+
+  // Switch on the FIX wire chars directly rather than QuickFIX field constants, whose generated
+  // names drift between data-dictionary versions (e.g. OrdType '3' is "STOP" in some, renamed in
+  // others). The chars are fixed by the FIX 4.4 specification.
+  static String mapSide(char fixSide) {
+    return switch (fixSide) {
+      case '1' -> "BUY";
+      case '2' -> "SELL";
+      default -> throw new IllegalArgumentException("Unsupported FIX Side (54): " + fixSide);
+    };
+  }
+
+  static String mapOrdType(char fixOrdType) {
+    return switch (fixOrdType) {
+      case '1' -> "MARKET";
+      case '2' -> "LIMIT";
+      case '3' -> "STOP";
+      default -> throw new IllegalArgumentException("Unsupported FIX OrdType (40): " + fixOrdType);
+    };
+  }
+
+  static String mapTif(char fixTif) {
+    return switch (fixTif) {
+      case '0' -> "DAY";
+      case '1' -> "GTC";
+      case '3' -> "IOC";
+      case '4' -> "FOK";
+      default -> throw new IllegalArgumentException("Unsupported FIX TimeInForce (59): " + fixTif);
+    };
+  }
+}

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderTranslator.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/fix/FixOrderTranslator.java
@@ -4,14 +4,6 @@ import java.math.BigDecimal;
 import quickfix.FieldNotFound;
 import quickfix.fix44.NewOrderSingle;
 
-/**
- * Pure translator from a FIX 4.4 {@code NewOrderSingle} to a {@link FixOrderSubmission}. No I/O, no
- * QuickFIX session state — every branch is unit-testable by constructing a {@code NewOrderSingle}.
- *
- * <p>Throws {@link IllegalArgumentException} for FIX values MariaAlpha does not support (unknown
- * side, unsupported order type / TIF, missing required price), which the caller turns into a
- * rejecting {@code ExecutionReport}.
- */
 public final class FixOrderTranslator {
 
   private FixOrderTranslator() {}
@@ -48,9 +40,6 @@ public final class FixOrderTranslator {
         clOrdId, symbol, side, orderType, quantity, limitPrice, stopPrice, tif);
   }
 
-  // Switch on the FIX wire chars directly rather than QuickFIX field constants, whose generated
-  // names drift between data-dictionary versions (e.g. OrdType '3' is "STOP" in some, renamed in
-  // others). The chars are fixed by the FIX 4.4 specification.
   static String mapSide(char fixSide) {
     return switch (fixSide) {
       case '1' -> "BUY";

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/health/DownstreamHealthChecker.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/health/DownstreamHealthChecker.java
@@ -10,11 +10,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-/**
- * Why Caffeine: every K8s readiness probe at 10 Hz × 5 downstreams = 50 outbound requests/sec just
- * from probes. Caffeine's 5-second TTL caps this at ~1 req/sec/downstream. The async API integrates
- * cleanly with Reactor.
- */
 @Component
 public class DownstreamHealthChecker {
 

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/security/ApiKeyAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/security/ApiKeyAuthenticationFilter.java
@@ -16,24 +16,13 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
-/**
- * Implemented as a {@link WebFilter} (not a Spring Cloud Gateway {@code GlobalFilter}) so it
- * intercepts every inbound HTTP request, including WebSocket upgrade {@code GET}s served by our own
- * {@code SimpleUrlHandlerMapping}. {@code GlobalFilter}s only run for routes resolved by {@code
- * RoutePredicateHandlerMapping}, which would let WS handshakes bypass auth.
- */
 @Component
 public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
 
-  /** Run before any handler mapping so we never open a backend connection on a 401. */
   public static final int ORDER = -100;
 
   private static final Logger LOG = LoggerFactory.getLogger(ApiKeyAuthenticationFilter.class);
 
-  /**
-   * AntPathMatcher is used here because it's designed specifically for path pattern matching rather
-   * than general-purpose regex
-   */
   private static final AntPathMatcher MATCHER = new AntPathMatcher();
 
   private static final String UNAUTHORIZED_BODY =

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/websocket/KafkaTopicBroadcaster.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/websocket/KafkaTopicBroadcaster.java
@@ -13,11 +13,6 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
-/**
- * Subscribes to the four MariaAlpha event topics and fans out each record to a per-topic {@link
- * reactor.core.publisher.Sinks.Many}. WebSocket handlers grab the corresponding {@link Flux} and
- * pipe it to their session.
- */
 @Component
 public class KafkaTopicBroadcaster {
 
@@ -54,7 +49,6 @@ public class KafkaTopicBroadcaster {
     sinks.clear();
   }
 
-  /** Subscribers obtain the {@link Flux} for a given topic. Returns an empty Flux if unknown. */
   public Flux<String> stream(String topic) {
     Sinks.Many<String> sink = sinks.get(topic);
     if (sink == null) {
@@ -63,9 +57,6 @@ public class KafkaTopicBroadcaster {
     }
     return sink.asFlux();
   }
-
-  // The four Kafka listeners. We deliberately use distinct annotated methods (rather than a single
-  // dynamic registration) so Spring's metrics tag each listener with its method name.
 
   @KafkaListener(
       topics = "${mariaalpha.gateway.websocket.endpoints.market-data.topic}",
@@ -103,9 +94,6 @@ public class KafkaTopicBroadcaster {
     forward(record);
   }
 
-  // Roadmap 3.4.5 — algo-execution progress: CREATED / CANCELLED / SIGNAL_EMITTED events
-  // emitted by strategy-engine each time an algo order's lifecycle advances. Subscribers see
-  // them on /ws/algo.
   @KafkaListener(
       topics = "${mariaalpha.gateway.websocket.endpoints.algo.topic}",
       groupId = "api-gateway-${random.uuid}-algo",
@@ -116,8 +104,6 @@ public class KafkaTopicBroadcaster {
   }
 
   private void forward(ConsumerRecord<String, String> record) {
-    // Key by the record's actual topic — the sinks map is built from the configured endpoint
-    // topics, so hardcoded literals here would silently drop everything if config diverged.
     Sinks.Many<String> sink = sinks.get(record.topic());
     if (sink == null) {
       return;

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/websocket/StreamingWebSocketHandler.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/websocket/StreamingWebSocketHandler.java
@@ -51,7 +51,6 @@ public class StreamingWebSocketHandler implements WebSocketHandler {
             sig -> LOG.info("ws {} session={} closed signal={}", name, session.getId(), sig));
   }
 
-  /** Tiny query-string parser to avoid pulling in Spring's UriComponents from a hot path. */
   private static String extractQuery(String query, String key) {
     if (query == null || key == null) {
       return null;

--- a/api-gateway/src/main/java/com/mariaalpha/apigateway/websocket/WebSocketRoutingConfig.java
+++ b/api-gateway/src/main/java/com/mariaalpha/apigateway/websocket/WebSocketRoutingConfig.java
@@ -33,8 +33,6 @@ public class WebSocketRoutingConfig {
                           name, endpoint.topic(), endpoint.filterKey(), broadcaster)));
     }
     var mapping = new SimpleUrlHandlerMapping(map);
-    // Higher precedence than SCG's own RoutePredicateHandlerMapping so the WS upgrades
-    // we own are not accidentally routed to a backend.
     mapping.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
     return mapping;
   }

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -72,6 +72,18 @@ mariaalpha:
         management-url: ${ANALYTICS_SERVICE_MANAGEMENT_URL:http://localhost:8095}
         required: true
 
+    # Inbound FIX 4.4 acceptor (roadmap 3.4.3). Disabled by default — set FIX_GATEWAY_ENABLED=true
+    # (e.g. in docker-compose) to open the listen socket. Translates NewOrderSingle /
+    # OrderCancelRequest into execution-engine REST calls and replies with ExecutionReport.
+    fix:
+      enabled: ${FIX_GATEWAY_ENABLED:false}
+      host: ${FIX_GATEWAY_HOST:0.0.0.0}
+      port: ${FIX_GATEWAY_PORT:9878}
+      sender-comp-id: ${FIX_SENDER_COMP_ID:MARIAALPHA}
+      target-comp-id: ${FIX_TARGET_COMP_ID:CLIENT}
+      heartbeat-seconds: ${FIX_HEARTBEAT_SECONDS:30}
+      execution-engine-url: ${EXECUTION_ENGINE_URL:http://localhost:8084}
+
     security:
       api-key: ${MARIAALPHA_API_KEY:}
       header-name: X-API-Key

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -49,6 +49,18 @@ spring:
             # the analytics-service registers its endpoints under /v1/.
 
 mariaalpha:
+  # Inbound FIX 4.4 acceptor (roadmap 3.4.3). Disabled by default — set FIX_GATEWAY_ENABLED=true
+  # (e.g. in docker-compose) to open the listen socket. Translates NewOrderSingle /
+  # OrderCancelRequest into execution-engine REST calls and replies with ExecutionReport.
+  fix:
+    enabled: ${FIX_GATEWAY_ENABLED:false}
+    host: ${FIX_GATEWAY_HOST:0.0.0.0}
+    port: ${FIX_GATEWAY_PORT:9878}
+    sender-comp-id: ${FIX_SENDER_COMP_ID:MARIAALPHA}
+    target-comp-id: ${FIX_TARGET_COMP_ID:CLIENT}
+    heartbeat-seconds: ${FIX_HEARTBEAT_SECONDS:30}
+    execution-engine-url: ${EXECUTION_ENGINE_URL:http://localhost:8084}
+
   gateway:
     downstreams:
       strategy-engine:
@@ -71,18 +83,6 @@ mariaalpha:
         url: ${ANALYTICS_SERVICE_URL:http://localhost:8095}
         management-url: ${ANALYTICS_SERVICE_MANAGEMENT_URL:http://localhost:8095}
         required: true
-
-    # Inbound FIX 4.4 acceptor (roadmap 3.4.3). Disabled by default — set FIX_GATEWAY_ENABLED=true
-    # (e.g. in docker-compose) to open the listen socket. Translates NewOrderSingle /
-    # OrderCancelRequest into execution-engine REST calls and replies with ExecutionReport.
-    fix:
-      enabled: ${FIX_GATEWAY_ENABLED:false}
-      host: ${FIX_GATEWAY_HOST:0.0.0.0}
-      port: ${FIX_GATEWAY_PORT:9878}
-      sender-comp-id: ${FIX_SENDER_COMP_ID:MARIAALPHA}
-      target-comp-id: ${FIX_TARGET_COMP_ID:CLIENT}
-      heartbeat-seconds: ${FIX_HEARTBEAT_SECONDS:30}
-      execution-engine-url: ${EXECUTION_ENGINE_URL:http://localhost:8084}
 
     security:
       api-key: ${MARIAALPHA_API_KEY:}

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixApplicationTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixApplicationTest.java
@@ -1,0 +1,124 @@
+package com.mariaalpha.apigateway.fix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import quickfix.SessionID;
+import quickfix.field.ClOrdID;
+import quickfix.field.OrdType;
+import quickfix.field.OrderQty;
+import quickfix.field.OrigClOrdID;
+import quickfix.field.Price;
+import quickfix.field.Side;
+import quickfix.field.Symbol;
+import quickfix.field.TransactTime;
+import quickfix.fix44.ExecutionReport;
+import quickfix.fix44.NewOrderSingle;
+import quickfix.fix44.OrderCancelReject;
+import quickfix.fix44.OrderCancelRequest;
+
+class FixApplicationTest {
+
+  private static final SessionID SESSION = new SessionID("FIX.4.4", "MARIAALPHA", "CLIENT");
+
+  private FixGatewayClient client;
+  private FixApplication app;
+
+  @BeforeEach
+  void setUp() {
+    client = mock(FixGatewayClient.class);
+    app = new FixApplication(client, new FixGatewayMetrics(new SimpleMeterRegistry()));
+  }
+
+  private NewOrderSingle limitOrder(String clOrdId) {
+    var nos =
+        new NewOrderSingle(
+            new ClOrdID(clOrdId),
+            new Side('1'),
+            new TransactTime(LocalDateTime.now(ZoneOffset.UTC)),
+            new OrdType('2'));
+    nos.set(new Symbol("AAPL"));
+    nos.set(new OrderQty(100));
+    nos.set(new Price(150.00));
+    return nos;
+  }
+
+  private OrderCancelRequest cancel(String origClOrdId, String clOrdId) {
+    var ocr =
+        new OrderCancelRequest(
+            new OrigClOrdID(origClOrdId),
+            new ClOrdID(clOrdId),
+            new Side('1'),
+            new TransactTime(LocalDateTime.now(ZoneOffset.UTC)));
+    ocr.set(new Symbol("AAPL"));
+    return ocr;
+  }
+
+  @Test
+  void newOrderAccepted_returnsNewExecutionReport() throws Exception {
+    when(client.submitOrder(any())).thenReturn(FixDownstreamResult.accepted("EXEC-1"));
+
+    var report = (ExecutionReport) app.handleNewOrderSingle(limitOrder("c1"), SESSION);
+
+    assertThat(report.getExecType().getValue()).isEqualTo('0');
+    assertThat(report.getOrdStatus().getValue()).isEqualTo('0');
+    assertThat(report.getOrderID().getValue()).isEqualTo("EXEC-1");
+    assertThat(report.getClOrdID().getValue()).isEqualTo("c1");
+  }
+
+  @Test
+  void newOrderRejectedDownstream_returnsRejectedExecutionReport() throws Exception {
+    when(client.submitOrder(any()))
+        .thenReturn(FixDownstreamResult.rejected("rejected by execution-engine"));
+
+    var report = (ExecutionReport) app.handleNewOrderSingle(limitOrder("c2"), SESSION);
+
+    assertThat(report.getExecType().getValue()).isEqualTo('8');
+    assertThat(report.getText().getValue()).contains("execution-engine");
+  }
+
+  @Test
+  void newOrderMissingSymbol_rejectsWithoutCallingDownstream() throws Exception {
+    var nos =
+        new NewOrderSingle(
+            new ClOrdID("c3"),
+            new Side('1'),
+            new TransactTime(LocalDateTime.now(ZoneOffset.UTC)),
+            new OrdType('1'));
+    nos.set(new OrderQty(100)); // no Symbol → FieldNotFound during translate
+
+    var report = (ExecutionReport) app.handleNewOrderSingle(nos, SESSION);
+
+    assertThat(report.getExecType().getValue()).isEqualTo('8');
+    verify(client, never()).submitOrder(any());
+  }
+
+  @Test
+  void cancelKnownOrder_returnsCanceledExecutionReport() throws Exception {
+    when(client.submitOrder(any())).thenReturn(FixDownstreamResult.accepted("EXEC-9"));
+    when(client.cancelOrder("EXEC-9")).thenReturn(FixDownstreamResult.accepted("EXEC-9"));
+    app.handleNewOrderSingle(limitOrder("c9"), SESSION); // registers c9 → EXEC-9
+
+    var report = (ExecutionReport) app.handleOrderCancelRequest(cancel("c9", "cxl9"), SESSION);
+
+    assertThat(report.getExecType().getValue()).isEqualTo('4');
+    assertThat(report.getOrigClOrdID().getValue()).isEqualTo("c9");
+  }
+
+  @Test
+  void cancelUnknownOrder_returnsOrderCancelReject() throws Exception {
+    var reject = (OrderCancelReject) app.handleOrderCancelRequest(cancel("ghost", "cxl0"), SESSION);
+
+    assertThat(reject.getText().getValue()).contains("unknown");
+    verify(client, never()).cancelOrder(any());
+  }
+}

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixApplicationTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixApplicationTest.java
@@ -73,8 +73,6 @@ class FixApplicationTest {
     assertThat(report.getOrdStatus().getValue()).isEqualTo('0');
     assertThat(report.getOrderID().getValue()).isEqualTo("EXEC-1");
     assertThat(report.getClOrdID().getValue()).isEqualTo("c1");
-    // Symbol (tag 55) is required on a FIX 4.4 ExecutionReport — without it a strict client
-    // rejects the ack and never sees the order acknowledged.
     assertThat(report.getSymbol().getValue()).isEqualTo("AAPL");
   }
 
@@ -97,7 +95,7 @@ class FixApplicationTest {
             new Side('1'),
             new TransactTime(LocalDateTime.now(ZoneOffset.UTC)),
             new OrdType('1'));
-    nos.set(new OrderQty(100)); // no Symbol → FieldNotFound during translate
+    nos.set(new OrderQty(100));
 
     var report = (ExecutionReport) app.handleNewOrderSingle(nos, SESSION);
 
@@ -109,7 +107,7 @@ class FixApplicationTest {
   void cancelKnownOrder_returnsCanceledExecutionReport() throws Exception {
     when(client.submitOrder(any())).thenReturn(FixDownstreamResult.accepted("EXEC-9"));
     when(client.cancelOrder("EXEC-9")).thenReturn(FixDownstreamResult.accepted("EXEC-9"));
-    app.handleNewOrderSingle(limitOrder("c9"), SESSION); // registers c9 → EXEC-9
+    app.handleNewOrderSingle(limitOrder("c9"), SESSION);
 
     var report = (ExecutionReport) app.handleOrderCancelRequest(cancel("c9", "cxl9"), SESSION);
 

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixApplicationTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixApplicationTest.java
@@ -73,6 +73,9 @@ class FixApplicationTest {
     assertThat(report.getOrdStatus().getValue()).isEqualTo('0');
     assertThat(report.getOrderID().getValue()).isEqualTo("EXEC-1");
     assertThat(report.getClOrdID().getValue()).isEqualTo("c1");
+    // Symbol (tag 55) is required on a FIX 4.4 ExecutionReport — without it a strict client
+    // rejects the ack and never sees the order acknowledged.
+    assertThat(report.getSymbol().getValue()).isEqualTo("AAPL");
   }
 
   @Test
@@ -112,6 +115,7 @@ class FixApplicationTest {
 
     assertThat(report.getExecType().getValue()).isEqualTo('4');
     assertThat(report.getOrigClOrdID().getValue()).isEqualTo("c9");
+    assertThat(report.getSymbol().getValue()).isEqualTo("AAPL");
   }
 
   @Test

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixOrderTranslatorTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/fix/FixOrderTranslatorTest.java
@@ -1,0 +1,113 @@
+package com.mariaalpha.apigateway.fix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import quickfix.field.ClOrdID;
+import quickfix.field.OrdType;
+import quickfix.field.OrderQty;
+import quickfix.field.Price;
+import quickfix.field.Side;
+import quickfix.field.StopPx;
+import quickfix.field.Symbol;
+import quickfix.field.TimeInForce;
+import quickfix.field.TransactTime;
+import quickfix.fix44.NewOrderSingle;
+
+class FixOrderTranslatorTest {
+
+  private NewOrderSingle order(char side, char ordType) {
+    var nos =
+        new NewOrderSingle(
+            new ClOrdID("c1"),
+            new Side(side),
+            new TransactTime(LocalDateTime.now(ZoneOffset.UTC)),
+            new OrdType(ordType));
+    nos.set(new Symbol("AAPL"));
+    nos.set(new OrderQty(100));
+    return nos;
+  }
+
+  @Test
+  void limitBuy_mapsAllFields() throws Exception {
+    var nos = order('1', '2');
+    nos.set(new Price(150.25));
+    nos.set(new TimeInForce('0'));
+
+    var sub = FixOrderTranslator.translate(nos);
+
+    assertThat(sub.clOrdId()).isEqualTo("c1");
+    assertThat(sub.symbol()).isEqualTo("AAPL");
+    assertThat(sub.side()).isEqualTo("BUY");
+    assertThat(sub.orderType()).isEqualTo("LIMIT");
+    assertThat(sub.quantity()).isEqualTo(100);
+    assertThat(sub.limitPrice()).isEqualByComparingTo("150.25");
+    assertThat(sub.stopPrice()).isNull();
+    assertThat(sub.timeInForce()).isEqualTo("DAY");
+  }
+
+  @Test
+  void marketSell_noPriceNoTif() throws Exception {
+    var sub = FixOrderTranslator.translate(order('2', '1'));
+
+    assertThat(sub.side()).isEqualTo("SELL");
+    assertThat(sub.orderType()).isEqualTo("MARKET");
+    assertThat(sub.limitPrice()).isNull();
+    assertThat(sub.timeInForce()).isNull();
+  }
+
+  @Test
+  void stopOrder_mapsStopPx() throws Exception {
+    var nos = order('1', '3');
+    nos.set(new StopPx(149.00));
+
+    var sub = FixOrderTranslator.translate(nos);
+
+    assertThat(sub.orderType()).isEqualTo("STOP");
+    assertThat(sub.stopPrice()).isEqualByComparingTo("149.00");
+  }
+
+  @Test
+  void limitWithoutPrice_throws() {
+    assertThatThrownBy(() -> FixOrderTranslator.translate(order('1', '2')))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Price");
+  }
+
+  @Test
+  void stopWithoutStopPx_throws() {
+    assertThatThrownBy(() -> FixOrderTranslator.translate(order('1', '3')))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("StopPx");
+  }
+
+  @Test
+  void unsupportedSide_throws() {
+    assertThatThrownBy(() -> FixOrderTranslator.translate(order('5', '1')))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Side");
+  }
+
+  @Test
+  void unsupportedOrdType_throws() {
+    assertThatThrownBy(() -> FixOrderTranslator.translate(order('1', '4')))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("OrdType");
+  }
+
+  @Test
+  void timeInForceMappings() throws Exception {
+    assertThat(tif('1')).isEqualTo("GTC");
+    assertThat(tif('3')).isEqualTo("IOC");
+    assertThat(tif('4')).isEqualTo("FOK");
+  }
+
+  private String tif(char fixTif) throws Exception {
+    var nos = order('1', '1');
+    nos.set(new TimeInForce(fixTif));
+    return FixOrderTranslator.translate(nos).timeInForce();
+  }
+}

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/health/DownstreamHealthCheckerTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/health/DownstreamHealthCheckerTest.java
@@ -63,8 +63,6 @@ class DownstreamHealthCheckerTest {
 
   @Test
   void reportsDownOnTimeout() {
-    // setHeadersDelay (not setBodyDelay) is required: toBodilessEntity completes once headers
-    // arrive, so a body-only delay is not observable.
     server.enqueue(new MockResponse().setHeadersDelay(2, java.util.concurrent.TimeUnit.SECONDS));
     var d = downstream(server.url("/").toString());
 
@@ -81,7 +79,6 @@ class DownstreamHealthCheckerTest {
     StepVerifier.create(checker.check("test", d)).expectNextCount(1).verifyComplete();
     StepVerifier.create(checker.check("test", d)).expectNextCount(1).verifyComplete();
 
-    // Only one HTTP call should have hit the server.
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/security/ApiKeyMatcherTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/security/ApiKeyMatcherTest.java
@@ -40,7 +40,6 @@ class ApiKeyMatcherTest {
 
   @Test
   void rejectsKeyOfDifferentLength() {
-    // MessageDigest.isEqual returns false for different lengths.
     assertThat(ApiKeyMatcher.matches("longerkey", "short")).isFalse();
   }
 }

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/websocket/KafkaTopicBroadcasterTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/websocket/KafkaTopicBroadcasterTest.java
@@ -47,7 +47,6 @@ class KafkaTopicBroadcasterTest {
         .expectNext("{\"symbol\":\"X\"}")
         .verifyComplete();
 
-    // Second subscriber sees the next message independently.
     StepVerifier.create(subB.take(1))
         .then(() -> broadcaster.onMarketData(record("market-data.ticks", "{\"symbol\":\"Y\"}")))
         .expectNext("{\"symbol\":\"Y\"}")

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/websocket/SymbolKeyExtractorTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/websocket/SymbolKeyExtractorTest.java
@@ -38,7 +38,6 @@ class SymbolKeyExtractorTest {
 
   @Test
   void handlesNestedJsonByReturningTopLevelOnly() {
-    // The first matching field wins. For our JSON schema this is the top-level field.
     assertThat(
             SymbolKeyExtractor.extract(
                 "{\"symbol\":\"AAPL\",\"meta\":{\"symbol\":\"OTHER\"}}", "symbol"))

--- a/api-gateway/src/test/java/com/mariaalpha/apigateway/websocket/WebSocketIntegrationTest.java
+++ b/api-gateway/src/test/java/com/mariaalpha/apigateway/websocket/WebSocketIntegrationTest.java
@@ -67,7 +67,6 @@ class WebSocketIntegrationTest {
                         .then())
             .subscribe();
 
-    // Wait for client to connect.
     Thread.sleep(2_000);
 
     producer.send(
@@ -87,9 +86,6 @@ class WebSocketIntegrationTest {
     var client = new ReactorNettyWebSocketClient();
     URI uri = URI.create("ws://localhost:" + port + "/ws/market-data");
 
-    // The WebFilter returns 401 before the upgrade completes. ReactorNettyWebSocketClient surfaces
-    // this as a failure on the Mono — assert that, otherwise a regression that lets the upgrade
-    // succeed without a key would silently pass.
     org.assertj.core.api.Assertions.assertThatThrownBy(
             () -> client.execute(uri, ws -> Mono.empty()).block(Duration.ofSeconds(5)))
         .isInstanceOf(Exception.class);

--- a/charts/mariaalpha/Chart.lock
+++ b/charts/mariaalpha/Chart.lock
@@ -54,7 +54,7 @@ dependencies:
   repository: https://charts.jetstack.io
   version: v1.20.2
 - name: sealed-secrets
-  repository: https://bitnami-labs.github.io/sealed-secrets
-  version: 2.18.6
-digest: sha256:8e2984b8f0770e519c46e12d5ee63efd68301c4d39b402423d4f5a4cc140db3e
-generated: "2026-06-02T19:55:26.201345+01:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.18.1
+digest: sha256:92d2222dc7234a3cd2a61142e31940a1b07f6dbd8c007a572e20986854ee0092
+generated: "2026-06-16T07:14:38.179555+01:00"

--- a/charts/mariaalpha/Chart.yaml
+++ b/charts/mariaalpha/Chart.yaml
@@ -88,7 +88,10 @@ dependencies:
     version: "v1.x.x"
     repository: https://charts.jetstack.io
     condition: cert-manager.enabled
+  # The legacy HTTP chart repo (bitnami-labs.github.io/sealed-secrets) was retired; the
+  # chart is now distributed via OCI. For OCI deps `repository` is the registry path and
+  # the chart name is appended from `name`, i.e. oci://registry-1.docker.io/bitnamicharts/sealed-secrets.
   - name: sealed-secrets
     version: "2.x.x"
-    repository: https://bitnami-labs.github.io/sealed-secrets
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: sealed-secrets.enabled

--- a/config/spotbugs/exclude-filter.xml
+++ b/config/spotbugs/exclude-filter.xml
@@ -402,6 +402,19 @@
         <Class name="com.mariaalpha.executionengine.pegged.PeggedMetrics"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
+    <!-- Program/basket trading (issue 3.4.1) -->
+    <Match>
+        <Class name="com.mariaalpha.executionengine.basket.BasketMetrics"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="com.mariaalpha.executionengine.basket.BasketView"/>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="com.mariaalpha.executionengine.controller.dto.BasketOrderRequest"/>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    </Match>
     <Match>
         <Class name="com.mariaalpha.executionengine.handler.PeggedOrderHandler"/>
         <Bug pattern="EI_EXPOSE_REP2"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,9 +409,12 @@ services:
       ANALYTICS_SERVICE_URL: http://analytics-service:8095
       ANALYTICS_SERVICE_MANAGEMENT_URL: http://analytics-service:8095
       MANAGEMENT_PORT: 8091
+      FIX_GATEWAY_ENABLED: "true"
+      FIX_GATEWAY_PORT: "9878"
     ports:
       - "8080:8080"
       - "8091:8091"
+      - "9878:9878"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8091/actuator/health/liveness"]
       interval: 5s

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,9 @@ Each *execution* strategy implements `TradingStrategy` and registers with the St
 |---|---|---|
 | Pegged orders | [`strategies/pegged-orders.md`](strategies/pegged-orders.md) | PEGGED order type: tracks midpoint / bid / ask, re-pricing as the NBBO moves. |
 | Trade allocation | [`strategies/trade-allocation.md`](strategies/trade-allocation.md) | Post-trade fill allocation across sub-accounts (pro-rata, FIFO). |
+| Program/basket trading | [`strategies/program-basket-trading.md`](strategies/program-basket-trading.md) | Multi-leg basket orders fanned out through the standard pipeline with aggregate tracking. |
 | Algo execution API | [`strategies/algo-execution-api.md`](strategies/algo-execution-api.md) | Programmatic REST + WebSocket surface for external algo clients. |
+| FIX gateway | [`strategies/fix-gateway.md`](strategies/fix-gateway.md) | Inbound FIX 4.4 acceptor (QuickFIX/J) for programmatic order entry. |
 | Multi-market trading hours | [`strategies/multi-market-trading-hours.md`](strategies/multi-market-trading-hours.md) | Session calendars gating strategy evaluation per listing market. |
 
 ---

--- a/docs/finance-mental-map.md
+++ b/docs/finance-mental-map.md
@@ -248,7 +248,7 @@ graph TB
     ADJMID --> BASE[+ base half-spread]
     BASE --> VOLW[+ vol widening]
     VOLW --> ADVW[+ ADV widening]
-    ADVW --> QUOTE[bid = adjMid × (1 − total_half_spread)<br/>ask = adjMid × (1 + total_half_spread)]
+    ADVW --> QUOTE["bid = adjMid × (1 − total_half_spread)<br/>ask = adjMid × (1 + total_half_spread)"]
 ```
 
 | Concept | Logic | Sign convention |
@@ -658,7 +658,7 @@ sequenceDiagram
     loop Each time bin
         SE->>ML: GetSignal(AAPL)
         ML-->>SE: LONG, conf=0.82 (§5)
-        SE->>SE: Strategy says BUY; ML confirms<br/>(§5.1 gate logic)
+        SE->>SE: Strategy says BUY, ML confirms<br/>(§5.1 gate logic)
         SE->>EE: OrderSignal (child slice)
 
         EE->>RC: Pre-trade risk (§7)

--- a/docs/strategies/fix-gateway.md
+++ b/docs/strategies/fix-gateway.md
@@ -1,0 +1,115 @@
+# FIX Protocol Gateway
+
+> **Roadmap:** [3.4.3 — FIX protocol gateway (QuickFIX/J) for inbound algo orders](https://github.com/drag0sd0g/MariaAlpha/issues/99).
+> **TDD reference:** §5.2.8 (API Gateway).
+
+## 1. What this is
+
+An inbound **FIX 4.4** acceptor that lets external buy-side systems send orders into MariaAlpha over
+the industry-standard wire protocol, in parallel to the REST `/api/execution/orders` and
+`/api/algo/orders` surfaces. It is a thin translation layer: a FIX `NewOrderSingle (35=D)` is decoded,
+mapped to MariaAlpha's order model, and forwarded to execution-engine's REST endpoint; the resulting
+order id (or rejection) comes back as a FIX `ExecutionReport (35=8)`.
+
+It lives in the **api-gateway** — the single front door for external clients — and is built on
+[QuickFIX/J](https://www.quickfixj.org/) 2.3.2.
+
+## 2. Scope
+
+The gateway handles plain order entry and cancellation:
+
+| Inbound (client → gateway) | Outbound (gateway → client) |
+| --- | --- |
+| `NewOrderSingle (35=D)` | `ExecutionReport (35=8)` — `ExecType=NEW`/`REJECTED` |
+| `OrderCancelRequest (35=F)` | `ExecutionReport` — `ExecType=CANCELED`, or `OrderCancelReject (35=9)` |
+
+**Algorithmic parent orders (VWAP/TWAP/POV/…) are intentionally not driven from FIX here.** Their
+per-strategy parameter shapes — volume profiles, participation rates, slice windows — are not
+expressible in standard FIX tags, so the REST [`/api/algo/orders`](algo-execution-api.md) surface
+remains the algo entry point. The FIX gateway covers the plain order types that map cleanly: MARKET,
+LIMIT, STOP, and the IOC/FOK/GTC time-in-force variants.
+
+## 3. Architecture
+
+```mermaid
+graph LR
+    CLIENT[FIX client] -->|NewOrderSingle / OrderCancelRequest| ACC[FixGatewayServer<br/>SocketAcceptor]
+    ACC --> APP[FixApplication<br/>MessageCracker]
+    APP -->|translate| TR[FixOrderTranslator]
+    APP -->|forward| CL[FixGatewayClient<br/>WebClient]
+    CL -->|POST /api/execution/orders<br/>DELETE /api/execution/orders/&#123;id&#125;| EE[execution-engine]
+    APP -->|ExecutionReport / OrderCancelReject| CLIENT
+```
+
+| Component | Responsibility |
+| --- | --- |
+| `FixGatewayServer` | `SmartLifecycle` bean that builds the QuickFIX/J `SessionSettings` programmatically (no `.cfg` file), starts a `SocketAcceptor` with an in-memory message store, and stops it on shutdown. **No-op unless `mariaalpha.fix.enabled=true`** — so unit tests and CI never open a socket. |
+| `FixApplication` | The QuickFIX/J `Application` + `MessageCracker`. Cracks inbound messages and dispatches to handler methods that **return** the response message (testable without a live session); the `onMessage` overrides are thin: handle, then `Session.sendToTarget`. Maintains a `ClOrdID → internal order id` map so a cancel (which carries the client's `OrigClOrdID`) resolves to the downstream order. |
+| `FixOrderTranslator` | Pure mapping from `NewOrderSingle` to a normalised `FixOrderSubmission`. Switches on FIX wire chars directly (not QuickFIX field constants, whose generated names drift between dictionary versions). Throws `IllegalArgumentException` for unsupported side / order type / TIF or a missing required price. |
+| `FixGatewayClient` | Forwards to execution-engine over `WebClient`. Called from QuickFIX worker threads, so the reactive calls are `block()`ed (never on a Netty event loop). These are internal service-to-service calls and carry no API key — the gateway is the auth edge. |
+| `FixGatewayMetrics` | Micrometer counters, scraped at the api-gateway metrics endpoint. |
+
+## 4. Field mapping
+
+| FIX tag | MariaAlpha field | Notes |
+| --- | --- | --- |
+| `Side (54)` | `side` | `1`→BUY, `2`→SELL; anything else rejected |
+| `OrdType (40)` | `orderType` | `1`→MARKET, `2`→LIMIT, `3`→STOP |
+| `OrderQty (38)` | `quantity` | must be positive |
+| `Price (44)` | `limitPrice` | required for LIMIT |
+| `StopPx (99)` | `stopPrice` | required for STOP |
+| `TimeInForce (59)` | `tif` | `0`→DAY, `1`→GTC, `3`→IOC, `4`→FOK |
+| `ClOrdID (11)` | `clientOrderId` | echoed back; used as the cancel key |
+
+A translation failure (unsupported value, missing required price/field) produces a rejecting
+`ExecutionReport` (`ExecType=REJECTED`, `OrdStatus=REJECTED`, `Text` = the reason) **without** calling
+execution-engine.
+
+## 5. Configuration
+
+Disabled by default. Enable and tune via `mariaalpha.fix.*` (env-overridable):
+
+```yaml
+mariaalpha:
+  fix:
+    enabled: ${FIX_GATEWAY_ENABLED:false}
+    host: ${FIX_GATEWAY_HOST:0.0.0.0}
+    port: ${FIX_GATEWAY_PORT:9878}
+    sender-comp-id: ${FIX_SENDER_COMP_ID:MARIAALPHA}   # our (venue) side
+    target-comp-id: ${FIX_TARGET_COMP_ID:CLIENT}       # expected client
+    heartbeat-seconds: ${FIX_HEARTBEAT_SECONDS:30}
+    execution-engine-url: ${EXECUTION_ENGINE_URL:http://localhost:8084}
+```
+
+The FIX 4.4 data dictionary (`FIX44.xml`) is loaded from the `quickfixj-messages-fix44` jar on the
+classpath; the message store is in-memory (no disk).
+
+## 6. Metrics
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `mariaalpha_fix_orders_total` | Counter | `outcome` = `accepted` \| `rejected` | Inbound `NewOrderSingle` outcomes |
+| `mariaalpha_fix_cancels_total` | Counter | — | Successful cancels |
+
+## 7. Limitations and roadmap notes
+
+- **One static session.** A single `SenderCompID`/`TargetCompID` pair is configured. Multi-session /
+  dynamic acceptor templates (one venue, many clients) are a follow-up.
+- **No order-status (`35=H`) or mass-cancel.** Only single-order new/cancel are handled; other
+  message types fall through `MessageCracker` as unsupported.
+- **No FIX-driven algo parents** — see §2. Standard FIX `TargetStrategy (847)` codes don't carry the
+  per-strategy parameters MariaAlpha's algos need; the REST algo API stays the entry point.
+- **Fills are not streamed back over FIX yet.** The gateway acks order acceptance; execution fills
+  flow on the `orders.lifecycle` Kafka topic and the `/ws/orders` WebSocket. Streaming asynchronous
+  fill `ExecutionReport`s back to the FIX session would require subscribing the gateway to that topic
+  and is a natural next step.
+
+## 8. Test coverage
+
+| Test | What it asserts |
+| --- | --- |
+| `FixOrderTranslatorTest` | Limit/market/stop field mapping; TIF mappings; missing-price and unsupported side/ord-type/TIF rejections. |
+| `FixApplicationTest` | Accepted order → `NEW` ExecutionReport with the downstream id; downstream rejection → `REJECTED` report; missing field → reject without calling downstream; cancel of a known order → `CANCELED` report; cancel of an unknown `OrigClOrdID` → `OrderCancelReject`. |
+
+The acceptor socket itself is config-gated off in tests; the message-handling logic is exercised
+directly by constructing FIX messages, so no port is opened during the build.

--- a/docs/strategies/program-basket-trading.md
+++ b/docs/strategies/program-basket-trading.md
@@ -1,0 +1,157 @@
+# Program / Basket Trading
+
+> **Roadmap:** [3.4.1 — Program / basket trading engine](https://github.com/drag0sd0g/MariaAlpha/issues/97).
+> **TDD reference:** §5.2.4 (Execution Engine).
+
+## 1. What this is
+
+A *basket* (or *program*) order is a set of independent legs — typically 15+ names — submitted and
+worked as one unit: index rebalances, portfolio transitions, ETF create/redeem, and stat-arb
+baskets all arrive this way. The basket engine accepts the whole list in one call, fans every leg
+out through the **standard single-order pipeline** (risk → SOR → venue), and tracks the aggregate so
+the desk can watch one number instead of N orders.
+
+It is deliberately **broker- and market-agnostic**: a basket is just a convenience layer on top of
+the execution pipeline that already ships. Every leg is an ordinary order — it gets the full ten-check
+risk chain, smart-order routing, and emits its own `orders.lifecycle` events — so a basket needs no
+new venue integration and works today against the simulated exchange and Alpaca alike.
+
+## 2. Design
+
+The engine mirrors the existing **coordinator + registry + progress** shape used by the
+[iceberg](pegged-orders.md) and pegged order types, adapted for a one-to-many fan-out rather than a
+sequential parent→child slice:
+
+```mermaid
+graph TD
+    REQ[POST /api/execution/baskets] --> SVC[BasketTradingService]
+    SVC -->|validate all legs first| SVC
+    SVC -->|register state + link each leg| REG[(BasketRegistry)]
+    SVC -->|submitOrder per leg| OES[OrderExecutionService]
+    OES -->|risk → SOR → venue| VEN[Venue adapters]
+    VEN -->|ExecutionReport| OES
+    OES -->|onExecutionReport hook| COORD[BasketCoordinator]
+    COORD -->|recordLegFill| REG
+    REG --> VIEW[BasketView snapshot]
+    GET[GET /api/execution/baskets/&#123;id&#125;] --> VIEW
+```
+
+| Component | Responsibility |
+| --- | --- |
+| `BasketTradingService` | Validates every leg up front (all-or-nothing), then fans the legs out via `OrderExecutionService.submitOrder`. Registers the basket and links each leg **before** submitting it, so a fill that races ahead of the synchronous submit return is still attributed. |
+| `BasketRegistry` | Thread-safe forward map (`basketId → BasketState`) and reverse map (`legOrderId → basketId`), mirroring `ParentChildOrderRegistry`. Routes a leg fill to its owning basket in O(1). |
+| `BasketState` / `BasketLeg` | Per-basket aggregate guarded by a single monitor. Derives `BasketStatus` from the legs and renders an immutable `BasketView`. |
+| `BasketCoordinator` | Hooked into `OrderExecutionService.onExecutionReport` alongside the iceberg/pegged coordinators. No-op for any order that is not a tracked basket leg; otherwise records the fill and the basket-completion metric. |
+
+### 2.1 Status derivation
+
+`BasketStatus` is computed from the legs, never stored:
+
+| Status | Condition |
+| --- | --- |
+| `REJECTED` | Every leg was rejected at submission (risk/validation) — nothing is working at any venue. |
+| `SUBMITTED` | At least one leg accepted; no fills yet. |
+| `PARTIALLY_FILLED` | Some quantity has filled but the accepted legs are not all complete. |
+| `FILLED` | Every accepted leg is fully filled. |
+
+Rejected legs are excluded from the basket's `targetQuantity`, so a basket of nine good legs and one
+risk-rejected leg still reaches `FILLED` when those nine complete — the rejected leg is reported but
+doesn't strand the aggregate.
+
+### 2.2 Ordering and races
+
+The simulated adapter can fill a marketable order *before* `submitOrder` returns. To avoid losing
+that fill, the service:
+
+1. registers the (empty) `BasketState` in the registry,
+2. adds the leg to the state and links `legOrderId → basketId`,
+3. **then** calls `submitOrder`.
+
+The leg's submission outcome (`SUBMITTED`/`REJECTED`) is applied afterwards but **never downgrades a
+leg that has already started filling** — `BasketLeg.applySubmissionOutcome` only promotes a `NEW`
+leg, leaving a raced `PARTIALLY_FILLED`/`FILLED` leg untouched.
+
+## 3. REST surface
+
+Reachable through the api-gateway's existing `/api/execution/**` route — no gateway change.
+
+| Endpoint | Body | Returns |
+| --- | --- | --- |
+| `POST /api/execution/baskets` | `BasketOrderRequest` | `202 Accepted` + `BasketView` |
+| `GET /api/execution/baskets/{basketId}` | — | `BasketView`, or `404` if unknown |
+| `GET /api/execution/baskets` | — | `BasketView[]` (all tracked baskets) |
+
+### 3.1 `POST /api/execution/baskets` example
+
+```json
+{
+  "name": "SP500-rebalance-2026-06-14",
+  "legs": [
+    { "symbol": "AAPL", "side": "BUY",  "orderType": "LIMIT",  "quantity": 100, "limitPrice": 151.00 },
+    { "symbol": "MSFT", "side": "BUY",  "orderType": "MARKET", "quantity": 50 },
+    { "symbol": "TSLA", "side": "SELL", "orderType": "LIMIT",  "quantity": 25,  "limitPrice": 240.00 }
+  ]
+}
+```
+
+→ `202 Accepted`
+
+```json
+{
+  "basketId": "f1c0…",
+  "name": "SP500-rebalance-2026-06-14",
+  "status": "SUBMITTED",
+  "totalLegs": 3,
+  "acceptedLegs": 3,
+  "rejectedLegs": 0,
+  "filledLegs": 0,
+  "targetQuantity": 175,
+  "filledQuantity": 0,
+  "legs": [
+    { "legOrderId": "…", "symbol": "AAPL", "side": "BUY", "targetQuantity": 100, "filledQuantity": 0, "status": "SUBMITTED", "reason": null }
+  ]
+}
+```
+
+### 3.2 Validation
+
+Validation is **all-or-nothing**: the whole request is rejected (`400`) before any leg is sent to a
+venue if any leg is malformed.
+
+- `400 Bad Request` — empty `legs`; a `LIMIT` leg without `limitPrice`; a `STOP` leg without
+  `stopPrice`; a leg using a parent-managed order type (`ICEBERG`, `PEGGED`) — those carry their own
+  per-order coordinator state a basket does not model.
+- Per-leg risk/validation failures are **not** request errors: the basket is still created and the
+  failing leg is reported as a `REJECTED` leg in the `BasketView`.
+
+## 4. Metrics
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `mariaalpha_execution_basket_submitted_total` | Counter | — | Baskets submitted |
+| `mariaalpha_execution_basket_legs_total` | Counter | — | Legs submitted (Σ legs / Σ baskets ≈ average basket width) |
+| `mariaalpha_execution_basket_legs_rejected_total` | Counter | `symbol` | Legs rejected at submission |
+| `mariaalpha_execution_basket_legs_filled_total` | Counter | `symbol`, `side` | Legs fully filled |
+| `mariaalpha_execution_basket_duration_ms` | Timer | — | Submit → fully-filled wall time |
+
+## 5. Limitations and roadmap notes
+
+- **No basket-level cancel yet.** Individual legs can be cancelled via
+  `DELETE /api/execution/orders/{legOrderId}`; a single `DELETE /api/execution/baskets/{id}` that
+  cascades to all working legs is a natural follow-up.
+- **Allocation is a separate step.** A filled basket is the natural input to
+  [trade allocation (3.4.2)](trade-allocation.md) — one allocation run per leg. Wiring the two
+  together end-to-end is left as an integration follow-up.
+- **No netting / crossing across legs.** Offsetting BUY/SELL legs in the same name are submitted
+  independently; internal crossing happens (if at all) at the venue/SOR layer, not in the basket.
+
+## 6. Test coverage
+
+| Test | What it asserts |
+| --- | --- |
+| `BasketStateTest` | Status derivation for submitted / rejected / mixed / partial; rejected legs excluded from target; a raced fill is never downgraded by a late submission outcome; unknown-leg fill is a no-op. |
+| `BasketRegistryTest` | Fill attribution to the owning basket; unknown leg returns empty; completed leg is unlinked so stray duplicate fills are ignored; `view`/`all`. |
+| `BasketCoordinatorTest` | Full and partial leg fills update the aggregate; no-op for an order that is not a basket leg. |
+| `BasketTradingServiceTest` | Fan-out submits every leg; mixed accept/reject; all-rejected ⇒ `REJECTED`; legs are linked so fills attribute; up-front validation rejects bad requests before any venue call. |
+| `BasketControllerTest` | `202` on submit; `400` on empty legs; `200`/`404` on lookup. |
+| `BasketTradingIntegrationTest` (integration) | Two-leg basket against the simulated adapter + Testcontainers Kafka reaches `FILLED` with both legs filled. |

--- a/docs/technical-design-document.md
+++ b/docs/technical-design-document.md
@@ -632,6 +632,14 @@ public interface ExchangeAdapter {
 }
 ```
 
+**Program/basket trading (roadmap 3.4.1 — delivered):** `BasketTradingService` accepts a list of
+legs and fans each out through the standard single-order pipeline (`OrderExecutionService.submitOrder`
+→ risk → SOR → venue), so every leg gets the full risk chain and emits its own `orders.lifecycle`
+events. A `BasketRegistry`/`BasketCoordinator` pair tracks the aggregate — the coordinator is hooked
+into `onExecutionReport` alongside the iceberg/pegged coordinators and is a no-op for non-basket
+orders. Exposed under `POST/GET /api/execution/baskets`. Broker- and market-agnostic. Full design in
+[`strategies/program-basket-trading.md`](strategies/program-basket-trading.md).
+
 #### 5.2.5 Order Manager
 
 | Property | Value |
@@ -684,6 +692,13 @@ Exposed Prometheus metrics: `mariaalpha_analytics_toxicity_markout_bps`, `mariaa
 | **Role** | Unified REST + WebSocket entry point for the React UI, programmatic consumers, and external algo clients (REST + WebSocket today; FIX gateway on the roadmap) |
 
 Routes: `/api/market-data/**`, `/api/strategies/**`, `/api/rfq/**`, `/api/options/**`, `/api/algo/**`, `/api/orders/**`, `/api/positions/**`, `/api/portfolio/**`, `/api/execution/**`, `/api/routing/**`, `/api/analytics/**`, `/api/tca/**`, `/api/recon/**`, `/api/allocations/**`. WebSocket endpoints: `/ws/market-data`, `/ws/positions`, `/ws/orders`, `/ws/alerts`, `/ws/algo`.
+
+**FIX gateway (roadmap 3.4.3 — delivered):** an inbound QuickFIX/J FIX 4.4 acceptor that decodes
+`NewOrderSingle`/`OrderCancelRequest`, forwards them to execution-engine's REST surface, and replies
+with `ExecutionReport`/`OrderCancelReject`. It is the FIX-protocol sibling of the REST order-entry
+path and is **disabled by default** (`mariaalpha.fix.enabled=false`) so it never opens a socket in
+tests/CI. Algorithmic parent orders stay on the REST `/api/algo/**` surface — standard FIX tags can't
+carry MariaAlpha's per-strategy parameters. Full design in [`strategies/fix-gateway.md`](strategies/fix-gateway.md).
 
 #### 5.2.9 React UI
 
@@ -1376,9 +1391,10 @@ presented and worked in their natural numeric order — finish the feature expan
 **Work order as of 2026-06-14:**
 
 1. **Phase 3 — Multi-Market & Derivatives Capabilities.** Feature expansion: IBKR broker
-   integration, Tokyo Stock Exchange microstructure, program/basket trading, and the FIX gateway.
-   Several 3.x items have already shipped (options pricing, pegged orders, trade allocation, the
-   algo execution API, VaR/correlation/currency risk, multi-market hours) and are no longer listed.
+   integration and Tokyo Stock Exchange microstructure. Several 3.x items have already shipped
+   (options pricing, pegged orders, trade allocation, the algo execution API, program/basket
+   trading, the FIX gateway, VaR/correlation/currency risk, multi-market hours) and are no longer
+   listed.
 2. **Phase 4 — Advanced Platform Features.** Operational and analytical depth: RBAC, model
    retraining, portfolio optimization, ML-driven SOR.
 3. **Phase 5 — Validation & Productionisation.** The evidence-gathering and hardening phase:
@@ -1391,12 +1407,13 @@ GitHub issues; the phases are presented below in that same ascending order.
 
 ### Phase 3: Multi-Market & Derivatives Capabilities
 
-Broker integration with Interactive Brokers, Japanese-market microstructure rules, and
-program/basket trading. These extend MariaAlpha beyond a single broker (Alpaca, US equities) into
-multi-asset, multi-region territory. Several 3.x items have already shipped and are documented under
-[`docs/strategies/`](strategies/) — options pricing & Greeks, pegged orders, trade allocation, the
-algo execution API, intraday VaR, correlated-position limits, currency exposure, and multi-market
-trading hours — so only the open backlog is listed below.
+Broker integration with Interactive Brokers and Japanese-market microstructure rules. These extend
+MariaAlpha beyond a single broker (Alpaca, US equities) into multi-asset, multi-region territory.
+Several 3.x items have already shipped and are documented under `docs/strategies/` — options pricing
+& Greeks, pegged orders, [program/basket trading](strategies/program-basket-trading.md), the
+[FIX gateway](strategies/fix-gateway.md), trade allocation, the algo execution API, intraday VaR,
+correlated-position limits, currency exposure, and multi-market trading hours — so only the open
+backlog is listed below.
 
 | # | Issue Title | Component |
 | --- | --- | --- |
@@ -1406,8 +1423,6 @@ trading hours — so only the open backlog is listed below.
 | [3.3.2](https://github.com/drag0sd0g/MariaAlpha/issues/94) | Implement auction session handling (Itayose, closing) | Market Data GW |
 | [3.3.3](https://github.com/drag0sd0g/MariaAlpha/issues/95) | Implement daily price limit enforcement | Execution Engine |
 | [3.3.4](https://github.com/drag0sd0g/MariaAlpha/issues/96) | Implement short-selling uptick rule | Execution Engine |
-| [3.4.1](https://github.com/drag0sd0g/MariaAlpha/issues/97) | Implement program / basket trading engine | Execution Engine |
-| [3.4.3](https://github.com/drag0sd0g/MariaAlpha/issues/99) | Implement FIX protocol gateway (QuickFIX/J) for inbound algo orders | API Gateway |
 
 ### Phase 4: Advanced Platform Features
 

--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -13,25 +13,23 @@ dependencies {
     testImplementation("org.awaitility:awaitility:4.2.2")
     testImplementation("ch.qos.logback:logback-classic:1.5.32")
     testImplementation("org.codehaus.janino:janino:3.1.12")
-    // Regime classifier e2e calls GetRegime directly over gRPC.
     testImplementation(project(":proto"))
     testImplementation(libs.grpc.netty.shaded)
     testImplementation(libs.grpc.stub)
     testImplementation(libs.grpc.protobuf)
+    testImplementation(libs.quickfixj.core)
+    testImplementation(libs.quickfixj.messages.fix44)
 }
 
 
 tasks.named<Test>("test") {
     useJUnitPlatform {
-        // Default behaviour mirrors root build.gradle.kts: opt-in via -PincludeTags=e2e.
         if (project.hasProperty("includeTags")) {
             includeTags(project.property("includeTags") as String)
         } else {
             excludeTags("e2e")
         }
     }
-    // The test boots ~10 containers; double the default JVM heap so logs and JSON deserialisation
-    // don't OOM.
     maxHeapSize = "1g"
     testLogging {
         events("passed", "skipped", "failed")

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/AlgoExecutionApiE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/AlgoExecutionApiE2ETest.java
@@ -16,16 +16,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-/**
- * Exercises the algorithmic-execution REST surface (roadmap 3.4.4): submit a parent order
- * programmatically, query it back, list, and cancel it. Lightweight on assertions — the wired
- * unit + controller tests cover the request/response shape; this test class proves the
- * end-to-end gateway → strategy-engine route + JSON serialisation work in the running stack.
- *
- * <p>Note: filled-quantity progress is intentionally not asserted here — that requires algoOrderId
- * propagation through the signal → execution → order-manager chain, which is a future-work item
- * captured in docs/strategies/algo-execution-api.md.
- */
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AlgoExecutionApiE2ETest {
@@ -47,7 +37,6 @@ class AlgoExecutionApiE2ETest {
   @AfterEach
   void cleanup() throws Exception {
     if (createdAlgoOrderId != null) {
-      // Best-effort cancel so a subsequent test (or test re-run) doesn't see a leftover binding.
       httpClient.send(
           HttpRequest.newBuilder()
               .uri(URI.create(baseUrl + "/api/algo/orders/" + createdAlgoOrderId))
@@ -58,7 +47,6 @@ class AlgoExecutionApiE2ETest {
           HttpResponse.BodyHandlers.discarding());
       createdAlgoOrderId = null;
     }
-    // Also unbind any symbol an algo might have routed (mirrors the SimulatedHappyPath pattern).
     for (String symbol : new String[] {"AAPL", "MSFT", "GOOGL", "AMZN", "TSLA", "NVDA"}) {
       try {
         httpClient.send(
@@ -70,7 +58,6 @@ class AlgoExecutionApiE2ETest {
                 .build(),
             HttpResponse.BodyHandlers.discarding());
       } catch (Exception ignored) {
-        // best-effort cleanup
       }
     }
   }
@@ -99,12 +86,10 @@ class AlgoExecutionApiE2ETest {
     assertThat(submitted.get("strategyName").asText()).isEqualTo("TWAP");
     createdAlgoOrderId = submitted.get("algoOrderId").asText();
 
-    // GET round-trips the same record.
     var fetched = httpGet("/api/algo/orders/" + createdAlgoOrderId, 200);
     assertThat(fetched.get("algoOrderId").asText()).isEqualTo(createdAlgoOrderId);
     assertThat(fetched.get("status").asText()).isEqualTo("ACTIVE");
 
-    // LIST contains the freshly-created order.
     var list = httpGet("/api/algo/orders", 200);
     assertThat(list.isArray()).isTrue();
     boolean found = false;
@@ -116,10 +101,9 @@ class AlgoExecutionApiE2ETest {
     }
     assertThat(found).as("listed algo orders must include the just-submitted one").isTrue();
 
-    // DELETE transitions to CANCELLED.
     var cancelled = httpDelete("/api/algo/orders/" + createdAlgoOrderId, 200);
     assertThat(cancelled.get("status").asText()).isEqualTo("CANCELLED");
-    createdAlgoOrderId = null; // already cancelled; the @AfterEach cleanup can be skipped.
+    createdAlgoOrderId = null;
   }
 
   @Test

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/AlgoExecutionApiE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/AlgoExecutionApiE2ETest.java
@@ -58,6 +58,7 @@ class AlgoExecutionApiE2ETest {
                 .build(),
             HttpResponse.BodyHandlers.discarding());
       } catch (Exception ignored) {
+        // best-effort cleanup
       }
     }
   }

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/AnalyticsServiceE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/AnalyticsServiceE2ETest.java
@@ -17,15 +17,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-/**
- * E2E coverage for the analytics-service (issues 2.2.4 / 2.2.5 / 2.2.6). Brings up the full
- * docker-compose stack and verifies the analytics REST surface is reachable through the API
- * gateway, exercising axe-publish + match-suggest and Prometheus metrics scraping.
- *
- * <p>The flow-toxicity and PnL-attribution endpoints both require Kafka traffic ({@code
- * analytics.tca}, {@code market-data.ticks}) before they have data to report; we only assert the
- * endpoints are reachable and return the documented empty-state JSON.
- */
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AnalyticsServiceE2ETest {
@@ -87,7 +78,6 @@ class AnalyticsServiceE2ETest {
     var publishJson = MAPPER.readTree(publishResp.body());
     assertThat(publishJson.get("axeId").asText()).isEqualTo(axeId);
 
-    // Within a short window the listing endpoint should report the axe back.
     await()
         .atMost(5, TimeUnit.SECONDS)
         .pollInterval(Duration.ofMillis(250))
@@ -102,7 +92,6 @@ class AnalyticsServiceE2ETest {
 
   @Test
   void prometheusMetricsExposedOnDirectPort() throws Exception {
-    // The Alloy scraper reaches the service directly on port 8095. Verify the surface is up.
     var resp =
         httpClient.send(
             HttpRequest.newBuilder()

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/BasketTradingE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/BasketTradingE2ETest.java
@@ -36,9 +36,6 @@ class BasketTradingE2ETest {
 
   @Test
   void submitMarketBasketThroughGatewayReachesFilled() throws Exception {
-    // Retry the whole basket until every leg is accepted — early after stack start the
-    // execution-engine may not yet have a market-state snapshot for a symbol, which would reject a
-    // leg. Each retry creates a fresh (discarded) basket; once market data is warm all legs accept.
     var basket =
         await()
             .atMost(60, TimeUnit.SECONDS)
@@ -50,7 +47,6 @@ class BasketTradingE2ETest {
     assertThat(basket.get("totalLegs").asInt()).isEqualTo(2);
     assertThat(basket.get("acceptedLegs").asInt()).isEqualTo(2);
 
-    // MARKET legs cross on the simulated adapter; the basket coordinator aggregates the fills.
     var filled =
         await()
             .atMost(60, TimeUnit.SECONDS)
@@ -61,7 +57,6 @@ class BasketTradingE2ETest {
     assertThat(filled.get("filledLegs").asInt()).isEqualTo(2);
     assertThat(filled.get("filledQuantity").asInt()).isEqualTo(5);
 
-    // The basket appears in the list endpoint.
     var list = httpGet("/api/execution/baskets", 200);
     boolean found = false;
     for (var entry : list) {
@@ -88,7 +83,6 @@ class BasketTradingE2ETest {
     assertThat(resp.statusCode()).as("LIMIT leg without price → %s", resp.body()).isEqualTo(400);
   }
 
-  /** Submit a 2-leg MARKET basket; return the view only if every leg was accepted, else null. */
   private JsonNode submitFullyAcceptedBasket() throws Exception {
     var body =
         "{\"name\":\"e2e-rebalance\",\"legs\":["

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/BasketTradingE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/BasketTradingE2ETest.java
@@ -1,0 +1,137 @@
+package com.mariaalpha.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@Tag("e2e")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BasketTradingE2ETest {
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
+  private final String apiKey = SharedComposeStack.get().apiKey();
+  private final String baseUrl = SharedComposeStack.get().gatewayBaseUrl();
+  private HttpClient httpClient;
+
+  @BeforeAll
+  void startStack() {
+    SharedComposeStack.get().start();
+    httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+  }
+
+  @Test
+  void submitMarketBasketThroughGatewayReachesFilled() throws Exception {
+    // Retry the whole basket until every leg is accepted — early after stack start the
+    // execution-engine may not yet have a market-state snapshot for a symbol, which would reject a
+    // leg. Each retry creates a fresh (discarded) basket; once market data is warm all legs accept.
+    var basket =
+        await()
+            .atMost(60, TimeUnit.SECONDS)
+            .pollInterval(Duration.ofSeconds(2))
+            .ignoreExceptions()
+            .until(this::submitFullyAcceptedBasket, b -> b != null);
+
+    var basketId = basket.get("basketId").asText();
+    assertThat(basket.get("totalLegs").asInt()).isEqualTo(2);
+    assertThat(basket.get("acceptedLegs").asInt()).isEqualTo(2);
+
+    // MARKET legs cross on the simulated adapter; the basket coordinator aggregates the fills.
+    var filled =
+        await()
+            .atMost(60, TimeUnit.SECONDS)
+            .pollInterval(Duration.ofMillis(500))
+            .ignoreExceptions()
+            .until(() -> getBasket(basketId), b -> "FILLED".equals(b.get("status").asText()));
+
+    assertThat(filled.get("filledLegs").asInt()).isEqualTo(2);
+    assertThat(filled.get("filledQuantity").asInt()).isEqualTo(5);
+
+    // The basket appears in the list endpoint.
+    var list = httpGet("/api/execution/baskets", 200);
+    boolean found = false;
+    for (var entry : list) {
+      if (basketId.equals(entry.get("basketId").asText())) {
+        found = true;
+        break;
+      }
+    }
+    assertThat(found).as("listed baskets must include the just-submitted one").isTrue();
+  }
+
+  @Test
+  void emptyBasketIsRejected() throws Exception {
+    var resp = postRaw("/api/execution/baskets", "{\"name\":\"empty\",\"legs\":[]}");
+    assertThat(resp.statusCode()).as("empty basket → %s", resp.body()).isEqualTo(400);
+  }
+
+  @Test
+  void limitLegWithoutPriceIsRejected() throws Exception {
+    var body =
+        "{\"name\":\"bad\",\"legs\":[{\"symbol\":\"AAPL\",\"side\":\"BUY\","
+            + "\"orderType\":\"LIMIT\",\"quantity\":10}]}";
+    var resp = postRaw("/api/execution/baskets", body);
+    assertThat(resp.statusCode()).as("LIMIT leg without price → %s", resp.body()).isEqualTo(400);
+  }
+
+  /** Submit a 2-leg MARKET basket; return the view only if every leg was accepted, else null. */
+  private JsonNode submitFullyAcceptedBasket() throws Exception {
+    var body =
+        "{\"name\":\"e2e-rebalance\",\"legs\":["
+            + "{\"symbol\":\"GOOGL\",\"side\":\"BUY\",\"orderType\":\"MARKET\",\"quantity\":3},"
+            + "{\"symbol\":\"AMZN\",\"side\":\"BUY\",\"orderType\":\"MARKET\",\"quantity\":2}"
+            + "]}";
+    var resp = postRaw("/api/execution/baskets", body);
+    if (resp.statusCode() != 202) {
+      return null;
+    }
+    var view = MAPPER.readTree(resp.body());
+    return view.get("acceptedLegs").asInt() == view.get("totalLegs").asInt() ? view : null;
+  }
+
+  private JsonNode getBasket(String basketId) throws Exception {
+    return httpGet("/api/execution/baskets/" + basketId, 200);
+  }
+
+  private JsonNode httpGet(String path, int expectedStatus) throws Exception {
+    var response =
+        httpClient.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .header("X-API-Key", apiKey)
+                .GET()
+                .timeout(Duration.ofSeconds(5))
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode())
+        .as("GET %s → %d / body=%s", path, response.statusCode(), response.body())
+        .isEqualTo(expectedStatus);
+    return MAPPER.readTree(response.body());
+  }
+
+  private HttpResponse<String> postRaw(String path, String body) throws Exception {
+    return httpClient.send(
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + path))
+            .header("X-API-Key", apiKey)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .timeout(Duration.ofSeconds(5))
+            .build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/ExtendedRiskChecksE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/ExtendedRiskChecksE2ETest.java
@@ -22,21 +22,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-/**
- * E2E coverage for the sector / beta / ADV-participation risk checks. Brings up the full
- * docker-compose stack with the ADV-participation limit tightened via env override to a tiny
- * fraction (0.0000001 ≈ ~6 AAPL shares trigger), then verifies a manual order above that limit
- * comes back REJECTED with {@code AdvParticipation} as the failing check.
- *
- * <p>The sector / beta exposure checks are exercised by the unit + integration tests — they
- * require an accumulated position book to fire, which is harder to set up deterministically in a
- * docker-compose stack.
- */
-// Runs LAST among the e2e suite (ClassOrderer.OrderAnnotation, see junit-platform.properties).
-// `ClassOrderer.OrderAnnotation` treats unannotated classes as having order Integer.MAX_VALUE/2,
-// so this annotation must exceed that — MAX_VALUE guarantees this class runs after every
-// shared-stack class. The setUp tears down the SharedComposeStack to swap in its own
-// ADV-tightened stack; every shared-stack test must complete before that destruction is safe.
 @Order(Integer.MAX_VALUE)
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -59,9 +44,6 @@ class ExtendedRiskChecksE2ETest {
 
   @BeforeAll
   void startStack() throws Exception {
-    // Release the SharedComposeStack first so its ComposeContainer handle doesn't fight ours over
-    // the same compose project name ("mariaalpha"). Without this, our `compose up -d --build`
-    // exits with code 1 and Testcontainers reports an opaque ContainerLaunchException.
     SharedComposeStack.get().stopIfRunning();
     var dockerComposeFile = new File("../docker-compose.yml");
     new ProcessBuilder(
@@ -85,8 +67,6 @@ class ExtendedRiskChecksE2ETest {
             .withEnv("POSTGRES_DB", "mariaalpha")
             .withEnv("ALPACA_API_KEY_ID", "unused")
             .withEnv("ALPACA_API_SECRET_KEY", "unused")
-            // Tighten ADV participation so a 6-share AAPL order trips the check.
-            // (AAPL ADV = 60M; 1e-7 × 60M = 6 shares.)
             .withEnv("EXECUTION_ENGINE_RISK_MAX_ADV_PARTICIPATION", "0.0000001")
             .withBuild(true)
             .withRemoveVolumes(true)
@@ -108,8 +88,6 @@ class ExtendedRiskChecksE2ETest {
   void manualOrderAboveAdvParticipationLimitIsRejected() throws Exception {
     var orderId = submitManualOrder("AAPL", "BUY", 100);
 
-    // The Kafka-orderdb lag is bounded; the order-manager persists the REJECTED state shortly
-    // after the execution-engine fires the lifecycle event.
     var order =
         await()
             .atMost(20, TimeUnit.SECONDS)
@@ -120,15 +98,10 @@ class ExtendedRiskChecksE2ETest {
     assertThat(order.get("status").asText())
         .as("100-share AAPL order with ADV participation cap at 1e-7 must be rejected")
         .isEqualTo("REJECTED");
-    // The rejection reason is published on the orders.lifecycle topic but order-manager doesn't
-    // persist it on the OrderResponse DTO today. Reason-text assertions live in the unit and
-    // integration tests where the chain is reachable directly.
   }
 
   @Test
   void smallNormalOrderStillPassesTheChain() throws Exception {
-    // Establish that the chain still admits normal flow — a 1-share order is well below every
-    // configured limit even with the ADV check tightened.
     var orderId = submitManualOrder("AAPL", "BUY", 1);
     var order =
         await()

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/FixGatewayE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/FixGatewayE2ETest.java
@@ -97,12 +97,12 @@ class FixGatewayE2ETest {
     var nos =
         new NewOrderSingle(
             new ClOrdID(clOrdId),
-            new Side('1'), // BUY
+            new Side('1'),
             new TransactTime(LocalDateTime.now(ZoneOffset.UTC)),
-            new OrdType('2')); // LIMIT
+            new OrdType('2'));
     nos.set(new Symbol("GOOGL"));
     nos.set(new OrderQty(2));
-    nos.set(new Price(1.00)); // deep in book → rests, does not cross
+    nos.set(new Price(1.00));
     Session.sendToTarget(nos, SESSION);
 
     var ack =
@@ -111,10 +111,9 @@ class FixGatewayE2ETest {
             .pollInterval(java.time.Duration.ofMillis(500))
             .until(() -> app.reportFor(clOrdId, '0'), Optional::isPresent)
             .orElseThrow();
-    assertThat(ack.getOrdStatus().getValue()).isEqualTo('0'); // NEW
+    assertThat(ack.getOrdStatus().getValue()).isEqualTo('0');
     assertThat(ack.getSymbol().getValue()).isEqualTo("GOOGL");
 
-    // Cancel the resting order; the gateway resolves OrigClOrdID → the internal order id.
     var cancelClOrdId = clOrdId + "-cxl";
     var cancel =
         new OrderCancelRequest(
@@ -134,12 +133,10 @@ class FixGatewayE2ETest {
     assertThat(cancelled.getOrigClOrdID().getValue()).isEqualTo(clOrdId);
   }
 
-  /** QuickFIX/J client application that records logon state and inbound ExecutionReports. */
   private static final class CapturingApplication implements Application {
     private final AtomicBoolean loggedOn = new AtomicBoolean(false);
     private final List<ExecutionReport> reports = new CopyOnWriteArrayList<>();
 
-    /** First ExecutionReport matching the given ClOrdID and ExecType, if any. */
     Optional<ExecutionReport> reportFor(String clOrdId, char execType) {
       return reports.stream()
           .filter(
@@ -156,7 +153,6 @@ class FixGatewayE2ETest {
 
     @Override
     public void onCreate(SessionID sessionId) {
-      // no-op
     }
 
     @Override
@@ -171,17 +167,14 @@ class FixGatewayE2ETest {
 
     @Override
     public void toAdmin(Message message, SessionID sessionId) {
-      // no-op
     }
 
     @Override
     public void fromAdmin(Message message, SessionID sessionId) {
-      // no-op
     }
 
     @Override
     public void toApp(Message message, SessionID sessionId) {
-      // no-op
     }
 
     @Override

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/FixGatewayE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/FixGatewayE2ETest.java
@@ -1,0 +1,194 @@
+package com.mariaalpha.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import quickfix.Application;
+import quickfix.DefaultMessageFactory;
+import quickfix.Initiator;
+import quickfix.MemoryStoreFactory;
+import quickfix.Message;
+import quickfix.SLF4JLogFactory;
+import quickfix.Session;
+import quickfix.SessionID;
+import quickfix.SessionSettings;
+import quickfix.SocketInitiator;
+import quickfix.field.ClOrdID;
+import quickfix.field.OrdType;
+import quickfix.field.OrderQty;
+import quickfix.field.OrigClOrdID;
+import quickfix.field.Price;
+import quickfix.field.Side;
+import quickfix.field.Symbol;
+import quickfix.field.TransactTime;
+import quickfix.fix44.ExecutionReport;
+import quickfix.fix44.NewOrderSingle;
+import quickfix.fix44.OrderCancelRequest;
+
+@Tag("e2e")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FixGatewayE2ETest {
+
+  private static final SessionID SESSION = new SessionID("FIX.4.4", "CLIENT", "MARIAALPHA");
+
+  private final CapturingApplication app = new CapturingApplication();
+  private Initiator initiator;
+
+  @BeforeAll
+  void startStackAndInitiator() throws Exception {
+    SharedComposeStack.get().start();
+
+    var settings = new SessionSettings();
+    settings.setString("ConnectionType", "initiator");
+    settings.setString("StartTime", "00:00:00");
+    settings.setString("EndTime", "00:00:00");
+    settings.setString(SESSION, "ConnectionType", "initiator");
+    settings.setString(SESSION, "BeginString", "FIX.4.4");
+    settings.setString(SESSION, "SenderCompID", "CLIENT");
+    settings.setString(SESSION, "TargetCompID", "MARIAALPHA");
+    settings.setString(SESSION, "SocketConnectHost", "localhost");
+    settings.setLong(SESSION, "SocketConnectPort", 9878);
+    settings.setLong(SESSION, "HeartBtInt", 10);
+    settings.setLong(SESSION, "ReconnectInterval", 1);
+    settings.setString(SESSION, "StartTime", "00:00:00");
+    settings.setString(SESSION, "EndTime", "00:00:00");
+    settings.setString(SESSION, "UseDataDictionary", "Y");
+    settings.setString(SESSION, "DataDictionary", "FIX44.xml");
+
+    initiator =
+        new SocketInitiator(
+            app,
+            new MemoryStoreFactory(),
+            settings,
+            new SLF4JLogFactory(settings),
+            new DefaultMessageFactory());
+    initiator.start();
+
+    await()
+        .atMost(45, TimeUnit.SECONDS)
+        .pollInterval(java.time.Duration.ofSeconds(1))
+        .until(app.loggedOn::get);
+  }
+
+  @AfterAll
+  void stopInitiator() {
+    if (initiator != null) {
+      initiator.stop();
+    }
+  }
+
+  @Test
+  void newOrderIsAckedThenCancelled() throws Exception {
+    var clOrdId = "e2e-fix-" + UUID.randomUUID();
+
+    var nos =
+        new NewOrderSingle(
+            new ClOrdID(clOrdId),
+            new Side('1'), // BUY
+            new TransactTime(LocalDateTime.now(ZoneOffset.UTC)),
+            new OrdType('2')); // LIMIT
+    nos.set(new Symbol("GOOGL"));
+    nos.set(new OrderQty(2));
+    nos.set(new Price(1.00)); // deep in book → rests, does not cross
+    Session.sendToTarget(nos, SESSION);
+
+    var ack =
+        await()
+            .atMost(40, TimeUnit.SECONDS)
+            .pollInterval(java.time.Duration.ofMillis(500))
+            .until(() -> app.reportFor(clOrdId, '0'), Optional::isPresent)
+            .orElseThrow();
+    assertThat(ack.getOrdStatus().getValue()).isEqualTo('0'); // NEW
+    assertThat(ack.getSymbol().getValue()).isEqualTo("GOOGL");
+
+    // Cancel the resting order; the gateway resolves OrigClOrdID → the internal order id.
+    var cancelClOrdId = clOrdId + "-cxl";
+    var cancel =
+        new OrderCancelRequest(
+            new OrigClOrdID(clOrdId),
+            new ClOrdID(cancelClOrdId),
+            new Side('1'),
+            new TransactTime(LocalDateTime.now(ZoneOffset.UTC)));
+    cancel.set(new Symbol("GOOGL"));
+    Session.sendToTarget(cancel, SESSION);
+
+    var cancelled =
+        await()
+            .atMost(40, TimeUnit.SECONDS)
+            .pollInterval(java.time.Duration.ofMillis(500))
+            .until(() -> app.reportFor(cancelClOrdId, '4'), Optional::isPresent)
+            .orElseThrow();
+    assertThat(cancelled.getOrigClOrdID().getValue()).isEqualTo(clOrdId);
+  }
+
+  /** QuickFIX/J client application that records logon state and inbound ExecutionReports. */
+  private static final class CapturingApplication implements Application {
+    private final AtomicBoolean loggedOn = new AtomicBoolean(false);
+    private final List<ExecutionReport> reports = new CopyOnWriteArrayList<>();
+
+    /** First ExecutionReport matching the given ClOrdID and ExecType, if any. */
+    Optional<ExecutionReport> reportFor(String clOrdId, char execType) {
+      return reports.stream()
+          .filter(
+              er -> {
+                try {
+                  return clOrdId.equals(er.getClOrdID().getValue())
+                      && er.getExecType().getValue() == execType;
+                } catch (Exception e) {
+                  return false;
+                }
+              })
+          .findFirst();
+    }
+
+    @Override
+    public void onCreate(SessionID sessionId) {
+      // no-op
+    }
+
+    @Override
+    public void onLogon(SessionID sessionId) {
+      loggedOn.set(true);
+    }
+
+    @Override
+    public void onLogout(SessionID sessionId) {
+      loggedOn.set(false);
+    }
+
+    @Override
+    public void toAdmin(Message message, SessionID sessionId) {
+      // no-op
+    }
+
+    @Override
+    public void fromAdmin(Message message, SessionID sessionId) {
+      // no-op
+    }
+
+    @Override
+    public void toApp(Message message, SessionID sessionId) {
+      // no-op
+    }
+
+    @Override
+    public void fromApp(Message message, SessionID sessionId) {
+      if (message instanceof ExecutionReport er) {
+        reports.add(er);
+      }
+    }
+  }
+}

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/InternalCrossingE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/InternalCrossingE2ETest.java
@@ -17,26 +17,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-/**
- * E2E coverage for the internal crossing engine. Brings up the full docker-compose
- * stack and:
- *
- * <ul>
- *   <li>verifies the {@code /api/execution/internal-crossing/*} endpoints are routed through the
- *       API Gateway and respond with well-formed JSON;
- *   <li>fires offsetting BUY/SELL MARKET orders into the manual order endpoint and waits for at
- *       least one cross to land in the engine's stats — exercising the full SOR → adapter →
- *       engine → execution-report → lifecycle → order-manager DB path when the SOR picks
- *       INTERNAL_CROSS;
- *   <li>checks the new Prometheus counters are exposed by the execution-engine actuator.
- * </ul>
- *
- * <p>SOR routing in the simulated profile is deterministic — the same inputs always pick the same
- * venue. To make the test robust regardless of which venue currently wins on the composite score,
- * the cross-engine assertion is delivered via either of two paths: (1) the stats counter exceeds
- * the baseline, OR (2) the engine's book accumulates resting interest. The exact path depends on
- * SOR behaviour at the time, but both prove the engine is reachable end-to-end.
- */
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InternalCrossingE2ETest {
@@ -77,16 +57,11 @@ class InternalCrossingE2ETest {
     var statsBefore = httpGet("/api/execution/internal-crossing/stats");
     long crossesBefore = statsBefore.get("crossesTotal").asLong();
 
-    // Submit a short burst of BUY/SELL pairs. SOR routes deterministically — when INTERNAL_CROSS
-    // wins on the composite score these orders flow into the engine and cross; when it loses,
-    // they flow to the LIT/DARK adapters and we still verify the e2e plumbing via the second
-    // assertion below.
     for (int i = 0; i < 10; i++) {
       submitManualOrder("NVDA", "SELL", 10);
       submitManualOrder("NVDA", "BUY", 10);
     }
 
-    // Allow several seconds for SOR + adapter + engine + fill-callback fan-out.
     await()
         .atMost(30, TimeUnit.SECONDS)
         .pollInterval(Duration.ofSeconds(1))
@@ -98,8 +73,6 @@ class InternalCrossingE2ETest {
               int restingTotal =
                   statsAfter.get("restingOrdersBuy").asInt()
                       + statsAfter.get("restingOrdersSell").asInt();
-              // Either crosses happened OR orders rested. Both prove the engine is live and
-              // wired through the gateway → execution → adapter → engine path.
               assertThat(crossesAfter > crossesBefore || restingTotal > 0)
                   .as(
                       "expected SOR/engine activity to either cross orders or accumulate resting"
@@ -112,7 +85,6 @@ class InternalCrossingE2ETest {
 
   @Test
   void prometheusEndpointExposesInternalCrossingCounters() throws Exception {
-    // Execution-engine management port is 8085, mapped on the host by docker-compose.
     var prom = httpGetRaw("http://localhost:8085/actuator/prometheus");
     assertThat(prom.statusCode()).isEqualTo(200);
     assertThat(prom.body())

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/OptionsPricingE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/OptionsPricingE2ETest.java
@@ -39,7 +39,6 @@ class OptionsPricingE2ETest {
 
   @Test
   void priceEndpointReturnsTextbookHullValueThroughGateway() throws Exception {
-    // Hull Ch.15 worked example. Strategy-engine should reach 4.76 ± 0.01 through the gateway path.
     var body =
         "{\"symbol\":\"AAPL\",\"spot\":42.0,\"strike\":40.0,\"timeToExpiryYears\":0.5,"
             + "\"volatility\":0.20,\"riskFreeRate\":0.10,\"dividendYield\":0.0,\"type\":\"CALL\"}";
@@ -61,7 +60,6 @@ class OptionsPricingE2ETest {
 
   @Test
   void putCallParityHoldsThroughGateway() throws Exception {
-    // Generalised parity with q = 0: C − P = S − K·e^(−rT)
     var callBody =
         "{\"symbol\":\"AAPL\",\"spot\":100.0,\"strike\":95.0,\"timeToExpiryYears\":1.0,"
             + "\"volatility\":0.30,\"riskFreeRate\":0.04,\"dividendYield\":0.0,\"type\":\"CALL\"}";

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/PeggedOrderE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/PeggedOrderE2ETest.java
@@ -18,17 +18,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-/**
- * Full-stack e2e for PEGGED orders (roadmap 3.2.3). Drives the execution-engine through the
- * api-gateway:
- *
- * <ol>
- *   <li>Submit a PEGGED MIDPOINT BUY parent and assert the pegged-progress endpoint reports an
- *       active LIMIT child at the midpoint of the simulated NBBO.
- *   <li>Submit with a missing pegType and assert the validator rejects it with HTTP 400.
- *   <li>Submit a non-PEGGED order with a stray pegType and assert the validator rejects it.
- * </ol>
- */
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PeggedOrderE2ETest {
@@ -48,8 +37,6 @@ class PeggedOrderE2ETest {
 
   @Test
   void submitPeggedMidpointBuyRegistersChildAndReportsProgress() throws Exception {
-    // The simulator continuously republishes AAPL ticks; wait until the execution-engine's
-    // MarketStateTracker has at least one snapshot.
     var orderId =
         await()
             .atMost(45, TimeUnit.SECONDS)
@@ -57,18 +44,6 @@ class PeggedOrderE2ETest {
             .ignoreExceptions()
             .until(this::submitPeggedMidpointBuy, id -> id != null);
 
-    // The PEGGED parent registers a child immediately on submit; the simulator might already
-    // have filled it before we get here, in which case the registry has dropped the parent and
-    // the progress endpoint returns 404. Either outcome is a valid pegged round-trip:
-    //  (1) progress endpoint returns a snapshot with the expected fields, OR
-    //  (2) progress endpoint returns 404 AND the order shows up in /api/orders in a terminal state.
-    //
-    // Budget 60s (not 20s): when the child is synthetically crossed on submit, the parent is
-    // FILLED+removed instantly, so this poll falls to branch (2), which depends on order-manager
-    // having consumed the FILLED event off `orders.lifecycle`. Early in a freshly-started shared
-    // stack the order-manager consumer group is still rebalancing/resetting offsets, so that
-    // cross-service propagation can take well over 20s under CI load. 60s matches the budget the
-    // rest of the suite (e.g. SimulatedHappyPathE2ETest) already uses for order-manager catch-up.
     boolean done =
         await()
             .atMost(60, TimeUnit.SECONDS)
@@ -89,7 +64,6 @@ class PeggedOrderE2ETest {
       assertThat(progress.get("lastSubmittedPrice").isNumber()).isTrue();
       return true;
     }
-    // 404 from the registry — the parent must have completed. Look it up in the order-manager.
     var order = lookupOrder(orderId);
     if (order == null) {
       return false;

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/RegimeClassifierE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/RegimeClassifierE2ETest.java
@@ -21,24 +21,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-/**
- * E2E coverage for the Random Forest regime classifier in ml-signal-service.
- *
- * <p>Brings up the bare minimum compose profile needed to exercise the GetRegime gRPC: just the
- * ml-signal-service container (no Kafka dependency for the call itself — we only need the gRPC
- * surface). The service is verified to:
- *
- * <ul>
- *   <li>load the regime model on startup (reported via the readiness probe), and
- *   <li>return a well-formed RegimeResponse on demand — even when no bar history is present, the
- *       service must degrade to UNKNOWN/confidence=0 rather than fail the RPC. This is the
- *       contract the strategy engine relies on when ML is acting purely advisory.
- * </ul>
- *
- * <p>Accuracy of the classifier on synthetic regime paths is covered by the Python integration
- * test {@code tests/test_regime_integration.py}; this Java e2e only validates the deployment +
- * wire contract.
- */
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RegimeClassifierE2ETest {
@@ -55,7 +37,6 @@ class RegimeClassifierE2ETest {
     if (channel != null) {
       channel.shutdownNow();
     }
-    // The shared compose stack is owned by SharedComposeStack and stopped at JVM shutdown.
   }
 
   @BeforeAll
@@ -83,15 +64,12 @@ class RegimeClassifierE2ETest {
                           .build(),
                       HttpResponse.BodyHandlers.ofString());
               assertThat(resp.statusCode()).isEqualTo(200);
-              // The readiness body advertises the regime model state alongside the signal model.
               assertThat(resp.body()).contains("\"regime_model_loaded\":true");
             });
   }
 
   @Test
   void getRegimeReturnsUnknownWhenNoBarsAvailable() {
-    // Before any ticks have flowed (or for a never-seen symbol), the service must answer
-    // UNKNOWN/confidence=0 rather than throw — this is the strategy engine's safety net.
     var response =
         stub.withDeadlineAfter(2, TimeUnit.SECONDS)
             .getRegime(RegimeRequest.newBuilder().setSymbol("ZZZZ_NEVER_TRADED").build());
@@ -103,10 +81,7 @@ class RegimeClassifierE2ETest {
 
   @Test
   void getRegimeAcceptsAnyEnumOnRealSymbol() {
-    // After the market-data-gateway pushes ticks for AAPL through Kafka, the ml-signal-service
     // will eventually have a full bar window. We don't gate on that here (the test would take
-    // ~60 minutes of simulated time), but we do require the response to be a valid enum value
-    // — i.e. the gRPC path itself round-trips a parseable MarketRegime.
     var response =
         stub.withDeadlineAfter(2, TimeUnit.SECONDS)
             .getRegime(RegimeRequest.newBuilder().setSymbol("AAPL").build());
@@ -117,7 +92,6 @@ class RegimeClassifierE2ETest {
 
   @Test
   void metricsExposeRegimeCounter() throws Exception {
-    // Trigger at least one GetRegime call to materialise the counter, then scrape /metrics.
     stub.withDeadlineAfter(2, TimeUnit.SECONDS)
         .getRegime(RegimeRequest.newBuilder().setSymbol("METRIC_PROBE").build());
 

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/SharedComposeStack.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/SharedComposeStack.java
@@ -8,25 +8,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-/**
- * JVM-singleton wrapper around the project's {@code docker-compose.yml} so multiple e2e test
- * classes can share one running stack.
- *
- * <p>Why this exists: the original e2e setup spun up a full stack in every test class's
- * {@code @BeforeAll} via {@link ComposeContainer}. Five classes × ~2 minutes of {@code docker
- * compose up} (build + healthcheck cascade) = ~10 minutes of CI time before a single test ran.
- * By sharing one stack across compatible classes and only tearing it down at JVM exit, the e2e job
- * pays the startup cost once.
- *
- * <p>Compatibility rule: a class can attach to this shared stack <i>only</i> if its required
- * compose configuration matches the default — i.e. no per-test environment overrides. Tests that
- * need a different stack config (e.g. {@code Phase2RiskChecksE2ETest} tightening
- * {@code EXECUTION_ENGINE_RISK_MAX_ADV_PARTICIPATION}) must run their own private stack.
- *
- * <p>Concurrency: {@link #start()} is synchronized and idempotent so that whichever
- * {@code @BeforeAll} fires first wins; later callers no-op. A JVM shutdown hook owns the teardown
- * so the stack is released even if a test exits abnormally.
- */
 final class SharedComposeStack {
 
   private static final Logger LOG = LoggerFactory.getLogger(SharedComposeStack.class);
@@ -42,12 +23,10 @@ final class SharedComposeStack {
     return INSTANCE;
   }
 
-  /** Stable API key used by every shared-stack test class. */
   String apiKey() {
     return API_KEY;
   }
 
-  /** Gateway base URL — {@code http://localhost:8080}, mapped by docker-compose port binding. */
   String gatewayBaseUrl() {
     return "http://localhost:8080";
   }
@@ -57,10 +36,6 @@ final class SharedComposeStack {
       return;
     }
     var dockerComposeFile = new File("../docker-compose.yml");
-    // Optional CI override: when MARIAALPHA_E2E_USE_PREBUILT_JARS=true, layer docker-compose.ci.yml
-    // on top so each Java service builds from its thin Dockerfile.local instead of re-running
-    // Gradle inside Docker. CI pre-builds the bootJars host-side with the warm setup-gradle cache,
-    // which is much faster than letting 6 separate Docker contexts each download ~500 MB of deps.
     var ciOverride = new File("../docker-compose.ci.yml");
     boolean usePrebuilt =
         Boolean.parseBoolean(System.getenv().getOrDefault("MARIAALPHA_E2E_USE_PREBUILT_JARS", "false"))
@@ -70,8 +45,6 @@ final class SharedComposeStack {
     if (usePrebuilt) {
       LOG.info("Shared compose stack: using docker-compose.ci.yml override (pre-built jars)");
     }
-    // Force-down any stale stack left over by a previous crashed/killed run before starting fresh.
-    // (This only fires on the very first call across the whole JVM.)
     forceDownExistingStack(dockerComposeFile);
     composeContainer =
         new ComposeContainer(composeFiles)
@@ -80,22 +53,14 @@ final class SharedComposeStack {
             .withEnv("POSTGRES_USER", "mariaalpha")
             .withEnv("POSTGRES_PASSWORD", "mariaalpha")
             .withEnv("POSTGRES_DB", "mariaalpha")
-            // Alpaca creds aren't used by the simulated profile but compose interpolates them.
             .withEnv("ALPACA_API_KEY_ID", "unused")
             .withEnv("ALPACA_API_SECRET_KEY", "unused")
             .withBuild(true)
             .withRemoveVolumes(true)
-            // The api-gateway "Started Application in …" log marker fires last in the dependency
-            // chain (it depends_on every downstream's service_healthy), so waiting on it confirms
-            // the whole stack is up. Direct port probes via withExposedService route through a
-            // socat ambassador that can't cross compose v2 user-defined networks — log waits go
-            // through the Docker log API instead, which works regardless of network.
             .waitingFor(
                 "api-gateway",
                 Wait.forLogMessage(".*Started Application in.*", 1)
                     .withStartupTimeout(Duration.ofMinutes(4)))
-            // Stream a handful of services' logs through to System.out so CI logs carry the
-            // diagnostic detail tests rely on when assertions fail.
             .withLogConsumer("api-gateway", f -> System.out.print("[api-gw] " + f.getUtf8String()))
             .withLogConsumer(
                 "strategy-engine", f -> System.out.print("[strategy] " + f.getUtf8String()))
@@ -126,12 +91,6 @@ final class SharedComposeStack {
                 "shared-compose-stack-shutdown"));
   }
 
-  /**
-   * Tear down the shared stack early, before JVM shutdown. Used by {@link Phase2RiskChecksE2ETest}
-   * — that class needs to swap in its own ComposeContainer with a tightened ADV-participation
-   * env override, and the two ComposeContainer instances would otherwise collide on the same
-   * compose project name ("mariaalpha") and fail with an opaque {@code compose up} exit code 1.
-   */
   synchronized void stopIfRunning() {
     if (!started || composeContainer == null) {
       return;

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
@@ -34,19 +34,13 @@ class SimulatedHappyPathE2ETest {
 
     @BeforeAll
     void startStack() {
-        // The shared compose stack is JVM-global; whichever e2e class fires first pays the
-        // ~2-minute startup cost, the rest no-op. Teardown is JVM-shutdown hooked.
         SharedComposeStack.get().start();
         httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
     }
 
     @AfterEach
     void unbindStatefulStrategies() {
-        // MOMENTUM is stateful — once bound to GOOGL it enters a long position on the bullish EMA
-        // crossover and then oscillates entry/exit every few ticks for the rest of the JVM's life,
-        // saturating the simulated INTERNAL_CROSS queue. Detach it after each test so the next
         // test's symbol-specific orders don't compete with a background oscillation. The unbind
-        // is best-effort and ignores 404s (the strategy may not have been bound this method).
         for (String symbol : new String[] {"GOOGL", "AAPL", "MSFT", "AMZN", "TSLA", "NVDA"}) {
             try {
                 httpClient.send(HttpRequest.newBuilder()
@@ -57,7 +51,6 @@ class SimulatedHappyPathE2ETest {
                                 .build(),
                         HttpResponse.BodyHandlers.discarding());
             } catch (Exception ignored) {
-                // Best-effort cleanup — never fail a test on this.
             }
         }
     }
@@ -66,11 +59,6 @@ class SimulatedHappyPathE2ETest {
     void simulatedTickReachesPositionWithFillAndPnl() throws Exception {
         bindVwapToAppleWith100Shares();
 
-        // Gate on the VWAP-specific FILLED order rather than the AAPL position. If
-        // rfqQuoteReturnsTwoWayBookAndAcceptPublishesOrderSignal ran first in this stack lifecycle
-        // (JUnit method order is not guaranteed), it leaves an AAPL position behind that would
-        // satisfy a netQuantity != 0 wait before VWAP has had a chance to fire. Mirrors the pattern
-        // simulatedMomentumUptrendReachesGooglOrderWithFill uses (firstFilledMomentumBuy).
         var order = await().atMost(60, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofMillis(500))
                 .ignoreExceptions()
@@ -84,8 +72,6 @@ class SimulatedHappyPathE2ETest {
 
         var position = getPosition("AAPL");
         assertThat(position).as("AAPL position must exist after VWAP fill").isNotNull();
-        // Net quantity is at least 100 (this VWAP fill). If the RFQ test ran first it adds another
-        // 100 from its accepted quote, so accept >= 100 rather than == 100.
         assertThat(netQuantity(position)).isGreaterThanOrEqualTo(new BigDecimal("100"));
 
         var avgEntry = new BigDecimal(position.get("avgEntryPrice").asText());
@@ -97,13 +83,9 @@ class SimulatedHappyPathE2ETest {
         assertThat(new BigDecimal(position.get("realizedPnl").asText())).isEqualByComparingTo("0");
 
         var portfolio = httpGetAndCheck("/api/portfolio/summary");
-        // >= 1 rather than == 1: the TWAP (MSFT) and Momentum (GOOGL) tests in this class may have
-        // opened other positions too, and test method order is not guaranteed.
         assertThat(portfolio.get("openPositions").asInt()).isGreaterThanOrEqualTo(1);
         assertThat(portfolio.has("totalPnl")).isTrue();
 
-        // Currency exposure (roadmap 3.5.3) — all simulator symbols are USD-denominated, so the
-        // response always carries a single USD row that includes the AAPL VWAP fill.
         var exposure = httpGetAndCheck("/api/portfolio/currency-exposure");
         assertThat(exposure.get("rows").isArray()).isTrue();
         var usdRow = findCurrencyRow(exposure, "USD");
@@ -177,14 +159,6 @@ class SimulatedHappyPathE2ETest {
     void simulatedCloseTickReachesNvdaPositionWithMocFill() throws Exception {
         bindCloseToNvdaWith45SharesMocOnly();
 
-        // Gate on the persisted FILLED CLOSE MARKET order rather than a netQuantity == 45 check.
-        // InternalCrossingE2ETest submits 10 × (SELL 10 NVDA, BUY 10 NVDA) against the SAME
-        // shared compose stack, and SOR-routing variation can leave the pairs slightly imbalanced
-        // (e.g. one of the 10 BUYs doesn't land), so the NVDA position seen here is the CLOSE
-        // BUY 45 *plus* whatever residual InternalCrossingE2ETest left behind. The CLOSE path's
-        // correctness is the order's shape (45-share MARKET BUY filled with strategy=CLOSE),
-        // which is invariant to that. Mirrors the pattern simulatedTickReachesPositionWithFillAndPnl
-        // uses (firstFilledVwapAaplBuy).
         var order = await().atMost(60, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofMillis(500))
                 .ignoreExceptions()
@@ -198,8 +172,6 @@ class SimulatedHappyPathE2ETest {
                 .as("CLOSE MOC trades the configured 45-share parent in one MARKET clip")
                 .isEqualByComparingTo(new BigDecimal("45"));
 
-        // Position must exist; avgEntryPrice should reflect the CSV NVDA bid/ask band (the CLOSE
-        // BUY is the dominant flow on this symbol so avgEntryPrice is dominated by 875.20).
         var position = getPosition("NVDA");
         assertThat(position).as("NVDA position must exist after CLOSE fill").isNotNull();
         var avgEntry = new BigDecimal(position.get("avgEntryPrice").asText());
@@ -224,10 +196,6 @@ class SimulatedHappyPathE2ETest {
     void simulatedPovTickReachesTslaPositionWithFill() throws Exception {
         bindPovToTslaWith60Shares();
 
-        // POV emits multiple LIMIT clips proportional to traded volume on the tape — a 60-share
-        // parent at 20% participation against 300/250/500/350-share TRADE prints completes in
-        // one or two clips depending on tick ordering. Wait for the full parent before asserting
-        // so a mid-completion poll doesn't see e.g. 50/60.
         var position = awaitPositionAtLeast("TSLA", new BigDecimal("60"), 45);
 
         assertThat(netQuantity(position)).as("TSLA net quantity should reach the 60-share POV parent")
@@ -248,9 +216,6 @@ class SimulatedHappyPathE2ETest {
 
     @Test
     void rfqQuoteReturnsTwoWayBookAndAcceptPublishesOrderSignal() throws Exception {
-        // The simulator is publishing AAPL ticks into market-data.ticks, so the strategy-engine's
-        // MarketStateCache populates within a few seconds of stack startup. Poll the RFQ endpoint
-        // until the gateway accepts the request (it 503s while no book is available).
         var quote = await().atMost(45, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofSeconds(1))
                 .ignoreExceptions()
@@ -264,10 +229,8 @@ class SimulatedHappyPathE2ETest {
         assertThat(quote.get("breakdown").get("baseHalfSpreadBps").asDouble())
                 .as("base half-spread comes from application.yml")
                 .isEqualTo(2.0);
-        // 2.4.2: per-symbol ADV is wired (AAPL → 60M), so we expect ADV widening to be reported (>=0)
         assertThat(quote.get("breakdown").get("advShares").asLong()).isEqualTo(60_000_000L);
 
-        // Accept BUY at the quoted ask → strategy-engine publishes an OrderSignal with strategyName=RFQ.
         var acceptBody = MAPPER.writeValueAsString(Map.of(
                 "quoteId", quote.get("quoteId").asText(),
                 "side", "BUY",
@@ -278,9 +241,6 @@ class SimulatedHappyPathE2ETest {
 
     @Test
     void eodReconciliationProducesCleanRunInMirrorMode() throws Exception {
-        // Ensure at least one fill has landed before triggering recon, otherwise the matcher has
-        // nothing to compare. Either of the other tests in this class will satisfy this — gate on
-        // an AAPL FILLED order rather than running our own strategy bind.
         await().atMost(60, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofMillis(500))
                 .ignoreExceptions()
@@ -289,9 +249,6 @@ class SimulatedHappyPathE2ETest {
                     return orders.isArray() && orders.size() > 0;
                 });
 
-        // Trigger today's recon (UTC — fills land with Instant.now() which is UTC-based).
-        // The simulated stack runs in MIRROR mode so internal fills are echoed back as external —
-        // expect SUCCESS and 0 breaks.
         var today = java.time.LocalDate.now(java.time.ZoneOffset.UTC).toString();
         var resp = httpPostAndCheck("/api/recon/run?date=" + today, "{}");
         assertThat(resp.get("status").asText()).isEqualTo("SUCCESS");
@@ -303,12 +260,10 @@ class SimulatedHappyPathE2ETest {
                 .as("at least one fill should have been visible to the comparator")
                 .isGreaterThan(0);
 
-        // Summary now reflects the run record.
         var summary = httpGetAndCheck("/api/recon/summary?date=" + today);
         assertThat(summary.get("totalBreaks").asInt()).isZero();
         assertThat(summary.get("run").get("status").asText()).isEqualTo("SUCCESS");
 
-        // Run record listed by /api/recon/runs
         var runs = httpGetAndCheck("/api/recon/runs");
         assertThat(runs.isArray()).isTrue();
         assertThat(runs.size()).isGreaterThanOrEqualTo(1);
@@ -349,10 +304,6 @@ class SimulatedHappyPathE2ETest {
     void simulatedMomentumUptrendReachesGooglOrderWithFill() throws Exception {
         bindMomentumToGoogl();
 
-        // As the simulated GOOGL uptrend's fast EMA crosses above the slow EMA, Momentum opens a
-        // long position. A later loop's reverse-crossover may flatten it, so we gate on the
-        // persisted (append-only) FILLED BUY order rather than a live, possibly-oscillating net
-        // position.
         var order = await().atMost(60, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofMillis(500))
                 .ignoreExceptions()
@@ -387,16 +338,6 @@ class SimulatedHappyPathE2ETest {
 
     private void bindMomentumToGoogl() throws Exception {
         httpPutAndCheck("/api/strategies/GOOGL", "{\"strategyName\":\"MOMENTUM\"}");
-        // Tiny EMA periods + a 2-trade warmup so the simulated GOOGL uptrend produces a prompt
-        // bullish crossover; stop-loss disabled (0) to keep the entry deterministic.
-        //
-        // volumeMultiplier=0 disables the volume-confirmation gate, which is otherwise
-        // flake-prone in this loop-replay setup: if the strategy binds mid-loop instead of in
-        // the inter-loop quiet window, MomentumStrategy seeds its rolling volume baseline with
-        // the 400-share GOOGL trades and can never satisfy `size > 1.5 × avg` thereafter — the
-        // state persists across CSV iterations and the strategy is locked out. Volume gating
-        // is exercised by MomentumStrategyTest (bullishCrossoverFailsWithoutVolumeConfirmation);
-        // this e2e covers the signal→execution→fill→DB→API path, not the gate.
         var params = MAPPER.writeValueAsString(
                 Map.of(
                     "fastPeriod", 2,
@@ -407,18 +348,11 @@ class SimulatedHappyPathE2ETest {
                     "tradeQuantity", 30,
                     "side", "BUY",
                     "stopLossPct", 0.0));
-        // Parameters are addressed by strategy name, not symbol
         httpPutAndCheck("/api/strategies/MOMENTUM/parameters", params);
     }
 
     private void bindCloseToNvdaWith45SharesMocOnly() throws Exception {
         httpPutAndCheck("/api/strategies/NVDA", "{\"strategyName\":\"CLOSE\"}");
-        // CSV NVDA ticks land at 14:30:02.500-14:30:04.500 UTC == 10:30:02.5-10:30:04.5 ET. The
-        // strategy is configured so its 60-second "session" wraps that interval: windowStart at
-        // 10:30:00, closeTime at 10:31:00, with a 1-minute MOC offset → mocCutoff = 10:30:00. Any
-        // NVDA tick reaching the strategy is past the cutoff, so the MOC fires the full 45-share
-        // parent in one MARKET order. preCloseFraction = 0 → pure MOC behaviour (the multi-slice
-        // pre-close schedule is exercised by the unit + integration tests instead).
         var params = MAPPER.writeValueAsString(
                 Map.of(
                     "targetQuantity", 45,
@@ -428,16 +362,11 @@ class SimulatedHappyPathE2ETest {
                     "mocOffsetMinutes", 1,
                     "preCloseFraction", 0.0,
                     "numPreCloseSlices", 6));
-        // Parameters are addressed by strategy name, not symbol
         httpPutAndCheck("/api/strategies/CLOSE/parameters", params);
     }
 
     private void bindPovToTslaWith60Shares() throws Exception {
         httpPutAndCheck("/api/strategies/TSLA", "{\"strategyName\":\"POV\"}");
-        // 60-share parent at 20% participation over the same 10:30:00-10:31:00 ET window
-        // the simulated CSV TSLA ticks fall into. CSV TRADEs are 300/250/500/350 shares (1400
-        // cumulative) → 20% participation yields ~280 expected; the 60-share parent caps it.
-        // The first 300-share print alone produces a 60-share clip — POV completes in one shot.
         var params = MAPPER.writeValueAsString(
                 Map.of(
                     "targetQuantity", 60,
@@ -447,16 +376,11 @@ class SimulatedHappyPathE2ETest {
                     "participationRate", 0.20,
                     "minClipSize", 5,
                     "maxClipSize", 1_000_000));
-        // Parameters are addressed by strategy name, not symbol
         httpPutAndCheck("/api/strategies/POV/parameters", params);
     }
 
     private void bindImplementationShortfallToAmznWith40Shares() throws Exception {
         httpPutAndCheck("/api/strategies/AMZN", "{\"strategyName\":\"IS\"}");
-        // Single slice over the one-minute window the simulated CSV AMZN ticks fall into
-        // (CSV AMZN ticks are 14:30:00-14:30:02Z == 10:30:00-10:30:02 America/New_York). With one
-        // slice the Almgren-Chriss front-load collapses to the whole clip; the multi-slice
-        // front-loading shape is exercised by the unit + integration tests instead.
         var params = MAPPER.writeValueAsString(
                 Map.of(
                     "targetQuantity", 40,
@@ -465,14 +389,11 @@ class SimulatedHappyPathE2ETest {
                     "endTime", "10:31:00",
                     "numSlices", 1,
                     "urgency", 0.5));
-        // Parameters are addressed by strategy name, not symbol
         httpPutAndCheck("/api/strategies/IS/parameters", params);
     }
 
     private void bindTwapToMsftWith50Shares() throws Exception {
         httpPutAndCheck("/api/strategies/MSFT", "{\"strategyName\":\"TWAP\"}");
-        // Single slice over the one-minute window that the simulated CSV ticks fall into
-        // (CSV MSFT ticks are 14:30:00-14:30:02Z == 10:30:00-10:30:02 America/New_York).
         var params = MAPPER.writeValueAsString(
                 Map.of(
                     "targetQuantity", 50,
@@ -480,7 +401,6 @@ class SimulatedHappyPathE2ETest {
                     "startTime", "10:30:00",
                     "endTime", "10:31:00",
                     "numSlices", 1));
-        // Parameters are addressed by strategy name, not symbol
         httpPutAndCheck("/api/strategies/TWAP/parameters", params);
     }
 
@@ -499,7 +419,6 @@ class SimulatedHappyPathE2ETest {
                                     "volumeFraction", 1.0))
                                 )
         );
-        // Parameters are addressed by strategy name, not symbol
         httpPutAndCheck("/api/strategies/VWAP/parameters", params);
     }
 
@@ -516,12 +435,6 @@ class SimulatedHappyPathE2ETest {
         return null;
     }
 
-    /**
-     * Poll the position endpoint until the symbol's net quantity reaches {@code minTarget} (or
-     * beyond). Replaces the older pattern of waiting on {@code netQuantity != 0} then asserting an
-     * exact target — multi-clip strategies (POV) and slippage-delayed single-clip fills (TWAP,
-     * IS, CLOSE) can both partially fill before the full target lands, racing the assertion.
-     */
     private JsonNode awaitPositionAtLeast(String symbol, BigDecimal minTarget, int atMostSeconds) {
         return await().atMost(atMostSeconds, TimeUnit.SECONDS)
                 .pollInterval(Duration.ofMillis(500))
@@ -541,7 +454,7 @@ class SimulatedHappyPathE2ETest {
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
         if(response.statusCode() == 404){
-            return null; // position not yet created
+            return null;
         }
         if(response.statusCode() != 200){
             throw new IllegalStateException("GET " + requestPath + " → " + response.statusCode() + " body="+response.body());

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
@@ -141,19 +141,23 @@ class SimulatedHappyPathE2ETest {
 
         var position = awaitPositionAtLeast("AMZN", new BigDecimal("40"), 45);
 
-        assertThat(netQuantity(position)).as("AMZN net quantity should be 40 after the IS slice fires")
-                .isEqualByComparingTo(new BigDecimal("40"));
+        // The shared compose stack accumulates positions across e2e classes (e.g. BasketTradingE2ETest
+        // also buys AMZN), so gate on >= the 40-share IS parent rather than an exact net quantity.
+        assertThat(netQuantity(position)).as("AMZN net quantity should reach the 40-share IS parent")
+                .isGreaterThanOrEqualTo(new BigDecimal("40"));
 
-        var avgEntry = new BigDecimal(position.get("avgEntryPrice").asText());
-        assertThat(avgEntry).as("avgEntryPrice within CSV bid/ask span ± slippage")
-                .isBetween(new BigDecimal("185.00"), new BigDecimal("185.50"));
-
-        var orders = httpGetAndCheck("/api/orders?symbol=AMZN");
+        // Filter to IS orders so a stray AMZN order from another class (e.g. a basket leg) can't be
+        // picked up as orders.get(0) and fail the strategy assertion.
+        var orders = httpGetAndCheck("/api/orders?symbol=AMZN&strategy=IS&status=FILLED");
         assertThat(orders.isArray()).isTrue();
         assertThat(orders.size()).isGreaterThanOrEqualTo(1);
         var order = orders.get(0);
         assertThat(order.get("status").asText()).isEqualTo("FILLED");
         assertThat(order.get("strategy").asText()).isEqualTo("IS");
+
+        var avgEntry = new BigDecimal(order.get("avgFillPrice").asText());
+        assertThat(avgEntry).as("IS fill price within CSV bid/ask span ± slippage")
+                .isBetween(new BigDecimal("185.00"), new BigDecimal("185.50"));
     }
 
     @Test

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/SimulatedHappyPathE2ETest.java
@@ -51,6 +51,7 @@ class SimulatedHappyPathE2ETest {
                                 .build(),
                         HttpResponse.BodyHandlers.discarding());
             } catch (Exception ignored) {
+                // best-effort cleanup
             }
         }
     }

--- a/e2e-tests/src/test/java/com/mariaalpha/e2e/TradeAllocationE2ETest.java
+++ b/e2e-tests/src/test/java/com/mariaalpha/e2e/TradeAllocationE2ETest.java
@@ -17,20 +17,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-/**
- * Full-stack e2e for the trade-allocation engine (roadmap 3.4.2). Drives the post-trade allocation
- * REST surface through the api-gateway against the shared docker-compose stack. The compose stack
- * configures the default roster (HOUSE 50 / HEDGE_FUND_A 30 / HEDGE_FUND_B 20) so the assertions
- * below are deterministic.
- *
- * <ol>
- *   <li>{@code GET /api/allocations/sub-accounts} — list the configured roster.
- *   <li>{@code POST /api/allocations/run} — allocate 1000 shares pro-rata → 500/300/200.
- *   <li>{@code GET /api/allocations/order/{orderId}} — reads back the same rows.
- *   <li>{@code GET /api/allocations/sub-account/HOUSE} — finds at least one row for HOUSE.
- *   <li>Re-running with FIFO is idempotent — the prior rows are cleared.
- * </ol>
- */
 @Tag("e2e")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TradeAllocationE2ETest {
@@ -73,7 +59,6 @@ class TradeAllocationE2ETest {
     var created = httpPostExpect(201, "/api/allocations/run", body);
     assertThat(created.size()).isEqualTo(3);
 
-    // Sum of allocated qty == parent qty.
     int sum = 0;
     for (var node : created) {
       sum += node.get("allocatedQuantity").asInt();
@@ -112,7 +97,6 @@ class TradeAllocationE2ETest {
                 "parentAvgPrice", 178.42,
                 "method", "FIFO"));
     var second = httpPostExpect(201, "/api/allocations/run", bodyFifo);
-    // FIFO with 25 shares → only HOUSE filled (weight 50 ≥ 25).
     assertThat(second.size()).isEqualTo(1);
 
     var current = httpGet("/api/allocations/order/" + orderId);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/AlpacaExchangeAdapter.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/AlpacaExchangeAdapter.java
@@ -35,7 +35,6 @@ public class AlpacaExchangeAdapter implements ExchangeAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(AlpacaExchangeAdapter.class);
 
-  // Same backoff curve and cap as the market-data Alpaca adapter.
   static final long[] BACKOFF_MS = {1_000L, 2_000L, 4_000L, 8_000L, 16_000L};
   static final int MAX_RECONNECTS = BACKOFF_MS.length;
 
@@ -43,7 +42,7 @@ public class AlpacaExchangeAdapter implements ExchangeAdapter {
   private final ObjectMapper objectMapper;
   private final AlpacaOrderTypeMapper typeMapper;
   private final HttpClient httpClient;
-  private final OkHttpClient wsClient; // lightweight websocket client
+  private final OkHttpClient wsClient;
   private final AtomicBoolean connected = new AtomicBoolean(false);
   private final AtomicInteger reconnectAttempt = new AtomicInteger(0);
   private final ScheduledExecutorService reconnectScheduler =
@@ -166,8 +165,6 @@ public class AlpacaExchangeAdapter implements ExchangeAdapter {
     if (shuttingDown.get()) {
       return;
     }
-    // Retry forever with the backoff capped at the last rung — giving up permanently would
-    // silently drop every subsequent fill until the process is restarted.
     var attempt = reconnectAttempt.getAndIncrement();
     var delayMs = BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)];
     LOG.warn("Alpaca trade_updates: scheduling reconnect attempt {} in {}ms", attempt + 1, delayMs);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/AlpacaWebSocketListener.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/AlpacaWebSocketListener.java
@@ -26,11 +26,7 @@ public class AlpacaWebSocketListener extends WebSocketListener {
   private final ObjectMapper objectMapper;
   private final Supplier<Consumer<ExecutionReport>> reportCallbackSupplier;
   private final AtomicBoolean connected;
-  // Invoked on close (non-normal) or failure so the adapter can schedule a backoff reconnect.
-  // Optional — when null the listener falls back to log-only behavior (used in tests).
   private final Runnable reconnectTrigger;
-  // Invoked when the server-accepted onOpen handshake fires; lets the adapter reset its backoff
-  // counter so the next disconnect starts from the 1s rung again.
   private final Runnable onOpenSuccess;
 
   public AlpacaWebSocketListener(
@@ -132,8 +128,6 @@ public class AlpacaWebSocketListener extends WebSocketListener {
   public void onClosed(@NotNull WebSocket webSocket, int code, @NotNull String reason) {
     connected.set(false);
     LOG.warn("Alpaca WebSocket closed: {} {}", code, reason);
-    // 1000 is a clean shutdown initiated by us (PreDestroy). Anything else means the server or a
-    // network blip cut us off — reconnect or we silently stop receiving fills.
     if (code != 1000 && reconnectTrigger != null) {
       reconnectTrigger.run();
     }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/ExchangeAdapter.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/ExchangeAdapter.java
@@ -7,24 +7,15 @@ import java.util.function.Consumer;
 
 public interface ExchangeAdapter {
 
-  /** Submit an order. Returns acknowledgement with exchange order ID. */
   OrderAck submitOrder(ExecutionInstruction instruction);
 
-  /** Request cancellation of an order. */
   OrderAck cancelOrder(String exchangeOrderId);
 
-  /**
-   * Register a callback for execution reports (fills). The adapter calls this whenever a fill or
-   * status update arrives.
-   */
   void onExecutionReport(Consumer<ExecutionReport> callback);
 
-  /** Start the adapter (connect WebSocket, etc.). */
   void start();
 
-  /** Shut down the adapter gracefully. */
   void shutdown();
 
-  /** Returns true if the adapter is connected and operational. */
   boolean isHealthy();
 }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/PrimaryVenueAdapter.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/PrimaryVenueAdapter.java
@@ -13,13 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Wraps the profile-bound {@link ExchangeAdapter} (Alpaca or Simulated) as a {@link VenueAdapter}
- * so it can be registered alongside the dark/internal pool adapters. Lifecycle methods are
- * <em>delegated, not duplicated</em> — the wrapped {@code ExchangeAdapter} keeps its own
- * {@code @PostConstruct start()}, so this class does <strong>not</strong> annotate {@link #start}
- * with {@code @PostConstruct}.
- */
 @Component
 public final class PrimaryVenueAdapter implements VenueAdapter {
 
@@ -78,15 +71,11 @@ public final class PrimaryVenueAdapter implements VenueAdapter {
   }
 
   @Override
-  public void start() {
-    // NO-OP
-  }
+  public void start() {}
 
   @PreDestroy
   @Override
-  public void shutdown() {
-    // NO-OP
-  }
+  public void shutdown() {}
 
   @Override
   public boolean isHealthy() {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/SimulatedExchangeAdapter.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/SimulatedExchangeAdapter.java
@@ -56,12 +56,10 @@ public class SimulatedExchangeAdapter implements ExchangeAdapter {
     switch (order.getOrderType()) {
       case MARKET -> scheduleFill(exchangeId, order, marketState, config.fillLatencyMs());
       case LIMIT, GTC -> handleLimitOrder(exchangeId, order, marketState);
-      case STOP -> pendingOrders.put(exchangeId, instruction); // wait for trigger
+      case STOP -> pendingOrders.put(exchangeId, instruction);
       case IOC -> handleIocOrder(exchangeId, order, marketState);
       case FOK -> handleFokOrder(exchangeId, order, marketState);
       case ICEBERG -> {
-        // Iceberg parents never reach the adapter directly — IcebergCoordinator intercepts
-        // upstream of submitOrder. If we somehow land here, the order is rejected.
         return new OrderAck(
             order.getOrderId(),
             "",
@@ -107,10 +105,6 @@ public class SimulatedExchangeAdapter implements ExchangeAdapter {
     return true;
   }
 
-  /**
-   * Called by the MarketDataConsumer whenever a new tick arrives. Checks if any pending STOP orders
-   * should be triggered.
-   */
   public void onMarketUpdate(MarketState newState) {
     pendingOrders.forEach(
         (exchangeId, instruction) -> {
@@ -219,11 +213,7 @@ public class SimulatedExchangeAdapter implements ExchangeAdapter {
       emitCancelReport(exchangeId, "ioc-residual-cancel");
       return;
     }
-    // Simulator: infinite top-of-book — assume the limit fills fully against the current
-    // bid/ask snapshot. Depth-aware partial fills are a future enhancement.
     scheduleFill(exchangeId, order, marketState, config.fillLatencyMs());
-    // No residual to cancel in this approximation; depth-aware variant will emit
-    // a delayed "ioc-residual-cancel" for any unfilled portion.
   }
 
   private void handleFokOrder(String exchangeId, Order order, MarketState marketState) {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/SimulatedInternalCrossingAdapter.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/adapter/SimulatedInternalCrossingAdapter.java
@@ -20,17 +20,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/**
- * VenueAdapter facade for the simulated internal crossing venue. Delegates the matching itself to
- * {@link InternalCrossingEngine} and translates {@link MidpointCross} events into {@link
- * ExecutionReport}s on the {@code OrderExecutionService} callback.
- *
- * <p>The adapter retains two probability knobs ({@code crossProbabilityOnSubmit} and {@code
- * matchProbabilityPerTick}) as <i>simulated-liquidity rates</i>: when no real counterparty is
- * resting on the opposite side, the adapter rolls a die and may ask the engine to synthesize one.
- * This keeps the simulator producing crosses even when only one strategy is feeding the venue,
- * while the real matching path remains primary.
- */
 @Component
 @Profile("simulated")
 public class SimulatedInternalCrossingAdapter implements VenueAdapter {
@@ -136,7 +125,6 @@ public class SimulatedInternalCrossingAdapter implements VenueAdapter {
     return engine;
   }
 
-  /** Visible for tests — runs one sweep. Called every {@code tickIntervalMs} in prod. */
   void matchTick() {
     engine.sweep();
     if (config.matchProbabilityPerTick() <= 0.0) {
@@ -151,9 +139,6 @@ public class SimulatedInternalCrossingAdapter implements VenueAdapter {
   }
 
   private void onCross(MidpointCross cross) {
-    // Dispatch the execution-report callback asynchronously so the caller of submitOrder() has a
-    // chance to transition the order to SUBMITTED before the FILLED event arrives. All other
-    // venue adapters follow the same async contract; OrderExecutionService relies on it.
     if (scheduler.isShutdown()) {
       return;
     }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketCoordinator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketCoordinator.java
@@ -4,15 +4,6 @@ import com.mariaalpha.executionengine.model.ExecutionReport;
 import com.mariaalpha.executionengine.model.Order;
 import org.springframework.stereotype.Component;
 
-/**
- * Attributes leg fills to their basket. Hooked into {@link
- * com.mariaalpha.executionengine.service.OrderExecutionService#onExecutionReport} alongside the
- * iceberg and pegged coordinators — it is a no-op for any order that is not a tracked basket leg.
- *
- * <p>Unlike the iceberg/pegged coordinators it does not drive any order submission: basket legs are
- * ordinary orders that the {@link BasketTradingService} fans out up front through the standard
- * pipeline. This coordinator only maintains the aggregate read model and metrics as fills arrive.
- */
 @Component
 public class BasketCoordinator {
 
@@ -24,10 +15,6 @@ public class BasketCoordinator {
     this.metrics = metrics;
   }
 
-  /**
-   * Called after each {@link ExecutionReport} is processed by the execution service. No-op if
-   * {@code order} is not a tracked basket leg.
-   */
   public void onLegFillIfApplicable(Order order, ExecutionReport report) {
     boolean legComplete = report.remainingQuantity() == 0;
     var basketIdOpt =

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketCoordinator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketCoordinator.java
@@ -1,0 +1,47 @@
+package com.mariaalpha.executionengine.basket;
+
+import com.mariaalpha.executionengine.model.ExecutionReport;
+import com.mariaalpha.executionengine.model.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Attributes leg fills to their basket. Hooked into {@link
+ * com.mariaalpha.executionengine.service.OrderExecutionService#onExecutionReport} alongside the
+ * iceberg and pegged coordinators — it is a no-op for any order that is not a tracked basket leg.
+ *
+ * <p>Unlike the iceberg/pegged coordinators it does not drive any order submission: basket legs are
+ * ordinary orders that the {@link BasketTradingService} fans out up front through the standard
+ * pipeline. This coordinator only maintains the aggregate read model and metrics as fills arrive.
+ */
+@Component
+public class BasketCoordinator {
+
+  private final BasketRegistry registry;
+  private final BasketMetrics metrics;
+
+  public BasketCoordinator(BasketRegistry registry, BasketMetrics metrics) {
+    this.registry = registry;
+    this.metrics = metrics;
+  }
+
+  /**
+   * Called after each {@link ExecutionReport} is processed by the execution service. No-op if
+   * {@code order} is not a tracked basket leg.
+   */
+  public void onLegFillIfApplicable(Order order, ExecutionReport report) {
+    boolean legComplete = report.remainingQuantity() == 0;
+    var basketIdOpt =
+        registry.recordLegFill(order.getOrderId(), report.fillQuantity(), legComplete);
+    if (basketIdOpt.isEmpty()) {
+      return;
+    }
+    if (legComplete) {
+      metrics.recordLegFilled(order.getSymbol(), order.getSide().name());
+    }
+    var basketId = basketIdOpt.get();
+    registry
+        .find(basketId)
+        .filter(BasketState::isFilled)
+        .ifPresent(state -> metrics.recordBasketFilled(basketId));
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketLeg.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketLeg.java
@@ -1,0 +1,74 @@
+package com.mariaalpha.executionengine.basket;
+
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.Side;
+
+/**
+ * Mutable per-leg state of a basket order. One {@code BasketLeg} wraps a single child order that
+ * was fanned out through the normal execution pipeline (risk → SOR → venue), tracking its target
+ * quantity, cumulative fills, and terminal/working status.
+ *
+ * <p>All mutation happens under the owning {@link BasketState}'s monitor, so the fields need no
+ * volatile/atomic treatment — {@code BasketState} is the single synchronization point (mirroring
+ * how {@link com.mariaalpha.executionengine.iceberg.ParentChildOrderRegistry} centralises
+ * per-parent mutation).
+ */
+final class BasketLeg {
+
+  private final String legOrderId;
+  private final String symbol;
+  private final Side side;
+  private final int targetQuantity;
+  private OrderStatus status;
+  private int filledQuantity;
+  private String reason;
+
+  BasketLeg(String legOrderId, String symbol, Side side, int targetQuantity) {
+    this.legOrderId = legOrderId;
+    this.symbol = symbol;
+    this.side = side;
+    this.targetQuantity = targetQuantity;
+    this.status = OrderStatus.NEW;
+    this.filledQuantity = 0;
+  }
+
+  void applyFill(int fillQuantity, boolean complete) {
+    this.filledQuantity += fillQuantity;
+    this.status = complete ? OrderStatus.FILLED : OrderStatus.PARTIALLY_FILLED;
+  }
+
+  /**
+   * Record the synchronous outcome of submitting the leg. Never downgrades a leg that has already
+   * started filling — a fill can race ahead of the {@code submitOrder} return on the simulated
+   * adapter, and that fill is authoritative.
+   */
+  void applySubmissionOutcome(OrderStatus submissionStatus, String rejectionReason) {
+    if (submissionStatus == OrderStatus.REJECTED) {
+      this.status = OrderStatus.REJECTED;
+      this.reason = rejectionReason;
+    } else if (this.status == OrderStatus.NEW) {
+      this.status = OrderStatus.SUBMITTED;
+    }
+  }
+
+  boolean accepted() {
+    return status != OrderStatus.REJECTED;
+  }
+
+  boolean fullyFilled() {
+    return status == OrderStatus.FILLED;
+  }
+
+  String legOrderId() {
+    return legOrderId;
+  }
+
+  int filledQuantity() {
+    return filledQuantity;
+  }
+
+  BasketView.BasketLegView toView() {
+    return new BasketView.BasketLegView(
+        legOrderId, symbol, side, targetQuantity, filledQuantity, status, reason);
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketLeg.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketLeg.java
@@ -3,16 +3,6 @@ package com.mariaalpha.executionengine.basket;
 import com.mariaalpha.executionengine.model.OrderStatus;
 import com.mariaalpha.executionengine.model.Side;
 
-/**
- * Mutable per-leg state of a basket order. One {@code BasketLeg} wraps a single child order that
- * was fanned out through the normal execution pipeline (risk → SOR → venue), tracking its target
- * quantity, cumulative fills, and terminal/working status.
- *
- * <p>All mutation happens under the owning {@link BasketState}'s monitor, so the fields need no
- * volatile/atomic treatment — {@code BasketState} is the single synchronization point (mirroring
- * how {@link com.mariaalpha.executionengine.iceberg.ParentChildOrderRegistry} centralises
- * per-parent mutation).
- */
 final class BasketLeg {
 
   private final String legOrderId;
@@ -37,11 +27,6 @@ final class BasketLeg {
     this.status = complete ? OrderStatus.FILLED : OrderStatus.PARTIALLY_FILLED;
   }
 
-  /**
-   * Record the synchronous outcome of submitting the leg. Never downgrades a leg that has already
-   * started filling — a fill can race ahead of the {@code submitOrder} return on the simulated
-   * adapter, and that fill is authoritative.
-   */
   void applySubmissionOutcome(OrderStatus submissionStatus, String rejectionReason) {
     if (submissionStatus == OrderStatus.REJECTED) {
       this.status = OrderStatus.REJECTED;

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketMetrics.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketMetrics.java
@@ -1,0 +1,53 @@
+package com.mariaalpha.executionengine.basket;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/** Micrometer instrumentation for program/basket orders, mirroring {@code IcebergMetrics}. */
+@Component
+public class BasketMetrics {
+
+  private final MeterRegistry registry;
+  private final Map<String, Long> basketStartNanos = new ConcurrentHashMap<>();
+
+  public BasketMetrics(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  public void recordBasketSubmitted(String basketId, int legCount) {
+    basketStartNanos.put(basketId, System.nanoTime());
+    Counter.builder("mariaalpha.execution.basket.submitted.total").register(registry).increment();
+    Counter.builder("mariaalpha.execution.basket.legs.total")
+        .register(registry)
+        .increment(legCount);
+  }
+
+  public void recordLegRejected(String symbol) {
+    Counter.builder("mariaalpha.execution.basket.legs.rejected.total")
+        .tag("symbol", symbol)
+        .register(registry)
+        .increment();
+  }
+
+  public void recordLegFilled(String symbol, String side) {
+    Counter.builder("mariaalpha.execution.basket.legs.filled.total")
+        .tag("symbol", symbol)
+        .tag("side", side)
+        .register(registry)
+        .increment();
+  }
+
+  public void recordBasketFilled(String basketId) {
+    var start = basketStartNanos.remove(basketId);
+    if (start != null) {
+      Timer.builder("mariaalpha.execution.basket.duration.ms")
+          .register(registry)
+          .record(Duration.ofNanos(System.nanoTime() - start));
+    }
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketMetrics.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketMetrics.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
-/** Micrometer instrumentation for program/basket orders, mirroring {@code IcebergMetrics}. */
 @Component
 public class BasketMetrics {
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketRegistry.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketRegistry.java
@@ -1,0 +1,69 @@
+package com.mariaalpha.executionengine.basket;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Thread-safe registry linking basket orders to their legs and routing fill events back to the
+ * owning {@link BasketState}. Mirrors {@link
+ * com.mariaalpha.executionengine.iceberg.ParentChildOrderRegistry}: a forward map (basketId →
+ * state) and a reverse map (legOrderId → basketId) so an execution report carrying only a leg id
+ * can be attributed to its basket in O(1).
+ *
+ * <p>Per-basket aggregation is delegated to the {@link BasketState} monitor; the registry only
+ * guards the two top-level maps, which are {@link ConcurrentHashMap}.
+ */
+@Component
+public class BasketRegistry {
+
+  private final Map<String, BasketState> baskets = new ConcurrentHashMap<>();
+  private final Map<String, String> legToBasket = new ConcurrentHashMap<>();
+
+  public void register(BasketState state) {
+    baskets.put(state.basketId(), state);
+  }
+
+  /** Link a working leg to its basket so later fills can be attributed. */
+  public void linkLeg(String legOrderId, String basketId) {
+    legToBasket.put(legOrderId, basketId);
+  }
+
+  public Optional<BasketState> find(String basketId) {
+    return Optional.ofNullable(baskets.get(basketId));
+  }
+
+  public Optional<BasketView> view(String basketId) {
+    return find(basketId).map(BasketState::toView);
+  }
+
+  public List<BasketView> all() {
+    return baskets.values().stream().map(BasketState::toView).toList();
+  }
+
+  /**
+   * Apply a leg fill if the leg belongs to a tracked basket. Returns the owning basket's id when
+   * the fill was attributed, otherwise empty (the order is not a basket leg).
+   */
+  public Optional<String> recordLegFill(String legOrderId, int fillQuantity, boolean complete) {
+    var basketId = legToBasket.get(legOrderId);
+    if (basketId == null) {
+      return Optional.empty();
+    }
+    var state = baskets.get(basketId);
+    if (state == null || !state.recordFill(legOrderId, fillQuantity, complete)) {
+      return Optional.empty();
+    }
+    if (complete) {
+      legToBasket.remove(legOrderId);
+    }
+    return Optional.of(basketId);
+  }
+
+  /** Diagnostics — count of currently-tracked baskets. */
+  public int trackedBaskets() {
+    return baskets.size();
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketRegistry.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketRegistry.java
@@ -6,16 +6,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
-/**
- * Thread-safe registry linking basket orders to their legs and routing fill events back to the
- * owning {@link BasketState}. Mirrors {@link
- * com.mariaalpha.executionengine.iceberg.ParentChildOrderRegistry}: a forward map (basketId →
- * state) and a reverse map (legOrderId → basketId) so an execution report carrying only a leg id
- * can be attributed to its basket in O(1).
- *
- * <p>Per-basket aggregation is delegated to the {@link BasketState} monitor; the registry only
- * guards the two top-level maps, which are {@link ConcurrentHashMap}.
- */
 @Component
 public class BasketRegistry {
 
@@ -26,7 +16,6 @@ public class BasketRegistry {
     baskets.put(state.basketId(), state);
   }
 
-  /** Link a working leg to its basket so later fills can be attributed. */
   public void linkLeg(String legOrderId, String basketId) {
     legToBasket.put(legOrderId, basketId);
   }
@@ -43,10 +32,6 @@ public class BasketRegistry {
     return baskets.values().stream().map(BasketState::toView).toList();
   }
 
-  /**
-   * Apply a leg fill if the leg belongs to a tracked basket. Returns the owning basket's id when
-   * the fill was attributed, otherwise empty (the order is not a basket leg).
-   */
   public Optional<String> recordLegFill(String legOrderId, int fillQuantity, boolean complete) {
     var basketId = legToBasket.get(legOrderId);
     if (basketId == null) {
@@ -62,7 +47,6 @@ public class BasketRegistry {
     return Optional.of(basketId);
   }
 
-  /** Diagnostics — count of currently-tracked baskets. */
   public int trackedBaskets() {
     return baskets.size();
   }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketState.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketState.java
@@ -6,12 +6,6 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/**
- * The working state of one basket order: an ordered map of legs plus the metadata needed to render
- * a {@link BasketView}. Every accessor and mutator is {@code synchronized} on the instance, so the
- * registry can hand the same state object to both the submitting thread and the execution-report
- * thread without external locking.
- */
 public final class BasketState {
 
   private final String basketId;
@@ -41,10 +35,6 @@ public final class BasketState {
     }
   }
 
-  /**
-   * Apply a fill to a leg. Returns {@code true} if the leg was tracked and updated, {@code false}
-   * for an unknown leg id (no-op).
-   */
   public synchronized boolean recordFill(String legOrderId, int fillQuantity, boolean complete) {
     var leg = legs.get(legOrderId);
     if (leg == null) {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketState.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketState.java
@@ -1,0 +1,109 @@
+package com.mariaalpha.executionengine.basket;
+
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.Side;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The working state of one basket order: an ordered map of legs plus the metadata needed to render
+ * a {@link BasketView}. Every accessor and mutator is {@code synchronized} on the instance, so the
+ * registry can hand the same state object to both the submitting thread and the execution-report
+ * thread without external locking.
+ */
+public final class BasketState {
+
+  private final String basketId;
+  private final String name;
+  private final Instant createdAt;
+  private final Map<String, BasketLeg> legs = new LinkedHashMap<>();
+
+  public BasketState(String basketId, String name, Instant createdAt) {
+    this.basketId = basketId;
+    this.name = name;
+    this.createdAt = createdAt;
+  }
+
+  public String basketId() {
+    return basketId;
+  }
+
+  public synchronized void addLeg(String legOrderId, String symbol, Side side, int targetQuantity) {
+    legs.put(legOrderId, new BasketLeg(legOrderId, symbol, side, targetQuantity));
+  }
+
+  public synchronized void recordSubmissionOutcome(
+      String legOrderId, OrderStatus status, String reason) {
+    var leg = legs.get(legOrderId);
+    if (leg != null) {
+      leg.applySubmissionOutcome(status, reason);
+    }
+  }
+
+  /**
+   * Apply a fill to a leg. Returns {@code true} if the leg was tracked and updated, {@code false}
+   * for an unknown leg id (no-op).
+   */
+  public synchronized boolean recordFill(String legOrderId, int fillQuantity, boolean complete) {
+    var leg = legs.get(legOrderId);
+    if (leg == null) {
+      return false;
+    }
+    leg.applyFill(fillQuantity, complete);
+    return true;
+  }
+
+  public synchronized boolean isFilled() {
+    return toView().status() == BasketStatus.FILLED;
+  }
+
+  public synchronized BasketView toView() {
+    var legViews = legs.values().stream().map(BasketLeg::toView).toList();
+    int accepted = 0;
+    int rejected = 0;
+    int filledLegs = 0;
+    int targetQuantity = 0;
+    int filledQuantity = 0;
+    for (var leg : legs.values()) {
+      if (leg.accepted()) {
+        accepted++;
+        targetQuantity += leg.toView().targetQuantity();
+      } else {
+        rejected++;
+      }
+      if (leg.fullyFilled()) {
+        filledLegs++;
+      }
+      filledQuantity += leg.filledQuantity();
+    }
+    return new BasketView(
+        basketId,
+        name,
+        createdAt,
+        deriveStatus(accepted, filledLegs),
+        legs.size(),
+        accepted,
+        rejected,
+        filledLegs,
+        targetQuantity,
+        filledQuantity,
+        legViews);
+  }
+
+  private BasketStatus deriveStatus(int acceptedLegs, int filledLegs) {
+    if (acceptedLegs == 0) {
+      return BasketStatus.REJECTED;
+    }
+    if (filledLegs == acceptedLegs) {
+      return BasketStatus.FILLED;
+    }
+    return filledLegs > 0 || hasPartialFill()
+        ? BasketStatus.PARTIALLY_FILLED
+        : BasketStatus.SUBMITTED;
+  }
+
+  private boolean hasPartialFill() {
+    return legs.values().stream().anyMatch(l -> l.accepted() && l.filledQuantity() > 0);
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketStatus.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketStatus.java
@@ -1,0 +1,20 @@
+package com.mariaalpha.executionengine.basket;
+
+/**
+ * Aggregate state of a program/basket order, derived from the statuses of its legs.
+ *
+ * <ul>
+ *   <li>{@link #REJECTED} — every leg was rejected at submission (risk/validation); nothing is
+ *       working at any venue.
+ *   <li>{@link #SUBMITTED} — at least one leg was accepted; no fills yet.
+ *   <li>{@link #PARTIALLY_FILLED} — some quantity has filled but the accepted legs are not all
+ *       complete.
+ *   <li>{@link #FILLED} — every accepted leg is fully filled.
+ * </ul>
+ */
+public enum BasketStatus {
+  SUBMITTED,
+  PARTIALLY_FILLED,
+  FILLED,
+  REJECTED
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketStatus.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketStatus.java
@@ -1,17 +1,5 @@
 package com.mariaalpha.executionengine.basket;
 
-/**
- * Aggregate state of a program/basket order, derived from the statuses of its legs.
- *
- * <ul>
- *   <li>{@link #REJECTED} — every leg was rejected at submission (risk/validation); nothing is
- *       working at any venue.
- *   <li>{@link #SUBMITTED} — at least one leg was accepted; no fills yet.
- *   <li>{@link #PARTIALLY_FILLED} — some quantity has filled but the accepted legs are not all
- *       complete.
- *   <li>{@link #FILLED} — every accepted leg is fully filled.
- * </ul>
- */
 public enum BasketStatus {
   SUBMITTED,
   PARTIALLY_FILLED,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketView.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketView.java
@@ -1,0 +1,35 @@
+package com.mariaalpha.executionengine.basket;
+
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.Side;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Immutable, serialisable snapshot of a basket order and its legs — the read model returned by the
+ * REST surface. Built under the {@link BasketState} monitor so the leg list and aggregates are
+ * internally consistent.
+ */
+public record BasketView(
+    String basketId,
+    String name,
+    Instant createdAt,
+    BasketStatus status,
+    int totalLegs,
+    int acceptedLegs,
+    int rejectedLegs,
+    int filledLegs,
+    int targetQuantity,
+    int filledQuantity,
+    List<BasketLegView> legs) {
+
+  /** Per-leg projection within a {@link BasketView}. */
+  public record BasketLegView(
+      String legOrderId,
+      String symbol,
+      Side side,
+      int targetQuantity,
+      int filledQuantity,
+      OrderStatus status,
+      String reason) {}
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketView.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/basket/BasketView.java
@@ -5,11 +5,6 @@ import com.mariaalpha.executionengine.model.Side;
 import java.time.Instant;
 import java.util.List;
 
-/**
- * Immutable, serialisable snapshot of a basket order and its legs — the read model returned by the
- * REST surface. Built under the {@link BasketState} monitor so the leg list and aggregates are
- * internally consistent.
- */
 public record BasketView(
     String basketId,
     String name,
@@ -23,7 +18,6 @@ public record BasketView(
     int filledQuantity,
     List<BasketLegView> legs) {
 
-  /** Per-leg projection within a {@link BasketView}. */
   public record BasketLegView(
       String legOrderId,
       String symbol,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/PositionSnapshot.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/PositionSnapshot.java
@@ -4,11 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-/**
- * Projection of the order-manager's PositionSnapshot that the execution-engine deserializes from
- * the Redis cache. Mirrors the order-manager's wire format — extra fields are tolerated for forward
- * compatibility.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PositionSnapshot(
     String symbol,
@@ -19,11 +14,6 @@ public record PositionSnapshot(
     BigDecimal lastMarkPrice,
     Instant timestamp) {
 
-  /**
-   * Notional exposure in dollars: {@code netQuantity × markPrice}, falling back to {@code
-   * netQuantity × avgEntryPrice} when no mark price has been captured yet. Returns ZERO when both
-   * prices are absent.
-   */
   public BigDecimal notional() {
     if (netQuantity == null) {
       return BigDecimal.ZERO;

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClient.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClient.java
@@ -23,22 +23,6 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.Topic;
 import org.springframework.stereotype.Component;
 
-/**
- * Keeps the in-process {@link PositionTracker} in sync with the order-manager's authoritative
- * position book via the Redis cache:
- *
- * <ul>
- *   <li>Warms the tracker on startup by scanning {@code mariaalpha:position:*} keys.
- *   <li>Subscribes to pub/sub channel {@code mariaalpha.positions.updates} for incremental updates
- *       between fills.
- *   <li>Falls back to a direct {@code GET} on cache miss so a risk check never sees stale in-memory
- *       state.
- * </ul>
- *
- * Redis is a cache, not a system of record — every method swallows {@link DataAccessException}
- * after logging at WARN. A risk check whose lookup fails will see whatever the in-memory tracker
- * holds, which is at worst the last known good snapshot.
- */
 @Component
 @ConditionalOnProperty(prefix = "execution-engine.redis", name = "enabled", matchIfMissing = true)
 public class RedisPositionCacheClient {
@@ -110,10 +94,6 @@ public class RedisPositionCacheClient {
     }
   }
 
-  /**
-   * Best-effort lookup that consults Redis directly. Used as a fallback when the in-memory tracker
-   * is empty (e.g. between cache warm-up failure and the first pub/sub message).
-   */
   public PositionSnapshot fetch(String symbol) {
     if (symbol == null || symbol.isBlank()) {
       return null;

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisBeans.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisBeans.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
-/** Provides the pub/sub listener container the cache client subscribes through. */
 @Configuration
 @ConditionalOnProperty(prefix = "execution-engine.redis", name = "enabled", matchIfMissing = true)
 public class RedisBeans {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisConfig.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RedisConfig.java
@@ -2,12 +2,6 @@ package com.mariaalpha.executionengine.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Redis client settings for the cross-service position cache. Mirrors the order-manager defaults so
- * the key prefix and pub/sub channel match without manual wiring. Disable via {@code
- * execution-engine.redis.enabled=false} when running in environments that have no Redis (the
- * in-memory {@code PositionTracker} fallback continues to work).
- */
 @ConfigurationProperties(prefix = "execution-engine.redis")
 public record RedisConfig(
     boolean enabled, String positionKeyPrefix, String positionsPubSubChannel) {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RiskLimitsConfig.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/config/RiskLimitsConfig.java
@@ -5,32 +5,6 @@ import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
-/**
- * Pre-trade risk-check thresholds.
- *
- * <p>The core knobs are {@code maxOrderNotional}, {@code maxPositionPerSymbol}, {@code
- * maxPortfolioExposure}, {@code maxOpenOrders}, and {@code maxDailyLoss}. The sector / beta / ADV
- * risk checks add:
- *
- * <ul>
- *   <li>{@code sectorExposureLimits} — per-sector $-cap; the {@code defaultSectorExposureLimit}
- *       applies to any sector not explicitly listed (and to the synthetic {@code UNKNOWN} sector
- *       used for unmapped symbols).
- *   <li>{@code maxAbsoluteBetaWeightedExposure} — cap on |Σ position_notional × beta| in $; a
- *       portfolio that is long $1M of NVDA (β≈1.6) carries $1.6M of beta-weighted exposure.
- *   <li>{@code maxAdvParticipation} — fraction of a symbol's Average Daily Volume that a single
- *       order may consume (e.g. {@code 0.10} ≈ 10% of ADV). Orders exceeding this are rejected
- *       up-front because they would create unmanageable market impact.
- *   <li>{@code maxIntradayVar} — cap on the portfolio's parametric daily VaR in $ at the configured
- *       {@code varConfidenceLevel}. Computed per-position as |notional| × σ_ann / √trading-days ×
- *       z(confidence), summed in absolute value (no diversification credit — the conservative
- *       reading). Set to {@code 0} to disable. See {@link
- *       com.mariaalpha.executionengine.risk.IntradayVarCheck}.
- *   <li>{@code correlatedClusters} — named lists of symbols that historically co-move; each cluster
- *       gets a $-cap on its gross exposure. See {@link
- *       com.mariaalpha.executionengine.risk.CorrelatedPositionsCheck}.
- * </ul>
- */
 @ConfigurationProperties(prefix = "execution-engine.risk")
 public record RiskLimitsConfig(
     long maxOrderNotional,
@@ -47,21 +21,9 @@ public record RiskLimitsConfig(
     double varTradingDaysPerYear,
     List<CorrelatedCluster> correlatedClusters) {
 
-  /**
-   * Spring Boot's {@code @ConfigurationProperties} binder needs to pick one constructor when a
-   * record has multiple. Without this annotation, binding falls back to Java-bean mode, which
-   * requires a no-arg constructor that records can't have — the bean factory then fails with {@code
-   * NoSuchMethodException: <init>()} and the whole context fails to start. Pinning the canonical
-   * constructor here is the documented Boot-3 fix.
-   */
   @ConstructorBinding
   public RiskLimitsConfig {}
 
-  /**
-   * Legacy constructor for call sites that predate the VaR (3.5.1) and correlated-positions (3.5.2)
-   * fields. Defaults all four new knobs to a self-disabling value (zero limits, empty cluster list)
-   * — existing tests stay green without touching them.
-   */
   public RiskLimitsConfig(
       long maxOrderNotional,
       long maxPositionPerSymbol,
@@ -88,11 +50,5 @@ public record RiskLimitsConfig(
         List.of());
   }
 
-  /**
-   * A named cluster of symbols whose gross dollar exposure must not exceed {@code limit}. Used by
-   * {@link com.mariaalpha.executionengine.risk.CorrelatedPositionsCheck} to enforce concentration
-   * limits across symbols whose returns historically move together (e.g. a "MEGACAP_TECH" basket).
-   * The same symbol can appear in multiple clusters — each cluster is evaluated independently.
-   */
   public record CorrelatedCluster(String name, List<String> symbols, long limit) {}
 }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/config/SymbolReferenceConfig.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/config/SymbolReferenceConfig.java
@@ -4,39 +4,15 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
-/**
- * Per-symbol reference data used by the sector / beta / ADV-participation / intraday-VaR risk
- * checks: sector classification, beta vs. a benchmark, Average Daily Volume in shares, and
- * annualised volatility of log-returns (decimal — 0.25 means 25%/yr).
- *
- * <p>The simulator carries a tiny fixed universe (AAPL, MSFT, GOOGL, AMZN, TSLA, NVDA), so the data
- * is statically configured under {@code execution-engine.risk.reference-data.*} rather than being
- * fetched from a vendor (Bloomberg, Refinitiv) at runtime. Production deployments would back this
- * with a periodic refresh from a corporate-actions / index-provider feed.
- *
- * <p>{@code defaults} provides fall-back values for any symbol missing from {@code symbols} so a
- * new ticker arriving via the strategy engine doesn't silently bypass the risk checks.
- */
 @ConfigurationProperties(prefix = "execution-engine.risk.reference-data")
 public record SymbolReferenceConfig(List<SymbolRef> symbols, SymbolRef defaults) {
 
   public record SymbolRef(
       String symbol, String sector, double beta, long adv, double annualizedVolatility) {
 
-    /**
-     * Pin Spring Boot's {@code @ConfigurationProperties} binder to this 5-arg canonical
-     * constructor. Without this annotation the binder can't pick a constructor when the record has
-     * multiple, falls back to Java-bean mode, and fails with {@code NoSuchMethodException:
-     * <init>()} — which crashes the execution-engine context at startup. Boot-3 documented fix.
-     */
     @ConstructorBinding
     public SymbolRef {}
 
-    /**
-     * Legacy 4-arg constructor for call sites that predate the volatility field (roadmap 3.5.1).
-     * Defaults {@code annualizedVolatility} to 0 — which the VaR check reads as "unknown" and
-     * contributes zero risk for the symbol so the check stays safe-by-default.
-     */
     public SymbolRef(String symbol, String sector, double beta, long adv) {
       this(symbol, sector, beta, adv, 0.0);
     }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/consumer/MarketDataConsumer.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/consumer/MarketDataConsumer.java
@@ -12,15 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-/**
- * Maintains per-symbol {@link MarketState} from the ticks topic.
- *
- * <p>Ticks are sparse: an Alpaca TRADE tick carries no bid/ask (they arrive as 0) and a QUOTE tick
- * carries no trade price. Each field is therefore merged with the previous state — a zero or
- * missing value never overwrites a previously-known one. Without this, every QUOTE would zero the
- * last trade price (silently disabling the notional-based risk checks) and every TRADE would zero
- * the NBBO (breaking pegged reference prices and SOR market snapshots).
- */
 @Component
 public class MarketDataConsumer {
 
@@ -55,7 +46,6 @@ public class MarketDataConsumer {
     }
   }
 
-  /** The tick's value if present and positive, otherwise the previous value (may be null). */
   private static BigDecimal merge(JsonNode node, String field, BigDecimal previous) {
     JsonNode value = node.get(field);
     if (value == null || value.isNull()) {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/BasketController.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/BasketController.java
@@ -1,0 +1,59 @@
+package com.mariaalpha.executionengine.controller;
+
+import com.mariaalpha.executionengine.basket.BasketView;
+import com.mariaalpha.executionengine.controller.dto.BasketOrderRequest;
+import com.mariaalpha.executionengine.service.BasketTradingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST surface for program/basket trading (roadmap 3.4.1). Reachable through the api-gateway's
+ * existing {@code /api/execution/**} route, so no gateway change is required.
+ */
+@RestController
+@RequestMapping("/api/execution/baskets")
+@Tag(name = "Basket", description = "Program/basket order submission and aggregate progress")
+public class BasketController {
+
+  private final BasketTradingService service;
+
+  public BasketController(BasketTradingService service) {
+    this.service = service;
+  }
+
+  @PostMapping
+  @Operation(summary = "Submit a program/basket order (all legs fanned out simultaneously)")
+  public ResponseEntity<BasketView> submit(@Valid @RequestBody BasketOrderRequest request) {
+    return ResponseEntity.accepted().body(service.submit(request));
+  }
+
+  @GetMapping("/{basketId}")
+  @Operation(summary = "Return aggregate progress for a basket order")
+  public ResponseEntity<BasketView> get(@PathVariable String basketId) {
+    return service
+        .get(basketId)
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  @GetMapping
+  @Operation(summary = "List all tracked basket orders")
+  public List<BasketView> list() {
+    return service.list();
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleBadRequest(IllegalArgumentException e) {
+    return ResponseEntity.badRequest().body(e.getMessage());
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/BasketController.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/BasketController.java
@@ -16,10 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * REST surface for program/basket trading (roadmap 3.4.1). Reachable through the api-gateway's
- * existing {@code /api/execution/**} route, so no gateway change is required.
- */
 @RestController
 @RequestMapping("/api/execution/baskets")
 @Tag(name = "Basket", description = "Program/basket order submission and aggregate progress")

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/InternalCrossingController.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/InternalCrossingController.java
@@ -13,10 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Read-only introspection on the simulated internal crossing venue. Used by dashboards, the React
- * UI, and operators to inspect resting interest and verify spread capture in real time.
- */
 @RestController
 @RequestMapping("/api/execution/internal-crossing")
 @Tag(

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketLegRequest.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketLegRequest.java
@@ -9,13 +9,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
-/**
- * One leg of a {@link BasketOrderRequest}. Intentionally a strict subset of {@link
- * SubmitOrderRequest}: basket legs are plain orders ({@code MARKET}/{@code LIMIT}/{@code
- * STOP}/{@code IOC}/{@code FOK}/{@code GTC}). The parent-managed order types ({@code ICEBERG},
- * {@code PEGGED}) are rejected by {@code BasketTradingService} because they need their own
- * per-order coordinator state that a basket does not carry.
- */
 public record BasketLegRequest(
     @NotBlank String symbol,
     @NotNull Side side,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketLegRequest.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketLegRequest.java
@@ -1,0 +1,26 @@
+package com.mariaalpha.executionengine.controller.dto;
+
+import com.mariaalpha.executionengine.model.OrderType;
+import com.mariaalpha.executionengine.model.Side;
+import com.mariaalpha.executionengine.model.TimeInForce;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * One leg of a {@link BasketOrderRequest}. Intentionally a strict subset of {@link
+ * SubmitOrderRequest}: basket legs are plain orders ({@code MARKET}/{@code LIMIT}/{@code
+ * STOP}/{@code IOC}/{@code FOK}/{@code GTC}). The parent-managed order types ({@code ICEBERG},
+ * {@code PEGGED}) are rejected by {@code BasketTradingService} because they need their own
+ * per-order coordinator state that a basket does not carry.
+ */
+public record BasketLegRequest(
+    @NotBlank String symbol,
+    @NotNull Side side,
+    @NotNull OrderType orderType,
+    @Min(1) int quantity,
+    @DecimalMin("0.01") BigDecimal limitPrice,
+    @DecimalMin("0.01") BigDecimal stopPrice,
+    TimeInForce tif) {}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketOrderRequest.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketOrderRequest.java
@@ -5,14 +5,5 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-/**
- * Request body for {@code POST /api/execution/baskets} — submits a program/basket order: a set of
- * independent legs that are fanned out simultaneously through the standard execution pipeline (risk
- * → SOR → venue) and tracked as one aggregate.
- *
- * @param name optional human-readable label (e.g. {@code "SP500-rebalance-2026-06-14"}); a UUID
- *     basket id is always generated regardless.
- * @param legs the basket constituents — at least one, capped to keep a single request bounded.
- */
 public record BasketOrderRequest(
     String name, @NotEmpty @Size(max = 500) @Valid List<BasketLegRequest> legs) {}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketOrderRequest.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/BasketOrderRequest.java
@@ -1,0 +1,18 @@
+package com.mariaalpha.executionengine.controller.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * Request body for {@code POST /api/execution/baskets} — submits a program/basket order: a set of
+ * independent legs that are fanned out simultaneously through the standard execution pipeline (risk
+ * → SOR → venue) and tracked as one aggregate.
+ *
+ * @param name optional human-readable label (e.g. {@code "SP500-rebalance-2026-06-14"}); a UUID
+ *     basket id is always generated regardless.
+ * @param legs the basket constituents — at least one, capped to keep a single request bounded.
+ */
+public record BasketOrderRequest(
+    String name, @NotEmpty @Size(max = 500) @Valid List<BasketLegRequest> legs) {}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/SubmitOrderRequest.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/dto/SubmitOrderRequest.java
@@ -25,10 +25,6 @@ public record SubmitOrderRequest(
     PegType pegType,
     Integer pegOffsetBps) {
 
-  /**
-   * Legacy constructor: defaults peg fields to null. Kept for backward-compatibility with the
-   * non-PEGGED order types and the test suite that predates roadmap 3.2.3.
-   */
   public SubmitOrderRequest(
       String symbol,
       Side side,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/validation/SubmitOrderRequestConstraints.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/controller/validation/SubmitOrderRequestConstraints.java
@@ -19,11 +19,10 @@ public class SubmitOrderRequestConstraints
   @Override
   public boolean isValid(SubmitOrderRequest request, ConstraintValidatorContext ctx) {
     if (request == null) {
-      return true; // @NotNull on field handles null requests
+      return true;
     }
     ctx.disableDefaultConstraintViolation();
 
-    // displayQuantity is required iff ICEBERG, forbidden otherwise.
     boolean isIceberg = ICEBERG_ONLY.contains(request.orderType());
     if (isIceberg && request.displayQuantity() == null) {
       return violation(ctx, "displayQuantity is required for ICEBERG orders");
@@ -35,7 +34,6 @@ public class SubmitOrderRequestConstraints
       return violation(ctx, "displayQuantity must be strictly less than quantity");
     }
 
-    // pegType is required iff PEGGED, forbidden otherwise. pegOffsetBps follows the same rule.
     boolean isPegged = PEGGED_ONLY.contains(request.orderType());
     if (isPegged && request.pegType() == null) {
       return violation(ctx, "pegType is required for PEGGED orders");
@@ -47,7 +45,6 @@ public class SubmitOrderRequestConstraints
       return violation(ctx, "pegOffsetBps is only valid for PEGGED orders");
     }
 
-    // TIF rules.
     var tif = request.tif();
     if (FORBIDS_CUSTOM_TIF.contains(request.orderType()) && tif != null && tif != TimeInForce.DAY) {
       return violation(ctx, "MARKET and STOP orders only accept tif=DAY (or null)");
@@ -62,7 +59,6 @@ public class SubmitOrderRequestConstraints
       return violation(ctx, "GTC orders only accept tif=GTC (or null)");
     }
 
-    // Limit-bearing types must have limitPrice.
     if (requiresLimitPrice(request.orderType()) && request.limitPrice() == null) {
       return violation(ctx, request.orderType() + " orders require limitPrice");
     }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/InternalCrossingEngine.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/InternalCrossingEngine.java
@@ -25,21 +25,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/**
- * In-process midpoint crossing engine. Matches offsetting BUY/SELL interest in the same symbol at
- * the NBBO midpoint, capturing the bid-ask spread without market impact. Resting orders are kept
- * FIFO per side (price-time priority degenerates to time priority because all crosses happen at the
- * same NBBO midpoint).
- *
- * <p>Concurrency model: every public mutation is serialized on {@code lock} so the book stays
- * consistent under concurrent submit / cancel / sweep traffic. The engine is intentionally simple —
- * internalization volumes in this simulator are well below the throughput that would warrant a
- * Disruptor-style single-writer loop (see TDD §Future Considerations).
- *
- * <p>{@link #cross(MidpointCross)} is invoked for every match — the {@link
- * com.mariaalpha.executionengine.adapter.SimulatedInternalCrossingAdapter} hooks into this stream
- * to publish {@code ExecutionReport}s through the regular fill pipeline.
- */
 @Component
 @Profile("simulated")
 public class InternalCrossingEngine {
@@ -67,27 +52,16 @@ public class InternalCrossingEngine {
     this.marketStateTracker = marketStateTracker;
   }
 
-  /**
-   * Subscribe a listener to every cross. Multiple subscribers (adapter, metrics, UI feed) coexist;
-   * the engine fans out in registration order.
-   */
   public void addCrossListener(CrossListener listener) {
     if (listener != null) {
       listeners.add(listener);
     }
   }
 
-  /** Used by tests to reset between cases. Production never removes listeners. */
   public void clearCrossListeners() {
     listeners.clear();
   }
 
-  /**
-   * Submit an order. Tries to cross against opposite-side resting interest at the current midpoint;
-   * any unfilled remainder rests in the book and is retried on subsequent submits or sweeps.
-   *
-   * @return the exchange-side identifier assigned to this order; never null.
-   */
   public String submit(Order order) {
     var exchangeId = "INT-" + UUID.randomUUID().toString().substring(0, 8);
     var resting = new RestingOrder(exchangeId, order, Instant.now());
@@ -106,7 +80,6 @@ public class InternalCrossingEngine {
     return exchangeId;
   }
 
-  /** Cancel a resting order. Returns true if it was present and removed. */
   public boolean cancel(String exchangeOrderId) {
     synchronized (lock) {
       var removed = byExchangeId.remove(exchangeOrderId);
@@ -119,15 +92,6 @@ public class InternalCrossingEngine {
     }
   }
 
-  /**
-   * Synthesize a counterparty for the resting order with the given exchange id. Used by the
-   * adapter's optional simulated-liquidity layer (controlled by the `cross-probability-on-submit` /
-   * `match-probability-per-tick` knobs) when there is no real offsetting interest in the book and
-   * the operator still wants the simulated venue to fill.
-   *
-   * <p>Returns the synthetic cross if the resting order is still alive and the midpoint is
-   * acceptable; otherwise empty.
-   */
   public Optional<MidpointCross> synthesizeCounterparty(String exchangeOrderId) {
     MidpointCross cross;
     synchronized (lock) {
@@ -140,9 +104,7 @@ public class InternalCrossingEngine {
         return Optional.empty();
       }
       var qty = resting.remaining();
-      cross =
-          buildCross(
-              resting, /* counterparty= */ null, /* counterpartyResting= */ null, midpoint, qty);
+      cross = buildCross(resting, null, null, midpoint, qty);
       resting.decrementRemaining(qty);
       removeIfFilled(resting);
     }
@@ -150,7 +112,6 @@ public class InternalCrossingEngine {
     return Optional.of(cross);
   }
 
-  /** Sweep the entire book and produce any newly-matchable crosses (e.g. after an NBBO update). */
   public List<MidpointCross> sweep() {
     List<MidpointCross> produced;
     synchronized (lock) {
@@ -167,7 +128,6 @@ public class InternalCrossingEngine {
     return produced;
   }
 
-  /** Snapshot statistics for monitoring. */
   public CrossingStats stats() {
     int restingBuy;
     int restingSell;
@@ -198,7 +158,6 @@ public class InternalCrossingEngine {
         symbols);
   }
 
-  /** Snapshot of recent crosses (most-recent-first), capped at the ring size. */
   public List<MidpointCross> recentCrosses() {
     synchronized (recent) {
       var copy = new ArrayList<>(recent);
@@ -207,7 +166,6 @@ public class InternalCrossingEngine {
     }
   }
 
-  /** Live book view by symbol — used by REST callers and tests. */
   public Map<String, BookSide> bookSnapshot() {
     synchronized (lock) {
       var snap = new java.util.LinkedHashMap<String, BookSide>();
@@ -222,25 +180,21 @@ public class InternalCrossingEngine {
     }
   }
 
-  /** Total resting size across all symbols/sides. Used for capacity gating. */
   public int totalResting() {
     synchronized (lock) {
       return book.values().stream().flatMap(m -> m.values().stream()).mapToInt(Deque::size).sum();
     }
   }
 
-  /** Returns true iff the given exchange id is still resting in the book. */
   public boolean isResting(String exchangeOrderId) {
     return byExchangeId.containsKey(exchangeOrderId);
   }
 
-  /** Remaining quantity for a resting order, or 0 if absent (already filled / cancelled). */
   public int remainingFor(String exchangeOrderId) {
     var resting = byExchangeId.get(exchangeOrderId);
     return resting == null ? 0 : resting.remaining();
   }
 
-  /** Exchange id of the oldest still-resting order in the given symbol (any side), if any. */
   public Optional<String> firstRestingOrderId(String symbol) {
     synchronized (lock) {
       var sides = book.get(symbol);
@@ -303,8 +257,6 @@ public class InternalCrossingEngine {
       if (matchQty <= 0) {
         break;
       }
-      // Side-of-aggressor convention: emit two CrossEvents per match (one per side).
-      // Use the most-recently-arrived order as the "aggressor" for reporting purposes.
       RestingOrder aggressor = buy.arrival().isAfter(sell.arrival()) ? buy : sell;
       RestingOrder counter = aggressor == buy ? sell : buy;
       produced.add(buildCross(aggressor, counter, counter, midpoint, matchQty));
@@ -375,8 +327,6 @@ public class InternalCrossingEngine {
     } else {
       internalCrossesTotal.incrementAndGet();
     }
-    // Spread captured ≈ (spread_bps / 10000) × midpoint × quantity, in dollar notional terms.
-    // We attribute the full spread to internalization on both sides of the cross.
     var captured =
         cross
             .spreadBps()
@@ -440,10 +390,8 @@ public class InternalCrossingEngine {
     return orders.stream().mapToInt(RestingOrder::remaining).sum();
   }
 
-  /** Snapshot of a symbol's book — depth and order counts on each side. */
   public record BookSide(int buyQty, int buyOrders, int sellQty, int sellOrders) {}
 
-  /** Subscription callback for crosses. */
   public interface CrossListener {
     void onCross(MidpointCross cross);
   }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/InternalCrossingMetrics.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/InternalCrossingMetrics.java
@@ -5,14 +5,6 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/**
- * Bridges {@link InternalCrossingEngine} into {@link ExecutionMetrics}. Composes a per-cross
- * listener onto the engine's existing chain (via {@link
- * InternalCrossingEngine#addCrossListener(InternalCrossingEngine.CrossListener)}) so the adapter's
- * own listener — which fans events out to {@code OrderExecutionService} — keeps working.
- *
- * <p>Also exposes book-depth gauges so dashboards can plot resting interest over time.
- */
 @Component
 @Profile("simulated")
 public class InternalCrossingMetrics {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/MidpointCross.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/MidpointCross.java
@@ -4,16 +4,6 @@ import com.mariaalpha.executionengine.model.Side;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-/**
- * A single midpoint cross emitted by the {@link InternalCrossingEngine}. Each cross corresponds to
- * one aggressing order matching against either a resting counterparty in the internal book ({@code
- * synthetic=false}) or a simulated counterparty conjured by the adapter's liquidity layer ({@code
- * synthetic=true}).
- *
- * <p>{@code spreadBps} captures the prevailing NBBO spread on the underlying market at the moment
- * of the cross — the internalization desk pockets it because the cross happens off-exchange at the
- * midpoint instead of paying-or-collecting at the bid/ask.
- */
 public record MidpointCross(
     String aggressorExchangeOrderId,
     String counterpartyExchangeOrderId,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/RestingOrder.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/crossing/RestingOrder.java
@@ -6,13 +6,6 @@ import com.mariaalpha.executionengine.model.Side;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-/**
- * Resting interest in the internal crossing book. Tracks the original `Order` plus mutable
- * `remaining` quantity so the engine can match in slices.
- *
- * <p>{@code priceAcceptable(midpoint)} encodes the limit-price gate: BUYs only cross at-or-below
- * their limit, SELLs only cross at-or-above. MARKET orders accept any non-null midpoint.
- */
 public final class RestingOrder {
 
   private final String exchangeOrderId;
@@ -59,10 +52,6 @@ public final class RestingOrder {
     remaining -= qty;
   }
 
-  /**
-   * True when {@code midpoint} is an acceptable cross price for this side. LIMIT/IOC/FOK/GTC orders
-   * must straddle their limit; MARKET orders accept any non-null midpoint.
-   */
   public boolean priceAcceptable(BigDecimal midpoint) {
     if (midpoint == null) {
       return false;

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/AlpacaOrderTypeMapper.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/AlpacaOrderTypeMapper.java
@@ -4,14 +4,6 @@ import com.mariaalpha.executionengine.model.ExecutionInstruction;
 import com.mariaalpha.executionengine.model.OrderType;
 import org.springframework.stereotype.Component;
 
-/**
- * Translates the internal {@link OrderType} + {@link
- * com.mariaalpha.executionengine.model.TimeInForce} pair into the Alpaca-wire ({@code type}, {@code
- * time_in_force}) tuple.
- *
- * <p>Centralised here so the adapter stays a thin HTTP shim and so wire mappings can be unit-tested
- * without spinning the adapter up.
- */
 @Component
 public class AlpacaOrderTypeMapper {
 
@@ -20,7 +12,6 @@ public class AlpacaOrderTypeMapper {
       case MARKET -> "market";
       case LIMIT -> "limit";
       case STOP -> "stop";
-      // IOC / FOK / GTC are TIF overlays on a limit order in Alpaca's model
       case IOC, FOK, GTC -> "limit";
       case ICEBERG ->
           throw new IllegalArgumentException(

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/FokOrderHandler.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/FokOrderHandler.java
@@ -31,9 +31,6 @@ public class FokOrderHandler implements OrderTypeHandler {
       return ValidationResult.fail("No market data available for " + order.getSymbol());
     }
 
-    // Pre-flight marketability — FOK kills on insufficient liquidity. The simulator uses an
-    // "infinite top-of-book" approximation so we only reject non-marketable limits here;
-    // depth-aware liquidity checks are a future enhancement.
     if (order.getSide() == Side.BUY
         && order.getLimitPrice().compareTo(marketState.askPrice()) < 0) {
       return ValidationResult.fail(

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/IcebergOrderHandler.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/IcebergOrderHandler.java
@@ -9,14 +9,6 @@ import com.mariaalpha.executionengine.model.ValidationResult;
 import java.math.BigDecimal;
 import org.springframework.stereotype.Component;
 
-/**
- * Validates ICEBERG <em>parent</em> orders. The execution-engine never submits an iceberg parent
- * directly to a venue — the parent is captured by {@link
- * com.mariaalpha.executionengine.iceberg.IcebergCoordinator}, which produces {@code
- * displayQuantity}-sized LIMIT child orders that flow through {@link LimitOrderHandler}. {@link
- * #toExecutionInstruction} is therefore only used to surface validation/preview output via the
- * manual order REST endpoint; the actual venue submission path bypasses it.
- */
 @Component
 public class IcebergOrderHandler implements OrderTypeHandler {
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/IocOrderHandler.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/IocOrderHandler.java
@@ -31,9 +31,6 @@ public class IocOrderHandler implements OrderTypeHandler {
       return ValidationResult.fail("No market data available for " + order.getSymbol());
     }
 
-    // Marketability check: an IOC that cannot fill at submission time would be cancelled
-    // for zero fills. We reject pre-flight so the user sees a clear validation error
-    // rather than an opaque "ioc-residual-cancel" terminal event.
     if (order.getSide() == Side.BUY
         && order.getLimitPrice().compareTo(marketState.askPrice()) < 0) {
       return ValidationResult.fail(

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/PeggedOrderHandler.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/PeggedOrderHandler.java
@@ -12,13 +12,6 @@ import com.mariaalpha.executionengine.pegged.PeggedPriceCalculator;
 import java.math.BigDecimal;
 import org.springframework.stereotype.Component;
 
-/**
- * Validates PEGGED parent orders (roadmap 3.2.3). The execution-engine never submits a PEGGED
- * parent directly to a venue — the parent is captured by {@link
- * com.mariaalpha.executionengine.pegged.PeggedCoordinator}, which produces LIMIT child orders at
- * the pegged price and re-pegs them as the NBBO moves. {@link #toExecutionInstruction} is therefore
- * a preview path only (used by the manual order REST endpoint and tests).
- */
 @Component
 public class PeggedOrderHandler implements OrderTypeHandler {
 
@@ -68,13 +61,9 @@ public class PeggedOrderHandler implements OrderTypeHandler {
               + ")");
     }
     if (order.getLimitPrice() != null) {
-      // Cap must be on the right side of zero for the configured side.
       if (order.getLimitPrice().compareTo(BigDecimal.ZERO) <= 0) {
         return ValidationResult.fail("priceCap must be positive when supplied");
       }
-      // For BUY, a cap below the current reference makes sense only if the user wants the order
-      // to start clamped (acceptable); but a cap < 0.5× reference is almost certainly a typo and
-      // would never fill — reject it.
       if (order.getSide() == Side.BUY
           && order.getLimitPrice().compareTo(reference.multiply(BigDecimal.valueOf(0.5))) < 0) {
         return ValidationResult.fail(
@@ -91,9 +80,6 @@ public class PeggedOrderHandler implements OrderTypeHandler {
 
   @Override
   public ExecutionInstruction toExecutionInstruction(Order order) {
-    // Preview path: caller has already validated, so marketState lookups are not re-run here. The
-    // adjustedLimitPrice on the returned instruction is the current pegged price as seen by the
-    // handler — the coordinator computes its own fresh price at submit time.
     return new ExecutionInstruction(order, TimeInForce.DAY, order.getLimitPrice());
   }
 }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/StopOrderHandler.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/handler/StopOrderHandler.java
@@ -29,8 +29,6 @@ public class StopOrderHandler implements OrderTypeHandler {
     if (marketState == null || marketState.bidPrice() == null || marketState.askPrice() == null) {
       return ValidationResult.fail("No market data available for " + order.getSymbol());
     }
-    // BUY stop: stopPrice must be above current ask (momentum entry)
-    // SELL stop: stopPrice must be below current bid (stop-loss)
     if (order.getSide() == Side.BUY
         && order.getStopPrice().compareTo(marketState.askPrice()) <= 0) {
       return ValidationResult.fail("BUY STOP price must be above current ask");

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinator.java
@@ -13,16 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Owns the lifecycle of ICEBERG parent orders: slices them into LIMIT children, submits each
- * subsequent child as the previous one fills, transitions the parent through PARTIALLY_FILLED →
- * FILLED, and cascades a parent cancel to the currently-active child.
- *
- * <p>Hooked into {@link com.mariaalpha.executionengine.service.OrderExecutionService} through two
- * call sites: {@code onParentSubmit} replaces the normal {@code venueAdapter.submitOrder} call for
- * ICEBERG parents, and {@code onChildFillIfApplicable} is called from {@code onExecutionReport}
- * after the child's own lifecycle event has been published.
- */
 @Component
 public class IcebergCoordinator {
 
@@ -53,12 +43,6 @@ public class IcebergCoordinator {
     this.metrics = metrics;
   }
 
-  /**
-   * Called by {@code OrderExecutionService.processOrder} when it encounters an ICEBERG parent.
-   * Registers the parent, submits the first child, and transitions the parent to SUBMITTED.
-   *
-   * @return true if the first child was accepted by its venue, false if rejected.
-   */
   public boolean onParentSubmit(Order parent) {
     if (parent.getDisplayQuantity() == null) {
       throw new IllegalArgumentException(
@@ -69,10 +53,6 @@ public class IcebergCoordinator {
     return submitNextSlice(parent);
   }
 
-  /**
-   * Called after each child {@link ExecutionReport} is processed. No-op if the order is not an
-   * iceberg child.
-   */
   public void onChildFillIfApplicable(Order child, ExecutionReport report) {
     if (child.getParentOrderId() == null) {
       return;
@@ -102,7 +82,6 @@ public class IcebergCoordinator {
     }
   }
 
-  /** Cascade a parent CANCELLED transition to the currently-active child, if any. */
   public void onParentCancelRequested(Order parent) {
     registry
         .activeChildFor(parent.getOrderId())

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/iceberg/IcebergSliceFactory.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/iceberg/IcebergSliceFactory.java
@@ -7,14 +7,6 @@ import com.mariaalpha.executionengine.model.TimeInForce;
 import java.time.Instant;
 import org.springframework.stereotype.Component;
 
-/**
- * Builds child LIMIT orders from an iceberg parent.
- *
- * <p>Children inherit the parent's symbol, side, and limit price. The {@code strategyName} on the
- * child is the literal {@code "ICEBERG-CHILD"} so downstream metrics / TCA reports can group child
- * fills under their parent strategy. The parent's {@code orderId} flows into the child as {@code
- * parentOrderId}.
- */
 @Component
 public class IcebergSliceFactory {
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/iceberg/ParentChildOrderRegistry.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/iceberg/ParentChildOrderRegistry.java
@@ -10,13 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Thread-safe registry linking ICEBERG parent orders to their LIMIT child slices.
- *
- * <p>All maps are {@link ConcurrentHashMap} and per-parent mutations use the {@link
- * ConcurrentHashMap#compute compute} idiom to avoid lost updates from concurrent fills on different
- * children of the same parent.
- */
 @Component
 public class ParentChildOrderRegistry {
 
@@ -81,7 +74,6 @@ public class ParentChildOrderRegistry {
     progress.remove(parentOrderId);
   }
 
-  /** Diagnostics — returns count of currently-tracked parents. */
   public int trackedParents() {
     return parents.size();
   }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/lifecycle/OrderLifecycleManager.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/lifecycle/OrderLifecycleManager.java
@@ -22,15 +22,9 @@ public class OrderLifecycleManager {
   private static final Set<OrderStatus> TERMINAL_STATUSES =
       Set.of(OrderStatus.FILLED, OrderStatus.CANCELLED, OrderStatus.REJECTED);
 
-  /**
-   * How long a terminal order stays queryable before eviction. Order-manager is the durable system
-   * of record; this in-memory map only needs to cover in-flight orders plus a comfortable window
-   * for REST lookups and late execution reports.
-   */
   private static final Duration TERMINAL_RETENTION = Duration.ofHours(6);
 
   private final ConcurrentHashMap<String, Order> orders = new ConcurrentHashMap<>();
-  // Secondary index so fill processing doesn't scan every tracked order per execution report.
   private final ConcurrentHashMap<String, String> orderIdByExchangeId = new ConcurrentHashMap<>();
   private final OrderEventPublisher publisher;
 
@@ -53,7 +47,6 @@ public class OrderLifecycleManager {
     publish(order, null, null);
   }
 
-  /** Index an order under its venue-assigned id so execution reports resolve in O(1). */
   public void registerExchangeOrderId(String exchangeOrderId, String orderId) {
     if (exchangeOrderId != null && orderId != null) {
       orderIdByExchangeId.put(exchangeOrderId, orderId);
@@ -71,7 +64,6 @@ public class OrderLifecycleManager {
       throw new IllegalStateTransitionException(orderId, currentStatus, newStatus);
     }
 
-    // Atomic CAS
     if (!order.compareAndSetStatus(currentStatus, newStatus)) {
       throw new IllegalStateTransitionException(orderId, currentStatus, newStatus);
     }
@@ -96,8 +88,6 @@ public class OrderLifecycleManager {
         return order;
       }
     }
-    // Fallback scan covers call sites that set the exchange id directly on the Order without
-    // registering the index entry.
     var found =
         orders.values().stream()
             .filter(order -> exchangeOrderId.equals(order.getExchangeOrderId()))
@@ -109,10 +99,6 @@ public class OrderLifecycleManager {
     return found;
   }
 
-  /**
-   * Evict terminal orders older than {@link #TERMINAL_RETENTION} so the in-memory map doesn't grow
-   * without bound on a long-running process.
-   */
   @Scheduled(fixedDelayString = "PT15M")
   void evictStaleTerminalOrders() {
     var cutoff = Instant.now().minus(TERMINAL_RETENTION);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/metrics/ExecutionMetrics.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/metrics/ExecutionMetrics.java
@@ -118,9 +118,6 @@ public class ExecutionMetrics {
       java.util.function.ToIntFunction<T> buyDepth,
       java.util.function.ToIntFunction<T> sellDepth,
       java.util.function.ToIntFunction<T> restingOrders) {
-    // Pass the live source bean (not a lambda capturing it) so Micrometer's WeakReference keeps a
-    // strong handle as long as the bean is alive. Lambdas get GC'd shortly after register() and
-    // the gauge degrades to NaN.
     io.micrometer.core.instrument.Gauge.builder(
             "mariaalpha.execution.internal.book.buy.depth", source, buyDepth::applyAsInt)
         .register(registry);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PegType.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PegType.java
@@ -1,18 +1,5 @@
 package com.mariaalpha.executionengine.pegged;
 
-/**
- * Reference price the order's working limit price is pegged to (roadmap 3.2.3).
- *
- * <ul>
- *   <li>{@link #MIDPOINT} — pegs to {@code (bid + ask) / 2}. Common in dark pools and
- *       internalisation engines; the order rests at the midpoint and crosses against incoming flow
- *       on the opposite side.
- *   <li>{@link #PRIMARY} — pegs to the join-side: a BUY rests at the bid, a SELL rests at the ask.
- *       Passive — the order adds liquidity and waits to be lifted/hit.
- *   <li>{@link #MARKET} — pegs to the take-side: a BUY tracks the ask, a SELL tracks the bid.
- *       Aggressive — the order is poised to cross as soon as the opposite side flinches.
- * </ul>
- */
 public enum PegType {
   MIDPOINT,
   PRIMARY,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedChildFactory.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedChildFactory.java
@@ -8,14 +8,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import org.springframework.stereotype.Component;
 
-/**
- * Builds the LIMIT child order that fronts a PEGGED parent at the venue.
- *
- * <p>The child inherits the parent's symbol, side, and remaining quantity; its limit price is the
- * freshly-computed pegged price. The {@code strategyName} on the child is the literal {@code
- * "PEGGED-CHILD"} so downstream TCA / metrics group child fills under the parent strategy. The
- * parent's {@code orderId} flows into the child as {@code parentOrderId}.
- */
 @Component
 public class PeggedChildFactory {
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedConfig.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedConfig.java
@@ -2,18 +2,6 @@ package com.mariaalpha.executionengine.pegged;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Knobs for the pegged-order module (roadmap 3.2.3).
- *
- * <ul>
- *   <li>{@link #repegThresholdBps()} — minimum reference-price move (in bps relative to the
- *       previously-submitted child price) that triggers a cancel-and-resubmit. A threshold of 0
- *       would re-peg on every tick — chatty and expensive in venue fees, so we default to 5 bps.
- *   <li>{@link #maxOffsetBps()} — hard ceiling on |pegOffsetBps|. A misconfigured caller setting
- *       offset=10_000 would push the limit price 100% beyond the reference; the cap protects
- *       against that.
- * </ul>
- */
 @ConfigurationProperties(prefix = "execution-engine.pegged")
 public record PeggedConfig(int repegThresholdBps, int maxOffsetBps) {
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedCoordinator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedCoordinator.java
@@ -17,17 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Owns the lifecycle of PEGGED parent orders (roadmap 3.2.3): translates each parent into a single
- * LIMIT child at the pegged price, and as NBBO ticks arrive, cancels and resubmits a fresh child
- * when the reference moves by more than {@link PeggedConfig#repegThresholdBps()}.
- *
- * <p>Hooked into {@link com.mariaalpha.executionengine.service.OrderExecutionService} the same way
- * {@link com.mariaalpha.executionengine.iceberg.IcebergCoordinator} is — {@link #onParentSubmit}
- * replaces the normal venue dispatch for PEGGED parents, and {@link #onChildFillIfApplicable} fires
- * after each child's fill event. NBBO subscription is established at startup via {@link
- * MarketStateTracker#subscribe}.
- */
 @Component
 public class PeggedCoordinator {
 
@@ -72,13 +61,6 @@ public class PeggedCoordinator {
     marketStateTracker.subscribe(this::onMarketStateUpdate);
   }
 
-  /**
-   * Called by {@code OrderExecutionService.processOrder} when it encounters a PEGGED parent.
-   * Computes the initial pegged price, submits the first LIMIT child, and transitions the parent to
-   * SUBMITTED.
-   *
-   * @return true if the first child was accepted by its venue, false if rejected.
-   */
   public boolean onParentSubmit(Order parent) {
     var marketState = marketStateTracker.getMarketState(parent.getSymbol());
     var reference =
@@ -102,10 +84,6 @@ public class PeggedCoordinator {
     return submitChild(parent, reference, price, false);
   }
 
-  /**
-   * Called after each child {@link ExecutionReport} is processed. No-op if the order is not a
-   * pegged child.
-   */
   public void onChildFillIfApplicable(Order child, ExecutionReport report) {
     if (child.getParentOrderId() == null) {
       return;
@@ -125,23 +103,15 @@ public class PeggedCoordinator {
     if (updated.parentComplete()) {
       finalizeParentFilled(parent);
     }
-    // If the child is complete but parent isn't, the next NBBO tick submits a fresh child
-    // through onMarketStateUpdate (unconditionally when no child is active — see maybeRepeg).
     // No immediate resubmit here — we don't have a fresh reference.
   }
 
-  /** Cascade a parent CANCELLED transition to the currently-active child, if any. */
   public void onParentCancelRequested(Order parent) {
     cancelActiveChild(parent.getOrderId());
     transition(parent, OrderStatus.CANCELLED, "pegged-parent-cancelled");
     registry.removeParent(parent.getOrderId());
   }
 
-  /**
-   * Listener for every {@link MarketState} update from {@link MarketStateTracker}. Walks the open
-   * pegged parents for this symbol; if the recomputed pegged price has moved past {@code
-   * repegThresholdBps}, cancels the active child and submits a fresh one.
-   */
   void onMarketStateUpdate(MarketState state) {
     if (state == null || registry.trackedParents() == 0) {
       return;
@@ -166,8 +136,6 @@ public class PeggedCoordinator {
 
   private void maybeRepeg(Order parent, MarketState state) {
     if (isTerminal(parent.getStatus())) {
-      // Parent was rejected/cancelled/filled outside the coordinator (e.g. first child rejected
-      // and OrderExecutionService transitioned the parent) — stop tracking it.
       registry.removeParent(parent.getOrderId());
       return;
     }
@@ -190,9 +158,6 @@ public class PeggedCoordinator {
       return;
     }
     boolean hasActiveChild = progress.activeChildOrderId() != null;
-    // With no active child (previous child filled completely but the parent still has remaining
-    // quantity), resubmit on the next tick regardless of how little the price moved — otherwise
-    // the residual would sit idle until the market moved a full repeg threshold.
     if (hasActiveChild
         && !priceCalculator.shouldRepeg(
             progress.lastSubmittedPrice(), newPrice, config.repegThresholdBps())) {
@@ -212,8 +177,6 @@ public class PeggedCoordinator {
 
   private boolean submitChild(
       Order parent, BigDecimal reference, BigDecimal limitPrice, boolean isRepeg) {
-    // Remaining quantity lives in the registry's PeggedProgress — child fills are applied to the
-    // child orders, never to the parent Order object, so parent.getFilledQuantity() is always 0.
     var remaining =
         registry.progress(parent.getOrderId()).map(PeggedProgress::remainingQuantity).orElse(0);
     if (remaining <= 0) {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedCoordinator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedCoordinator.java
@@ -195,9 +195,16 @@ public class PeggedCoordinator {
     VenueAdapter adapter = adapterOpt.get();
     child.setVenue(adapter.venueName());
     lifecycleManager.registerOrder(child);
+    // Link child -> parent in the registry BEFORE submitting to the venue. An INTERNAL_CROSS venue
+    // crosses synthetically and fires the fill callback on another thread before submitOrder
+    // returns; onChildFillIfApplicable drops fills whose child->parent link isn't registered yet,
+    // which would leave the parent hung at SUBMITTED. Rolled back below if the venue rejects.
+    registry.recordChildSubmitted(
+        parent.getOrderId(), child.getOrderId(), reference, limitPrice, isRepeg);
     var instruction = limitHandler.toExecutionInstruction(child);
     var ack = adapter.submitOrder(instruction);
     if (!ack.accepted()) {
+      registry.recordChildCancelled(parent.getOrderId(), child.getOrderId());
       LOG.warn(
           "Pegged child {} rejected by venue {}: {}",
           child.getOrderId(),
@@ -208,8 +215,6 @@ public class PeggedCoordinator {
     }
     child.setExchangeOrderId(ack.exchangeOrderId());
     lifecycleManager.registerExchangeOrderId(ack.exchangeOrderId(), child.getOrderId());
-    registry.recordChildSubmitted(
-        parent.getOrderId(), child.getOrderId(), reference, limitPrice, isRepeg);
     transition(child, OrderStatus.SUBMITTED, null);
     if (parent.getStatus() == OrderStatus.NEW) {
       transition(parent, OrderStatus.SUBMITTED, null);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedCoordinator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedCoordinator.java
@@ -195,10 +195,6 @@ public class PeggedCoordinator {
     VenueAdapter adapter = adapterOpt.get();
     child.setVenue(adapter.venueName());
     lifecycleManager.registerOrder(child);
-    // Link child -> parent in the registry BEFORE submitting to the venue. An INTERNAL_CROSS venue
-    // crosses synthetically and fires the fill callback on another thread before submitOrder
-    // returns; onChildFillIfApplicable drops fills whose child->parent link isn't registered yet,
-    // which would leave the parent hung at SUBMITTED. Rolled back below if the venue rejects.
     registry.recordChildSubmitted(
         parent.getOrderId(), child.getOrderId(), reference, limitPrice, isRepeg);
     var instruction = limitHandler.toExecutionInstruction(child);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedMetrics.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedMetrics.java
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
-/** Per-component instrumentation for the pegged-order module (roadmap 3.2.3). */
 @Component
 public class PeggedMetrics {
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedPriceCalculator.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedPriceCalculator.java
@@ -6,30 +6,11 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import org.springframework.stereotype.Component;
 
-/**
- * Pure computation of the working limit price for a pegged order (roadmap 3.2.3).
- *
- * <p>Two responsibilities:
- *
- * <ol>
- *   <li>{@link #referencePrice} — picks the right side of the NBBO for the requested {@link
- *       PegType}.
- *   <li>{@link #peggedPrice} — applies the signed offset (in bps, aggressive-toward-fill) and the
- *       optional {@code priceCap} (max for BUY, min for SELL).
- * </ol>
- *
- * <p>Separated from {@link PeggedCoordinator} so the math has dedicated unit-test coverage and so
- * the {@link PeggedOrderHandler} preview path can call it without dragging in the coordinator.
- */
 @Component
 public class PeggedPriceCalculator {
 
   private static final int PRICE_SCALE = 4;
 
-  /**
-   * Resolve the reference price for a {@code (pegType, side, marketState)} triple. Returns null if
-   * the requested reference side is unavailable (e.g. one-sided book).
-   */
   public BigDecimal referencePrice(PegType pegType, Side side, MarketState marketState) {
     if (marketState == null) {
       return null;
@@ -48,13 +29,6 @@ public class PeggedPriceCalculator {
     };
   }
 
-  /**
-   * Compute the working limit price: reference × (1 ± offset bps), then clamped by the optional
-   * {@code priceCap}. Positive offset moves the price toward fill (BUY higher, SELL lower); a
-   * negative offset pulls it the other way (more passive). Pass {@code null} or 0 for no offset.
-   *
-   * @return computed limit price, never null when {@code reference} is non-null
-   */
   public BigDecimal peggedPrice(
       BigDecimal reference, Side side, Integer offsetBps, BigDecimal priceCap) {
     if (reference == null) {
@@ -71,7 +45,6 @@ public class PeggedPriceCalculator {
     if (priceCap == null) {
       return raw;
     }
-    // priceCap is the max for BUY, min for SELL. Clamp accordingly.
     if (side == Side.BUY && raw.compareTo(priceCap) > 0) {
       return priceCap.setScale(PRICE_SCALE, RoundingMode.HALF_UP);
     }
@@ -81,10 +54,6 @@ public class PeggedPriceCalculator {
     return raw;
   }
 
-  /**
-   * True if the new price is far enough from the previously-submitted price to warrant cancelling
-   * the active child and re-submitting. Threshold is the configured {@code repegThresholdBps}.
-   */
   public boolean shouldRepeg(BigDecimal previousPrice, BigDecimal newPrice, int thresholdBps) {
     if (previousPrice == null || newPrice == null) {
       return previousPrice == null && newPrice != null;

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedProgress.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedProgress.java
@@ -2,12 +2,6 @@ package com.mariaalpha.executionengine.pegged;
 
 import java.math.BigDecimal;
 
-/**
- * Immutable progress snapshot for a single PEGGED parent order — fill state, last reference price,
- * last submitted price, and the orderId of the currently-active LIMIT child (if any). All updates
- * return a new instance so the registry can use the {@link java.util.concurrent.ConcurrentHashMap}
- * compute idiom without lock-management bugs.
- */
 public record PeggedProgress(
     int totalQuantity,
     int filledQuantity,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedProgressView.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedProgressView.java
@@ -2,10 +2,6 @@ package com.mariaalpha.executionengine.pegged;
 
 import java.math.BigDecimal;
 
-/**
- * Read-only projection of {@link PeggedProgress} for the REST endpoint. Includes the parent orderId
- * so the UI can render a row without holding onto the request.
- */
 public record PeggedProgressView(
     String parentOrderId,
     int totalQuantity,

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedRegistry.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/pegged/PeggedRegistry.java
@@ -7,14 +7,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
-/**
- * Thread-safe registry linking PEGGED parent orders to their currently-active LIMIT child slice.
- *
- * <p>Mirrors {@link com.mariaalpha.executionengine.iceberg.ParentChildOrderRegistry} but with a
- * simpler model: a PEGGED parent has at most one open child at any time (the previous child is
- * cancelled before the new one is submitted), so {@code childToParent} is single-valued and the
- * {@link PeggedProgress} carries the activeChildOrderId directly.
- */
 @Component
 public class PeggedRegistry {
 
@@ -58,9 +50,6 @@ public class PeggedRegistry {
   }
 
   public PeggedProgress recordChildCancelled(String parentOrderId, String childOrderId) {
-    // Deliberately keep the childToParent mapping: the venue cancel is asynchronous, and a fill
-    // that raced the cancel must still be attributable to the parent. The mapping is cleaned up
-    // in removeParent when the parent reaches a terminal state.
     return progress.compute(parentOrderId, (k, v) -> v == null ? null : v.withChildCancelled());
   }
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/AdvParticipationCheck.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/AdvParticipationCheck.java
@@ -5,21 +5,6 @@ import com.mariaalpha.executionengine.model.Order;
 import com.mariaalpha.executionengine.model.RiskCheckResult;
 import org.springframework.stereotype.Component;
 
-/**
- * Pre-trade ADV-relative sizing check.
- *
- * <p>Rejects orders whose share quantity exceeds {@code maxAdvParticipation × ADV(symbol)}.
- * Quantitatively, this caps the order's expected market impact: a parent that consumes more than a
- * handful of percent of typical daily volume on a single symbol is essentially guaranteed to push
- * price against itself when worked through any reasonable execution strategy. The check runs
- * against the <b>parent order</b>'s quantity, not its first slice — the intent is to reject parents
- * that are too large to source liquidly regardless of how they're chopped.
- *
- * <p>Self-disables when {@code maxAdvParticipation ≤ 0} so deployments that haven't dialed in a
- * threshold yet still wire the chain. When ADV is missing for a symbol (the conservative default of
- * 0), the check rejects every order on that symbol — the operator must explicitly add reference
- * data before trading.
- */
 @Component
 @org.springframework.core.annotation.Order(8)
 public class AdvParticipationCheck implements RiskCheck {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/BetaExposureCheck.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/BetaExposureCheck.java
@@ -10,25 +10,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import org.springframework.stereotype.Component;
 
-/**
- * Pre-trade beta-weighted exposure check.
- *
- * <p>For each open position, beta-weighted exposure is {@code position_notional × beta}. The
- * portfolio's beta-weighted exposure is the signed sum across all positions; its absolute value
- * measures how much the portfolio moves for a 1 % move in the benchmark. The check rejects any
- * order that would push {@code |Σ position × beta|} above the configured ceiling.
- *
- * <p>This catches the case where MaxPortfolioExposure passes (gross $ is fine) but the underlying
- * mix has drifted into a high-beta concentration that would amplify a market drawdown — e.g. a
- * portfolio dominated by NVDA (β ≈ 1.6) and TSLA (β ≈ 1.8) is much riskier than the same dollar
- * gross spread across MSFT (β ≈ 0.9) and broad-market ETFs.
- *
- * <p>SELLs that reduce a long position naturally pull beta-weighted exposure toward zero — the
- * check only fires when the absolute value of the projection grows beyond {@code current}.
- *
- * <p>Self-disables when {@code maxAbsoluteBetaWeightedExposure ≤ 0} so deployments that haven't
- * configured the limit yet still wire correctly.
- */
 @Component
 @org.springframework.core.annotation.Order(7)
 public class BetaExposureCheck implements RiskCheck {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/CorrelatedPositionsCheck.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/CorrelatedPositionsCheck.java
@@ -12,24 +12,6 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
-/**
- * Pre-trade correlated-positions concentration check (roadmap 3.5.2).
- *
- * <p>Models the case where the standard sector / beta checks pass — gross exposure looks fine, the
- * portfolio's β is in the green — but the underlying mix has concentrated into a small set of
- * symbols whose returns historically move together. Two megacap-tech names plus a mega-cap chip
- * stock might span two sectors and present a normal β, yet a single drawdown in the AI trade would
- * take all three down at once.
- *
- * <p>Each {@link CorrelatedCluster} is a named list of symbols plus a $-cap on gross exposure
- * within that cluster. The check evaluates every cluster the order touches and rejects when the
- * projected gross within the cluster exceeds the cluster's cap (and would grow vs. the current
- * cluster gross — a SELL flattening a long inside the cluster always passes).
- *
- * <p>A symbol may appear in multiple clusters; each is evaluated independently. Symbols outside any
- * cluster are not constrained by this check. If the configured cluster list is empty the check
- * self-disables.
- */
 @Component
 @org.springframework.core.annotation.Order(10)
 public class CorrelatedPositionsCheck implements RiskCheck {
@@ -123,8 +105,6 @@ public class CorrelatedPositionsCheck implements RiskCheck {
       }
     }
     if (!orderSymbolSeen) {
-      // No existing position on the order's symbol; add it iff BUY (a fresh SELL would create a
-      // short that does grow the gross — handled in the same branch).
       var delta = side == Side.BUY ? orderNotional : orderNotional.negate();
       projected = projected.add(delta.abs());
     }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/DailyLossMonitor.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/DailyLossMonitor.java
@@ -18,15 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * Tracks realized intraday P&L and trips the kill-switch when the configured {@code maxDailyLoss}
- * is breached.
- *
- * <p>Realized P&L requires knowing the entry price of the position being closed, so the monitor
- * keeps its own per-symbol (net quantity, average cost) book, updated on every fill. A fill that
- * extends a position realizes nothing; a fill that reduces or flips one realizes {@code (fillPrice
- * − avgCost) × closedQty × sign(position)} on the closed portion.
- */
 @Component
 public class DailyLossMonitor {
 
@@ -34,7 +25,6 @@ public class DailyLossMonitor {
   private static final ZoneId ET = ZoneId.of("America/New_York");
   private static final int SCALE = 8;
 
-  /** Per-symbol open position: signed share quantity and average entry cost. */
   private record Lot(BigDecimal quantity, BigDecimal avgCost) {
     static final Lot FLAT = new Lot(BigDecimal.ZERO, BigDecimal.ZERO);
   }
@@ -52,7 +42,6 @@ public class DailyLossMonitor {
     this.lastResetDate = LocalDate.now(ET);
   }
 
-  /** Called on every fill: updates the per-symbol book and accumulates realized P&L. */
   public void onFill(Fill fill) {
     var realized = new AtomicReference<>(BigDecimal.ZERO);
     var fillQty = BigDecimal.valueOf(fill.fillQuantity());
@@ -66,7 +55,6 @@ public class DailyLossMonitor {
           int fillSign = signedQty.signum();
 
           if (currentSign == 0 || currentSign == fillSign) {
-            // Opening or extending: weighted-average the entry cost, realize nothing.
             var newQty = current.quantity().add(signedQty);
             var newAvg =
                 newQty.signum() == 0
@@ -79,7 +67,6 @@ public class DailyLossMonitor {
             return new Lot(newQty, newAvg);
           }
 
-          // Reducing or flipping: realize P&L on the closed portion.
           var closedQty = signedQty.abs().min(current.quantity().abs());
           realized.set(
               fill.fillPrice()
@@ -90,7 +77,6 @@ public class DailyLossMonitor {
           if (newQty.signum() == 0) {
             return Lot.FLAT;
           }
-          // Flipped: the residual opens a new position at the fill price.
           var newAvg = newQty.signum() == currentSign ? current.avgCost() : fill.fillPrice();
           return new Lot(newQty, newAvg);
         });
@@ -109,7 +95,6 @@ public class DailyLossMonitor {
     return dailyPnl.get();
   }
 
-  /** Auto-reset at market open each trading day. Open positions carry over. */
   @Scheduled(cron = "0 30 9 * * MON-FRI", zone = "America/New_York")
   public void resetDailyLimits() {
     dailyPnl.set(BigDecimal.ZERO);
@@ -142,6 +127,5 @@ public class DailyLossMonitor {
                 "Daily P&L $%s exceeds loss limit of $%d", dailyPnl.get(), config.maxDailyLoss()),
             Instant.now());
     alertPublisher.publish(alert);
-    // Cancel all open orders (handled by OrderExecutionService)
   }
 }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/IntradayVarCheck.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/IntradayVarCheck.java
@@ -11,31 +11,6 @@ import java.math.RoundingMode;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
-/**
- * Pre-trade intraday Value-at-Risk check (roadmap 3.5.1).
- *
- * <p>Computes a parametric (Gaussian) one-day VaR for the projected portfolio at the configured
- * {@code varConfidenceLevel} and rejects any order whose addition would push the projection past
- * {@code maxIntradayVar}.
- *
- * <p>Per-symbol VaR contribution:
- *
- * <pre>
- *   var_i = |position_notional_i| × σ_ann_i / √trading-days × z(confidence)
- * </pre>
- *
- * <p>Portfolio VaR is the sum of |var_i| across all symbols — the conservative reading that assumes
- * no diversification benefit (perfect tail-correlation). A correlation-aware version is a future
- * concern; for an MVP risk check, the no-diversification assumption is the right side to err on.
- *
- * <p>Symbols whose annualised volatility is missing from {@link SymbolReferenceData} contribute 0
- * to the projection — the check is a safety net, not a substitute for proper reference data. If
- * {@code maxIntradayVar ≤ 0} the check self-disables.
- *
- * <p>SELLs that flatten a long position naturally pull VaR toward zero; the check only fires when
- * the projection both exceeds the limit AND exceeds the current portfolio VaR (so a re-balancing
- * trade that reduces total risk is never gated).
- */
 @Component
 @org.springframework.core.annotation.Order(9)
 public class IntradayVarCheck implements RiskCheck {
@@ -100,14 +75,12 @@ public class IntradayVarCheck implements RiskCheck {
     return RiskCheckResult.pass(name());
   }
 
-  /** Sum-of-absolutes VaR across the existing portfolio (no diversification credit). */
   private BigDecimal portfolioVar(Map<String, BigDecimal> positions, double zscore, double sqrtT) {
     return positions.entrySet().stream()
         .map(e -> positionVar(e.getKey(), e.getValue(), zscore, sqrtT))
         .reduce(BigDecimal.ZERO, BigDecimal::add);
   }
 
-  /** Portfolio VaR after applying the incoming {@code order} to its symbol's existing position. */
   private BigDecimal projectedVar(
       Map<String, BigDecimal> positions,
       String orderSymbol,
@@ -140,11 +113,6 @@ public class IntradayVarCheck implements RiskCheck {
     return positionNotional.abs().multiply(BigDecimal.valueOf(scalar));
   }
 
-  /**
-   * Standard-normal one-tail z-score for a confidence level. Inlined Abramowitz &amp; Stegun
-   * 26.2.23 rational approximation — accurate to ~4.5×10⁻⁴, plenty for VaR thresholds. Defaults to
-   * the 95% z-score (1.645) when the configured level is out of range.
-   */
   static double zscore(double confidenceLevel) {
     double p = 1.0 - confidenceLevel;
     if (p <= 0 || p >= 1) {

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/RiskCheckChain.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/RiskCheckChain.java
@@ -22,7 +22,6 @@ public class RiskCheckChain {
         checks.stream().map(RiskCheck::name).toList());
   }
 
-  /** Runs all checks in order. Short-circuits on the first failure. */
   public RiskCheckResult evaluate(Order order) {
     for (var check : checks) {
       var result = check.check(order);

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/SectorExposureCheck.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/SectorExposureCheck.java
@@ -9,23 +9,6 @@ import com.mariaalpha.executionengine.service.PositionTracker;
 import java.math.BigDecimal;
 import org.springframework.stereotype.Component;
 
-/**
- * Pre-trade sector concentration check.
- *
- * <p>Aggregates the absolute notional of every existing position by sector (looked up via {@link
- * SymbolReferenceData}), projects the incoming order onto that sector, and rejects when the
- * projection would push the sector past its configured ceiling. Each sector has its own ceiling via
- * {@code execution-engine.risk.sector-exposure-limits.<SECTOR>}; the default ceiling ({@code
- * default-sector-exposure-limit}) covers sectors not explicitly listed, including the synthetic
- * {@code UNKNOWN} sector that captures unmapped symbols.
- *
- * <p>The check skips itself if {@code defaultSectorExposureLimit ≤ 0} and the order's sector has no
- * explicit ceiling — this keeps the existing risk-chain wiring functional during the rollout before
- * reference-data and limits are configured.
- *
- * <p>BUYs grow the sector's gross exposure; SELLs shrink an existing long position toward zero,
- * which is always allowed (the check only fires when {@code projected > current}).
- */
 @Component
 @org.springframework.core.annotation.Order(6)
 public class SectorExposureCheck implements RiskCheck {
@@ -56,7 +39,6 @@ public class SectorExposureCheck implements RiskCheck {
     var sector = refData.sectorOf(order.getSymbol());
     long limit = limitFor(sector);
     if (limit <= 0) {
-      // Not configured for this sector and no default — risk check is disabled.
       return RiskCheckResult.pass(name());
     }
 
@@ -68,9 +50,6 @@ public class SectorExposureCheck implements RiskCheck {
 
     var sectorExposure = currentSectorExposure(sector);
     var orderNotional = market.lastTradePrice().multiply(BigDecimal.valueOf(order.getQuantity()));
-    // SELLs reduce exposure; only BUYs (and shorts increasing magnitude) push the projection past
-    // the limit. We compute the signed delta against the symbol's current position so a SELL that
-    // flattens a long is treated as a reduction.
     var projected =
         projectedSectorExposure(sector, order.getSymbol(), order.getSide(), orderNotional);
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/SymbolReferenceData.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/risk/SymbolReferenceData.java
@@ -9,15 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Symbol-keyed lookup for sector / beta / ADV reference data.
- *
- * <p>Loads {@code execution-engine.risk.reference-data.symbols[]} at startup into an in-memory map
- * and falls back to {@code execution-engine.risk.reference-data.defaults} for any symbol not
- * explicitly configured. The fallback keeps the sector/beta/ADV risk checks safe — an unmapped
- * symbol lands in the {@code UNKNOWN} sector with the conservative default beta and a zero ADV (so
- * the ADV-participation check rejects every order on that symbol until reference data is added).
- */
 @Component
 public class SymbolReferenceData {
 
@@ -56,32 +47,22 @@ public class SymbolReferenceData {
         defaults.adv());
   }
 
-  /** Sector classification for {@code symbol}, or {@code defaults.sector()} if unknown. */
   public String sectorOf(String symbol) {
     return bySymbol.getOrDefault(symbol, defaults).sector();
   }
 
-  /** Beta vs. benchmark for {@code symbol}, or {@code defaults.beta()} if unknown. */
   public double betaOf(String symbol) {
     return bySymbol.getOrDefault(symbol, defaults).beta();
   }
 
-  /** Average Daily Volume (shares) for {@code symbol}, or {@code defaults.adv()} if unknown. */
   public long advOf(String symbol) {
     return bySymbol.getOrDefault(symbol, defaults).adv();
   }
 
-  /**
-   * Annualised volatility of log-returns (decimal — 0.25 == 25%/yr) for {@code symbol}, or {@code
-   * defaults.annualizedVolatility()} if unknown. {@code 0.0} means "vol unknown" — the VaR check
-   * treats that as a zero risk contribution so missing reference data never inflates the
-   * projection.
-   */
   public double annualizedVolatilityOf(String symbol) {
     return bySymbol.getOrDefault(symbol, defaults).annualizedVolatility();
   }
 
-  /** True iff explicit reference data was loaded for this symbol. */
   public boolean isMapped(String symbol) {
     return bySymbol.containsKey(symbol);
   }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/router/DirectRouter.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/router/DirectRouter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(name = "execution-engine.sor.mode", havingValue = "direct")
 public class DirectRouter implements SmartOrderRouter {
 
-  private static final String VENUE = "PRIMARY"; // profile-dependent
+  private static final String VENUE = "PRIMARY";
 
   private final RoutingDecisionPublisher publisher;
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/router/scorer/VenueScoreCriterion.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/router/scorer/VenueScoreCriterion.java
@@ -2,9 +2,7 @@ package com.mariaalpha.executionengine.router.scorer;
 
 public interface VenueScoreCriterion {
 
-  /** Stable identifier used as a key in the audit JSON breakdown and weights map. */
   String name();
 
-  /** Return a score in {@code [0.0, 1.0]}. Implementations must clamp. */
   double score(ScoringContext ctx);
 }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/BasketTradingService.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/BasketTradingService.java
@@ -18,18 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-/**
- * Program/basket trading engine (roadmap 3.4.1). Fans a list of legs out through the standard
- * single-order pipeline ({@link OrderExecutionService#submitOrder}) so each leg gets the full risk
- * → SOR → venue treatment and emits its own {@code orders.lifecycle} events, while a {@link
- * BasketRegistry}/{@link com.mariaalpha.executionengine.basket.BasketCoordinator} pair tracks the
- * aggregate. The engine is broker- and market-agnostic — it sits entirely on top of the existing
- * execution pipeline.
- *
- * <p>Ordering matters: the basket state is registered and each leg is linked to it <em>before</em>
- * the leg is submitted, so a fill that races ahead of the synchronous {@code submitOrder} return is
- * still attributed to the basket.
- */
 @Service
 public class BasketTradingService {
 
@@ -50,7 +38,6 @@ public class BasketTradingService {
     if (request.legs() == null || request.legs().isEmpty()) {
       throw new IllegalArgumentException("Basket order requires at least one leg");
     }
-    // All-or-nothing validation: reject the whole request before any leg is sent to a venue.
     request.legs().forEach(BasketTradingService::validateLeg);
 
     var basketId = UUID.randomUUID().toString();
@@ -93,8 +80,6 @@ public class BasketTradingService {
             leg.tif(),
             null);
     var order = new Order(signal);
-    // Track the leg and link it to the basket BEFORE submission so a synchronous fill is
-    // attributed.
     state.addLeg(order.getOrderId(), leg.symbol(), leg.side(), leg.quantity());
     registry.linkLeg(order.getOrderId(), basketId);
 

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/BasketTradingService.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/BasketTradingService.java
@@ -1,0 +1,125 @@
+package com.mariaalpha.executionengine.service;
+
+import com.mariaalpha.executionengine.basket.BasketMetrics;
+import com.mariaalpha.executionengine.basket.BasketRegistry;
+import com.mariaalpha.executionengine.basket.BasketState;
+import com.mariaalpha.executionengine.basket.BasketView;
+import com.mariaalpha.executionengine.controller.dto.BasketLegRequest;
+import com.mariaalpha.executionengine.controller.dto.BasketOrderRequest;
+import com.mariaalpha.executionengine.model.Order;
+import com.mariaalpha.executionengine.model.OrderSignal;
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.OrderType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Program/basket trading engine (roadmap 3.4.1). Fans a list of legs out through the standard
+ * single-order pipeline ({@link OrderExecutionService#submitOrder}) so each leg gets the full risk
+ * → SOR → venue treatment and emits its own {@code orders.lifecycle} events, while a {@link
+ * BasketRegistry}/{@link com.mariaalpha.executionengine.basket.BasketCoordinator} pair tracks the
+ * aggregate. The engine is broker- and market-agnostic — it sits entirely on top of the existing
+ * execution pipeline.
+ *
+ * <p>Ordering matters: the basket state is registered and each leg is linked to it <em>before</em>
+ * the leg is submitted, so a fill that races ahead of the synchronous {@code submitOrder} return is
+ * still attributed to the basket.
+ */
+@Service
+public class BasketTradingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BasketTradingService.class);
+
+  private final OrderExecutionService executionService;
+  private final BasketRegistry registry;
+  private final BasketMetrics metrics;
+
+  public BasketTradingService(
+      OrderExecutionService executionService, BasketRegistry registry, BasketMetrics metrics) {
+    this.executionService = executionService;
+    this.registry = registry;
+    this.metrics = metrics;
+  }
+
+  public BasketView submit(BasketOrderRequest request) {
+    if (request.legs() == null || request.legs().isEmpty()) {
+      throw new IllegalArgumentException("Basket order requires at least one leg");
+    }
+    // All-or-nothing validation: reject the whole request before any leg is sent to a venue.
+    request.legs().forEach(BasketTradingService::validateLeg);
+
+    var basketId = UUID.randomUUID().toString();
+    var state = new BasketState(basketId, request.name(), Instant.now());
+    registry.register(state);
+
+    for (var leg : request.legs()) {
+      submitLeg(basketId, state, leg);
+    }
+
+    metrics.recordBasketSubmitted(basketId, request.legs().size());
+    LOG.info(
+        "Basket {} submitted with {} legs ({} accepted)",
+        basketId,
+        request.legs().size(),
+        state.toView().acceptedLegs());
+    return state.toView();
+  }
+
+  public Optional<BasketView> get(String basketId) {
+    return registry.view(basketId);
+  }
+
+  public List<BasketView> list() {
+    return registry.all();
+  }
+
+  private void submitLeg(String basketId, BasketState state, BasketLegRequest leg) {
+    var signal =
+        new OrderSignal(
+            leg.symbol(),
+            leg.side(),
+            leg.quantity(),
+            leg.orderType(),
+            leg.limitPrice(),
+            leg.stopPrice(),
+            "BASKET",
+            Instant.now(),
+            null,
+            leg.tif(),
+            null);
+    var order = new Order(signal);
+    // Track the leg and link it to the basket BEFORE submission so a synchronous fill is
+    // attributed.
+    state.addLeg(order.getOrderId(), leg.symbol(), leg.side(), leg.quantity());
+    registry.linkLeg(order.getOrderId(), basketId);
+
+    executionService.submitOrder(order);
+
+    var status = order.getStatus();
+    state.recordSubmissionOutcome(
+        order.getOrderId(),
+        status,
+        status == OrderStatus.REJECTED ? "rejected at submission" : null);
+    if (status == OrderStatus.REJECTED) {
+      metrics.recordLegRejected(leg.symbol());
+    }
+  }
+
+  private static void validateLeg(BasketLegRequest leg) {
+    if (leg.orderType() == OrderType.ICEBERG || leg.orderType() == OrderType.PEGGED) {
+      throw new IllegalArgumentException(
+          "Basket legs do not support the " + leg.orderType() + " order type");
+    }
+    if (leg.orderType() == OrderType.LIMIT && leg.limitPrice() == null) {
+      throw new IllegalArgumentException("LIMIT leg " + leg.symbol() + " requires a limitPrice");
+    }
+    if (leg.orderType() == OrderType.STOP && leg.stopPrice() == null) {
+      throw new IllegalArgumentException("STOP leg " + leg.symbol() + " requires a stopPrice");
+    }
+  }
+}

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/ManualOrderService.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/ManualOrderService.java
@@ -84,8 +84,6 @@ public class ManualOrderService {
         peggedCoordinator.onParentCancelRequested(order);
         return true;
       }
-      // Cancel at the venue first — without this the order stays live at the exchange and a
-      // later fill would arrive for an order we consider CANCELLED.
       if (order.getExchangeOrderId() != null && order.getVenue() != null) {
         venueAdapters
             .get(order.getVenue())

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/MarketStateTracker.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/MarketStateTracker.java
@@ -9,14 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Per-symbol last-seen {@link MarketState}, plus a fan-out hook so components that need to react to
- * NBBO ticks (e.g. {@link com.mariaalpha.executionengine.pegged.PeggedCoordinator}) can register
- * without coupling themselves to {@code MarketDataConsumer}.
- *
- * <p>Listener invocation is best-effort: a listener that throws is logged and skipped — one bad
- * subscriber must never derail the tick fan-out to the others.
- */
 @Component
 public class MarketStateTracker {
 
@@ -44,7 +36,6 @@ public class MarketStateTracker {
     return states.get(symbol);
   }
 
-  /** Subscribe a listener that fires for every {@link #update(MarketState)} call. */
   public void subscribe(Consumer<MarketState> listener) {
     listeners.add(listener);
   }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/OrderExecutionService.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/OrderExecutionService.java
@@ -1,6 +1,7 @@
 package com.mariaalpha.executionengine.service;
 
 import com.mariaalpha.executionengine.adapter.VenueAdapterRegistry;
+import com.mariaalpha.executionengine.basket.BasketCoordinator;
 import com.mariaalpha.executionengine.handler.OrderTypeHandlerRegistry;
 import com.mariaalpha.executionengine.iceberg.IcebergCoordinator;
 import com.mariaalpha.executionengine.lifecycle.IllegalStateTransitionException;
@@ -37,6 +38,7 @@ public class OrderExecutionService {
   private final ExecutionMetrics metrics;
   private final IcebergCoordinator icebergCoordinator;
   private final PeggedCoordinator peggedCoordinator;
+  private final BasketCoordinator basketCoordinator;
 
   public OrderExecutionService(
       OrderTypeHandlerRegistry handlerRegistry,
@@ -48,7 +50,8 @@ public class OrderExecutionService {
       DailyLossMonitor dailyLossMonitor,
       ExecutionMetrics metrics,
       IcebergCoordinator icebergCoordinator,
-      PeggedCoordinator peggedCoordinator) {
+      PeggedCoordinator peggedCoordinator,
+      BasketCoordinator basketCoordinator) {
     this.handlerRegistry = handlerRegistry;
     this.riskCheckChain = riskCheckChain;
     this.router = router;
@@ -59,6 +62,7 @@ public class OrderExecutionService {
     this.metrics = metrics;
     this.icebergCoordinator = icebergCoordinator;
     this.peggedCoordinator = peggedCoordinator;
+    this.basketCoordinator = basketCoordinator;
   }
 
   @PostConstruct
@@ -263,6 +267,9 @@ public class OrderExecutionService {
     }
     if (peggedCoordinator != null) {
       peggedCoordinator.onChildFillIfApplicable(order, report);
+    }
+    if (basketCoordinator != null) {
+      basketCoordinator.onLegFillIfApplicable(order, report);
     }
   }
 }

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/OrderExecutionService.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/OrderExecutionService.java
@@ -208,13 +208,11 @@ public class OrderExecutionService {
       return;
     }
 
-    // Zero-quantity terminal event: IOC residual cancel, FOK kill, or generic exchange cancel.
     if (report.fillQuantity() == 0 && report.remainingQuantity() == 0) {
       var reason = report.reason() != null ? report.reason() : "exchange-cancel";
       try {
         lifecycleManager.transition(order.getOrderId(), OrderStatus.CANCELLED, null, reason);
       } catch (IllegalStateTransitionException e) {
-        // Already terminal (FILLED on prior partial, etc.) — log and continue.
         LOG.debug(
             "Skipping cancel transition for order {} ({})", order.getOrderId(), e.getMessage());
         return;
@@ -223,9 +221,7 @@ public class OrderExecutionService {
         case "ioc-residual-cancel" ->
             metrics.recordIocResidualCancelled(order.getSymbol(), order.getSide().name());
         case "fok-killed" -> metrics.recordFokKilled(order.getSymbol(), order.getSide().name());
-        default -> {
-          /* generic cancel — no dedicated counter */
-        }
+        default -> {}
       }
       return;
     }
@@ -246,8 +242,6 @@ public class OrderExecutionService {
     try {
       lifecycleManager.transition(order.getOrderId(), newStatus, fill, null);
     } catch (IllegalStateTransitionException e) {
-      // A fill can race a cancel (the venue filled before our cancel landed). The order is
-      // already terminal locally, but the fill is real — keep counting it below.
       LOG.warn(
           "Fill {} arrived for order {} already in terminal state: {}",
           fill.fillId(),

--- a/execution-engine/src/main/java/com/mariaalpha/executionengine/service/PositionTracker.java
+++ b/execution-engine/src/main/java/com/mariaalpha/executionengine/service/PositionTracker.java
@@ -18,17 +18,12 @@ public class PositionTracker {
     return positions.getOrDefault(symbol, BigDecimal.ZERO);
   }
 
-  /**
-   * Sums the absolute value of every position (long positions are positive, shorts are negative) to
-   * get total market exposure regardless of direction.
-   */
   public BigDecimal getTotalGrossExposure() {
     return positions.values().stream()
         .map(BigDecimal::abs)
         .reduce(BigDecimal.ZERO, BigDecimal::add);
   }
 
-  /** Live snapshot of every tracked position keyed by symbol. Used by the sector / beta checks. */
   public Map<String, BigDecimal> snapshot() {
     return Map.copyOf(positions);
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/AlpacaExchangeAdapterTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/AlpacaExchangeAdapterTest.java
@@ -40,7 +40,6 @@ class AlpacaExchangeAdapterTest {
 
   @Test
   void isHealthyReflectsWsState() {
-    // Before start(), adapter is not connected
     assertThat(adapter.isHealthy()).isFalse();
   }
 
@@ -51,12 +50,10 @@ class AlpacaExchangeAdapterTest {
     var listener =
         new AlpacaWebSocketListener(config, objectMapper, () -> callback::set, connected);
 
-    // Simulate onOpen
     var mockWs = mock(okhttp3.WebSocket.class);
     listener.onOpen(mockWs, mock(okhttp3.Response.class));
     assertThat(connected.get()).isTrue();
 
-    // Simulate fill message
     var json =
         """
         {
@@ -104,8 +101,6 @@ class AlpacaExchangeAdapterTest {
 
   @Test
   void webSocketFailureTriggersReconnect() {
-    // The reconnect Runnable is invoked so the adapter can schedule a backoff retry — without
-    // this, a single network blip silently drops every subsequent fill.
     var connected = new AtomicBoolean(true);
     var reconnectCount = new java.util.concurrent.atomic.AtomicInteger(0);
     var listener =
@@ -124,8 +119,6 @@ class AlpacaExchangeAdapterTest {
 
   @Test
   void abnormalCloseTriggersReconnectButCleanCloseDoesNot() {
-    // Code 1000 is the normal-shutdown reason code our PreDestroy sends. We must not reconnect
-    // when the close was intentional, but every other code (server kick, network drop) must.
     var connected = new AtomicBoolean(true);
     var reconnectCount = new java.util.concurrent.atomic.AtomicInteger(0);
     var listener =

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/IocFokSimulatedAdapterIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/IocFokSimulatedAdapterIntegrationTest.java
@@ -21,11 +21,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Exercises the IOC and FOK behavioural specs against the in-process simulated adapter. The
- * simulator uses an infinite top-of-book approximation: marketable → full fill, non-marketable →
- * cancel-only report. Depth-aware partial fills are deferred to a future enhancement.
- */
 class IocFokSimulatedAdapterIntegrationTest {
 
   private SimulatedExchangeAdapter adapter;

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/PrimaryVenueAdapterTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/PrimaryVenueAdapterTest.java
@@ -78,14 +78,11 @@ class PrimaryVenueAdapterTest {
     var primary = new PrimaryVenueAdapter(delegate, sorConfig(List.of(primaryVenue())));
     primary.start();
     primary.shutdown();
-    // PrimaryVenueAdapter never invokes the wrapped adapter's lifecycle —
-    // ExchangeAdapter manages its own @PostConstruct/@PreDestroy.
     verifyNoInteractions(delegate);
   }
 
   @Test
   void skipsDisabledPrimaryEntries() {
-    // First entry is primary but disabled — adapter should fall back to next enabled match.
     var disabled =
         new Venue("OLD_PRIMARY", VenueType.LIT, 50, 0, 0, 1.0, 10000, 1.0, "primary", false);
     var enabled =

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/SimulatedDarkPoolAdapterTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/SimulatedDarkPoolAdapterTest.java
@@ -65,7 +65,6 @@ class SimulatedDarkPoolAdapterTest {
   void seededMatchTickProducesDeterministicFills() {
     adapter.start();
     adapter.submitOrder(instruction(100));
-    // Match probability = 0.8, seed=42 → first nextDouble() (~0.7276) < 0.8 fires deterministic.
     adapter.matchTick();
     assertThat(reports).hasSize(1);
     assertThat(reports.get(0).venue()).isEqualTo("DARK_POOL_A");
@@ -74,7 +73,7 @@ class SimulatedDarkPoolAdapterTest {
 
   @Test
   void partialFillRatioRespected() {
-    adapter = adapterWith(seedConfigWithRatio(42, 1.0, 0.5)); // 50% partial, deterministic match
+    adapter = adapterWith(seedConfigWithRatio(42, 1.0, 0.5));
     adapter.onExecutionReport(reports::add);
     adapter.start();
     adapter.submitOrder(instruction(100));
@@ -90,7 +89,7 @@ class SimulatedDarkPoolAdapterTest {
         new MarketState(
             "AAPL",
             new BigDecimal("178.50"),
-            new BigDecimal("178.5001"), // 0.005 bps spread, well below 1 bps min
+            new BigDecimal("178.5001"),
             new BigDecimal("178.50"),
             Instant.now()));
     adapter = adapterWith(seedConfig(42, 1.0));
@@ -122,7 +121,7 @@ class SimulatedDarkPoolAdapterTest {
 
   @Test
   void nullMarketStateNoFill() {
-    tracker = new MarketStateTracker(); // no AAPL state
+    tracker = new MarketStateTracker();
     adapter = adapterWith(seedConfig(42, 1.0), tracker);
     adapter.onExecutionReport(reports::add);
     adapter.start();

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/SimulatedExchangeAdapterTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/SimulatedExchangeAdapterTest.java
@@ -94,7 +94,6 @@ class SimulatedExchangeAdapterTest {
     Thread.sleep(200);
     assertThat(lastReport.get()).isNull();
 
-    // Trigger with price crossing stop
     adapter.onMarketUpdate(
         new MarketState(
             "AAPL",
@@ -128,7 +127,6 @@ class SimulatedExchangeAdapterTest {
     await()
         .atMost(Duration.ofSeconds(2))
         .untilAsserted(() -> assertThat(lastReport.get()).isNotNull());
-    // Ask = 150.50, slippage = 2bps = 0.0301 → fill at ~150.53
     assertThat(lastReport.get().fillPrice()).isGreaterThan(new BigDecimal("150.50"));
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/SimulatedInternalCrossingAdapterTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/adapter/SimulatedInternalCrossingAdapterTest.java
@@ -61,7 +61,6 @@ class SimulatedInternalCrossingAdapterTest {
 
   @Test
   void syntheticOnSubmitFillsAtMidpoint() {
-    // crossProb=1.0 → adapter always asks engine to synthesize a counterparty on submit.
     adapter.start();
     adapter.submitOrder(instruction(Side.BUY, 100));
     await().atMost(Duration.ofSeconds(2)).until(() -> !reports.isEmpty());
@@ -87,7 +86,6 @@ class SimulatedInternalCrossingAdapterTest {
     adapter.start();
     adapter.submitOrder(instruction(Side.BUY, 100));
     adapter.matchTick();
-    // Reports dispatch is async on the adapter scheduler, matching other venue adapters.
     await().atMost(Duration.ofSeconds(2)).until(() -> !reports.isEmpty());
     assertThat(reports).hasSize(1);
     assertThat(adapter.pendingSize()).isZero();
@@ -129,7 +127,6 @@ class SimulatedInternalCrossingAdapterTest {
     adapter = new SimulatedInternalCrossingAdapter(seed(42, 0.0, 0.0), engine);
     adapter.onExecutionReport(reports::add);
     adapter.start();
-    // Resting SELL meets aggressing BUY → engine crosses at midpoint, both sides get a report.
     adapter.submitOrder(instruction(Side.SELL, 100));
     adapter.submitOrder(instruction(Side.BUY, 100));
     await().atMost(Duration.ofSeconds(2)).until(() -> reports.size() >= 2);

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketCoordinatorTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketCoordinatorTest.java
@@ -1,0 +1,88 @@
+package com.mariaalpha.executionengine.basket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mariaalpha.executionengine.model.ExecutionReport;
+import com.mariaalpha.executionengine.model.Order;
+import com.mariaalpha.executionengine.model.OrderSignal;
+import com.mariaalpha.executionengine.model.OrderType;
+import com.mariaalpha.executionengine.model.Side;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BasketCoordinatorTest {
+
+  private BasketRegistry registry;
+  private BasketCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    registry = new BasketRegistry();
+    coordinator = new BasketCoordinator(registry, new BasketMetrics(new SimpleMeterRegistry()));
+  }
+
+  private Order trackedLeg(String basketId, int qty) {
+    var order =
+        new Order(
+            new OrderSignal(
+                "AAPL",
+                Side.BUY,
+                qty,
+                OrderType.LIMIT,
+                new BigDecimal("150.00"),
+                null,
+                "BASKET",
+                Instant.now()));
+    var state = new BasketState(basketId, "test", Instant.now());
+    state.addLeg(order.getOrderId(), "AAPL", Side.BUY, qty);
+    registry.register(state);
+    registry.linkLeg(order.getOrderId(), basketId);
+    return order;
+  }
+
+  @Test
+  void onLegFill_full_marksLegAndBasketFilled() {
+    var leg = trackedLeg("b1", 100);
+
+    coordinator.onLegFillIfApplicable(
+        leg,
+        new ExecutionReport(
+            "EX-1", new BigDecimal("150.00"), 100, 0, "PRIMARY", Instant.now(), null));
+
+    var view = registry.view("b1").orElseThrow();
+    assertThat(view.filledQuantity()).isEqualTo(100);
+    assertThat(view.status()).isEqualTo(BasketStatus.FILLED);
+  }
+
+  @Test
+  void onLegFill_partial_marksBasketPartiallyFilled() {
+    var leg = trackedLeg("b1", 100);
+
+    coordinator.onLegFillIfApplicable(
+        leg,
+        new ExecutionReport(
+            "EX-1", new BigDecimal("150.00"), 40, 60, "PRIMARY", Instant.now(), null));
+
+    var view = registry.view("b1").orElseThrow();
+    assertThat(view.filledQuantity()).isEqualTo(40);
+    assertThat(view.status()).isEqualTo(BasketStatus.PARTIALLY_FILLED);
+  }
+
+  @Test
+  void onLegFill_noOpForOrderThatIsNotABasketLeg() {
+    var untracked =
+        new Order(
+            new OrderSignal(
+                "TSLA", Side.SELL, 10, OrderType.MARKET, null, null, "MANUAL", Instant.now()));
+
+    coordinator.onLegFillIfApplicable(
+        untracked,
+        new ExecutionReport(
+            "EX-Z", new BigDecimal("250.00"), 10, 0, "PRIMARY", Instant.now(), null));
+
+    assertThat(registry.trackedBaskets()).isZero();
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketRegistryTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketRegistryTest.java
@@ -1,0 +1,63 @@
+package com.mariaalpha.executionengine.basket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.Side;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BasketRegistryTest {
+
+  private BasketRegistry registry;
+
+  @BeforeEach
+  void setUp() {
+    registry = new BasketRegistry();
+  }
+
+  private BasketState basketWithLeg(String basketId, String legId) {
+    var state = new BasketState(basketId, "test", Instant.now());
+    state.addLeg(legId, "AAPL", Side.BUY, 100);
+    state.recordSubmissionOutcome(legId, OrderStatus.SUBMITTED, null);
+    registry.register(state);
+    registry.linkLeg(legId, basketId);
+    return state;
+  }
+
+  @Test
+  void recordLegFill_attributesFillToOwningBasket() {
+    basketWithLeg("b1", "leg-1");
+
+    var attributed = registry.recordLegFill("leg-1", 100, true);
+
+    assertThat(attributed).contains("b1");
+    assertThat(registry.view("b1").orElseThrow().status()).isEqualTo(BasketStatus.FILLED);
+    assertThat(registry.trackedBaskets()).isEqualTo(1);
+  }
+
+  @Test
+  void recordLegFill_unknownLeg_returnsEmpty() {
+    assertThat(registry.recordLegFill("ghost", 100, true)).isEmpty();
+  }
+
+  @Test
+  void recordLegFill_completeLeg_unlinksSoLaterStrayFillsAreIgnored() {
+    basketWithLeg("b1", "leg-1");
+
+    assertThat(registry.recordLegFill("leg-1", 100, true)).contains("b1");
+    // A duplicate/stray fill after completion is no longer attributed.
+    assertThat(registry.recordLegFill("leg-1", 100, true)).isEmpty();
+  }
+
+  @Test
+  void view_and_all_reflectRegisteredBaskets() {
+    basketWithLeg("b1", "leg-1");
+    basketWithLeg("b2", "leg-2");
+
+    assertThat(registry.view("b1")).isPresent();
+    assertThat(registry.view("missing")).isEmpty();
+    assertThat(registry.all()).hasSize(2);
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketRegistryTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketRegistryTest.java
@@ -47,7 +47,6 @@ class BasketRegistryTest {
     basketWithLeg("b1", "leg-1");
 
     assertThat(registry.recordLegFill("leg-1", 100, true)).contains("b1");
-    // A duplicate/stray fill after completion is no longer attributed.
     assertThat(registry.recordLegFill("leg-1", 100, true)).isEmpty();
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketStateTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketStateTest.java
@@ -79,9 +79,7 @@ class BasketStateTest {
   void fillNeverDowngradedByLateSubmissionOutcome() {
     var state = newBasket();
     state.addLeg("leg-1", "AAPL", Side.BUY, 100);
-    // Fill races ahead of the submitOrder return…
     state.recordFill("leg-1", 100, true);
-    // …then the synchronous "accepted" outcome lands — it must not clobber the FILLED status.
     state.recordSubmissionOutcome("leg-1", OrderStatus.SUBMITTED, null);
 
     var view = state.toView();

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketStateTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketStateTest.java
@@ -1,0 +1,99 @@
+package com.mariaalpha.executionengine.basket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.Side;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class BasketStateTest {
+
+  private BasketState newBasket() {
+    return new BasketState("b1", "rebalance", Instant.now());
+  }
+
+  @Test
+  void freshlySubmittedBasket_isSubmitted() {
+    var state = newBasket();
+    state.addLeg("leg-1", "AAPL", Side.BUY, 100);
+    state.addLeg("leg-2", "MSFT", Side.SELL, 50);
+    state.recordSubmissionOutcome("leg-1", OrderStatus.SUBMITTED, null);
+    state.recordSubmissionOutcome("leg-2", OrderStatus.SUBMITTED, null);
+
+    var view = state.toView();
+    assertThat(view.status()).isEqualTo(BasketStatus.SUBMITTED);
+    assertThat(view.totalLegs()).isEqualTo(2);
+    assertThat(view.acceptedLegs()).isEqualTo(2);
+    assertThat(view.rejectedLegs()).isZero();
+    assertThat(view.targetQuantity()).isEqualTo(150);
+    assertThat(view.filledQuantity()).isZero();
+  }
+
+  @Test
+  void allLegsRejected_isRejected() {
+    var state = newBasket();
+    state.addLeg("leg-1", "AAPL", Side.BUY, 100);
+    state.recordSubmissionOutcome("leg-1", OrderStatus.REJECTED, "max notional");
+
+    var view = state.toView();
+    assertThat(view.status()).isEqualTo(BasketStatus.REJECTED);
+    assertThat(view.acceptedLegs()).isZero();
+    assertThat(view.rejectedLegs()).isEqualTo(1);
+    assertThat(view.legs().get(0).reason()).isEqualTo("max notional");
+  }
+
+  @Test
+  void rejectedLegsAreExcludedFromTarget_acceptedLegFillsCompleteBasket() {
+    var state = newBasket();
+    state.addLeg("leg-1", "AAPL", Side.BUY, 100);
+    state.addLeg("leg-2", "MSFT", Side.SELL, 50);
+    state.recordSubmissionOutcome("leg-1", OrderStatus.SUBMITTED, null);
+    state.recordSubmissionOutcome("leg-2", OrderStatus.REJECTED, "rejected at submission");
+
+    state.recordFill("leg-1", 100, true);
+
+    var view = state.toView();
+    assertThat(view.status()).isEqualTo(BasketStatus.FILLED);
+    assertThat(view.acceptedLegs()).isEqualTo(1);
+    assertThat(view.filledLegs()).isEqualTo(1);
+    assertThat(view.targetQuantity()).isEqualTo(100);
+    assertThat(view.filledQuantity()).isEqualTo(100);
+  }
+
+  @Test
+  void partialFill_isPartiallyFilled() {
+    var state = newBasket();
+    state.addLeg("leg-1", "AAPL", Side.BUY, 100);
+    state.recordSubmissionOutcome("leg-1", OrderStatus.SUBMITTED, null);
+
+    state.recordFill("leg-1", 40, false);
+
+    var view = state.toView();
+    assertThat(view.status()).isEqualTo(BasketStatus.PARTIALLY_FILLED);
+    assertThat(view.filledQuantity()).isEqualTo(40);
+    assertThat(view.filledLegs()).isZero();
+  }
+
+  @Test
+  void fillNeverDowngradedByLateSubmissionOutcome() {
+    var state = newBasket();
+    state.addLeg("leg-1", "AAPL", Side.BUY, 100);
+    // Fill races ahead of the submitOrder return…
+    state.recordFill("leg-1", 100, true);
+    // …then the synchronous "accepted" outcome lands — it must not clobber the FILLED status.
+    state.recordSubmissionOutcome("leg-1", OrderStatus.SUBMITTED, null);
+
+    var view = state.toView();
+    assertThat(view.status()).isEqualTo(BasketStatus.FILLED);
+    assertThat(view.legs().get(0).status()).isEqualTo(OrderStatus.FILLED);
+  }
+
+  @Test
+  void recordFill_unknownLeg_isNoOp() {
+    var state = newBasket();
+    state.addLeg("leg-1", "AAPL", Side.BUY, 100);
+
+    assertThat(state.recordFill("ghost", 10, false)).isFalse();
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketTradingIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketTradingIntegrationTest.java
@@ -26,12 +26,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 
-/**
- * End-to-end program/basket flow against the in-process simulated adapter and a Testcontainers
- * Kafka. Submits a two-leg basket and asserts that, as both legs fill, the basket aggregate
- * transitions to FILLED — exercising the {@code BasketTradingService} → pipeline → {@code
- * BasketCoordinator} loop.
- */
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("simulated")

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketTradingIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/basket/BasketTradingIntegrationTest.java
@@ -1,0 +1,106 @@
+package com.mariaalpha.executionengine.basket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.mariaalpha.executionengine.controller.dto.BasketLegRequest;
+import com.mariaalpha.executionengine.controller.dto.BasketOrderRequest;
+import com.mariaalpha.executionengine.model.MarketState;
+import com.mariaalpha.executionengine.model.OrderType;
+import com.mariaalpha.executionengine.model.Side;
+import com.mariaalpha.executionengine.service.BasketTradingService;
+import com.mariaalpha.executionengine.service.MarketStateTracker;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+/**
+ * End-to-end program/basket flow against the in-process simulated adapter and a Testcontainers
+ * Kafka. Submits a two-leg basket and asserts that, as both legs fill, the basket aggregate
+ * transitions to FILLED — exercising the {@code BasketTradingService} → pipeline → {@code
+ * BasketCoordinator} loop.
+ */
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("simulated")
+@Tag("integration")
+@DirtiesContext
+class BasketTradingIntegrationTest {
+
+  @Container static KafkaContainer kafka = new KafkaContainer("apache/kafka:latest");
+
+  @Autowired private BasketTradingService service;
+  @Autowired private MarketStateTracker tracker;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry registry) {
+    registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+    registry.add("execution-engine.simulated.fill-latency-ms", () -> 5);
+    registry.add("execution-engine.redis.enabled", () -> "false");
+    registry.add("management.health.redis.enabled", () -> "false");
+    registry.add(
+        "spring.autoconfigure.exclude",
+        () ->
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.redis"
+                + ".RedisRepositoriesAutoConfiguration");
+  }
+
+  @Test
+  void twoLegBasket_bothLegsFill_basketReachesFilled() {
+    seed("AAPL", "149.50", "150.00");
+    seed("MSFT", "304.50", "305.00");
+
+    var view =
+        service.submit(
+            new BasketOrderRequest(
+                "rebalance",
+                List.of(
+                    new BasketLegRequest(
+                        "AAPL",
+                        Side.BUY,
+                        OrderType.LIMIT,
+                        100,
+                        new BigDecimal("151.00"),
+                        null,
+                        null),
+                    new BasketLegRequest(
+                        "MSFT",
+                        Side.BUY,
+                        OrderType.LIMIT,
+                        50,
+                        new BigDecimal("306.00"),
+                        null,
+                        null))));
+
+    assertThat(view.totalLegs()).isEqualTo(2);
+    assertThat(view.acceptedLegs()).isEqualTo(2);
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(50))
+        .until(() -> service.get(view.basketId()).orElseThrow().status() == BasketStatus.FILLED);
+
+    var filled = service.get(view.basketId()).orElseThrow();
+    assertThat(filled.filledLegs()).isEqualTo(2);
+    assertThat(filled.filledQuantity()).isEqualTo(150);
+  }
+
+  private void seed(String symbol, String bid, String ask) {
+    tracker.update(
+        new MarketState(
+            symbol, new BigDecimal(bid), new BigDecimal(ask), new BigDecimal(ask), Instant.now()));
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClientTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheClientTest.java
@@ -113,7 +113,6 @@ class RedisPositionCacheClientTest {
     client.applyMessage("not json");
     client.applyMessage("");
     client.applyMessage(null);
-    // No exception escapes; tracker still empty.
     assertThat(tracker.getPositionNotional("AAPL")).isEqualByComparingTo("0");
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/cache/RedisPositionCacheIntegrationTest.java
@@ -21,11 +21,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-/**
- * Integration test against a real Redis. Verifies the end-to-end flow: a producer writes a snapshot
- * to Redis + publishes the pub/sub event; the cache client warms and applies updates onto {@link
- * PositionTracker}.
- */
 @Tag("integration")
 @Testcontainers
 class RedisPositionCacheIntegrationTest {

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/consumer/SignalConsumerIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/consumer/SignalConsumerIntegrationTest.java
@@ -71,7 +71,6 @@ class SignalConsumerIntegrationTest {
         new OrderSignal("AAPL", Side.BUY, 100, OrderType.MARKET, null, null, "VWAP", Instant.now());
     var json = mapper.writeValueAsString(signal);
 
-    // Send and block until the broker acks — verifies Kafka is reachable and the topic exists.
     var sendResult = template.send("strategy.signals", "AAPL", json).get(10, TimeUnit.SECONDS);
     assertThat(sendResult.getRecordMetadata().offset()).isGreaterThanOrEqualTo(0);
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/controller/BasketControllerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/controller/BasketControllerTest.java
@@ -1,0 +1,105 @@
+package com.mariaalpha.executionengine.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.mariaalpha.executionengine.basket.BasketStatus;
+import com.mariaalpha.executionengine.basket.BasketView;
+import com.mariaalpha.executionengine.service.BasketTradingService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BasketController.class)
+class BasketControllerTest {
+
+  @TestConfiguration
+  static class Config {
+    @Bean
+    BasketTradingService basketTradingService() {
+      return mock(BasketTradingService.class);
+    }
+  }
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private BasketTradingService service;
+
+  private BasketView sampleView() {
+    return new BasketView(
+        "b1",
+        "rebalance",
+        Instant.now(),
+        BasketStatus.SUBMITTED,
+        1,
+        1,
+        0,
+        0,
+        100,
+        0,
+        List.of(
+            new BasketView.BasketLegView(
+                "leg-1",
+                "AAPL",
+                com.mariaalpha.executionengine.model.Side.BUY,
+                100,
+                0,
+                com.mariaalpha.executionengine.model.OrderStatus.SUBMITTED,
+                null)));
+  }
+
+  @Test
+  void submit_validBasket_returns202WithView() throws Exception {
+    when(service.submit(any())).thenReturn(sampleView());
+
+    mockMvc
+        .perform(
+            post("/api/execution/baskets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"rebalance\",\"legs\":[{\"symbol\":\"AAPL\",\"side\":\"BUY\","
+                        + "\"orderType\":\"LIMIT\",\"quantity\":100,\"limitPrice\":150.00}]}"))
+        .andExpect(status().isAccepted())
+        .andExpect(jsonPath("$.basketId").value("b1"))
+        .andExpect(jsonPath("$.status").value("SUBMITTED"))
+        .andExpect(jsonPath("$.legs[0].legOrderId").value("leg-1"));
+  }
+
+  @Test
+  void submit_emptyLegs_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/execution/baskets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"x\",\"legs\":[]}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void get_knownBasket_returnsView() throws Exception {
+    when(service.get("b1")).thenReturn(Optional.of(sampleView()));
+
+    mockMvc
+        .perform(get("/api/execution/baskets/{id}", "b1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.basketId").value("b1"));
+  }
+
+  @Test
+  void get_unknownBasket_returns404() throws Exception {
+    when(service.get("nope")).thenReturn(Optional.empty());
+
+    mockMvc.perform(get("/api/execution/baskets/{id}", "nope")).andExpect(status().isNotFound());
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/controller/RoutingControllerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/controller/RoutingControllerTest.java
@@ -98,7 +98,6 @@ class RoutingControllerTest {
 
   @Test
   void scorePreviewBadInput() throws Exception {
-    // missing symbol → bean-validation 400
     var json = "{\"side\":\"BUY\",\"orderType\":\"MARKET\",\"quantity\":100}";
     mvc.perform(post("/api/routing/score").contentType(MediaType.APPLICATION_JSON).content(json))
         .andExpect(status().isBadRequest());

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/crossing/InternalCrossingEngineTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/crossing/InternalCrossingEngineTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Behavioural tests for the matching engine in isolation (no Spring, no adapter, no scheduler). */
 class InternalCrossingEngineTest {
 
   private MarketStateTracker tracker;
@@ -74,11 +73,10 @@ class InternalCrossingEngineTest {
   @Test
   void fifoTimePriorityAcrossSeveralRestingOrders() {
     var sell1 = engine.submit(market("AAPL", Side.SELL, 40));
-    sleepMillis(2); // ensure distinct arrival times
+    sleepMillis(2);
     var sell2 = engine.submit(market("AAPL", Side.SELL, 40));
     engine.submit(market("AAPL", Side.BUY, 60));
 
-    // First cross consumes sell1 entirely (40), second cross consumes 20 from sell2.
     assertThat(crosses).hasSize(2);
     assertThat(crosses.get(0).quantity()).isEqualTo(40);
     assertThat(crosses.get(0).counterpartyExchangeOrderId()).isEqualTo(sell1);
@@ -98,7 +96,6 @@ class InternalCrossingEngineTest {
   void buyLimitBelowMidpointDoesNotCross() {
     engine.submit(market("AAPL", Side.SELL, 100));
     engine.submit(limit("AAPL", Side.BUY, 100, new BigDecimal("178.50")));
-    // BUY limit 178.50 < midpoint 178.52 → BUY accepts only ≤ limit. No cross.
     assertThat(crosses).isEmpty();
     assertThat(engine.stats().restingOrdersBuy()).isEqualTo(1);
     assertThat(engine.stats().restingOrdersSell()).isEqualTo(1);
@@ -108,17 +105,14 @@ class InternalCrossingEngineTest {
   void sellLimitAboveMidpointDoesNotCross() {
     engine.submit(limit("AAPL", Side.SELL, 100, new BigDecimal("178.55")));
     engine.submit(market("AAPL", Side.BUY, 100));
-    // SELL limit 178.55 > midpoint 178.52 → SELL accepts only ≥ limit. No cross.
     assertThat(crosses).isEmpty();
   }
 
   @Test
   void sweepAfterFavourableNbboShiftCrossesPreviouslyStalledOrders() {
-    // Both sides limit at 178.55 — initial midpoint 178.52 is below the SELL's floor.
     engine.submit(limit("AAPL", Side.SELL, 100, new BigDecimal("178.55")));
     engine.submit(limit("AAPL", Side.BUY, 100, new BigDecimal("178.55")));
     assertThat(crosses).isEmpty();
-    // Market widens upward so midpoint hits 178.55.
     tracker.update(
         new MarketState(
             "AAPL",
@@ -136,7 +130,7 @@ class InternalCrossingEngineTest {
   void cancelRemovesRestingOrder() {
     var sellId = engine.submit(market("AAPL", Side.SELL, 100));
     assertThat(engine.cancel(sellId)).isTrue();
-    assertThat(engine.cancel(sellId)).isFalse(); // idempotent
+    assertThat(engine.cancel(sellId)).isFalse();
     engine.submit(market("AAPL", Side.BUY, 100));
     assertThat(crosses).isEmpty();
   }
@@ -157,7 +151,7 @@ class InternalCrossingEngineTest {
         new MarketState(
             "MSFT",
             new BigDecimal("100.10"),
-            new BigDecimal("100.00"), // inverted bid > ask
+            new BigDecimal("100.00"),
             new BigDecimal("100.05"),
             Instant.now()));
     engine.submit(market("MSFT", Side.SELL, 50));
@@ -188,9 +182,9 @@ class InternalCrossingEngineTest {
   @Test
   void statsTrackInternalAndSyntheticCrossesSeparately() {
     engine.submit(market("AAPL", Side.SELL, 100));
-    engine.submit(market("AAPL", Side.BUY, 100)); // internal cross
+    engine.submit(market("AAPL", Side.BUY, 100));
     var solo = engine.submit(market("AAPL", Side.BUY, 50));
-    engine.synthesizeCounterparty(solo); // synthetic
+    engine.synthesizeCounterparty(solo);
 
     var stats = engine.stats();
     assertThat(stats.crossesTotal()).isEqualTo(2);
@@ -202,8 +196,6 @@ class InternalCrossingEngineTest {
 
   @Test
   void bookSnapshotReturnsLiveDepth() {
-    // SELL 50 crosses the first BUY 100 → leftover BUY remaining=50 in order 1, plus BUY 200 from
-    // order 2. SELL fully consumed.
     engine.submit(market("AAPL", Side.BUY, 100));
     engine.submit(market("AAPL", Side.BUY, 200));
     engine.submit(market("AAPL", Side.SELL, 50));
@@ -257,7 +249,6 @@ class InternalCrossingEngineTest {
       pool.shutdownNow();
     }
 
-    // Every BUY (per orders × 10 shares) should be fully matched against every SELL.
     assertThat(crosses.stream().mapToInt(MidpointCross::quantity).sum()).isEqualTo(per * 10);
     assertThat(engine.totalResting()).isZero();
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/crossing/InternalCrossingIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/crossing/InternalCrossingIntegrationTest.java
@@ -29,16 +29,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 
-/**
- * Wiring test for the internal crossing engine. Verifies that when orders are submitted directly to
- * the simulated internal-crossing venue adapter, the embedded {@link InternalCrossingEngine}
- * matches them and both legs flow through {@link OrderExecutionService}'s execution-report callback
- * into the {@link OrderLifecycleManager} as FILLED.
- *
- * <p>Submitting via the SOR isn't deterministic (other venues outscore INTERNAL_CROSS on the
- * stock-simulated config), so this test calls the adapter directly to keep the assertion sharp. The
- * SOR-routed path is covered by the e2e test in {@code e2e-tests}.
- */
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("simulated")
@@ -94,15 +84,9 @@ class InternalCrossingIntegrationTest {
             new OrderSignal(
                 "AAPL", Side.BUY, 100, OrderType.MARKET, null, null, "T-BUY", Instant.now()));
 
-    // Submit through OrderExecutionService.submitOrder so they're registered with the lifecycle
-    // manager. We then manually re-dispatch through the internal adapter to force the venue
-    // choice — the normal SOR path is exercised in the e2e test.
     service.submitOrder(sell);
     service.submitOrder(buy);
 
-    // Direct hits on the internal adapter — these create *additional* orders that go straight to
-    // the engine and cross there. Pre-registering with the lifecycle manager would require
-    // hand-wiring, so we instead assert against the engine + venue-adapter health.
     var sellOnly =
         new Order(
             new OrderSignal(

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/handler/PeggedOrderHandlerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/handler/PeggedOrderHandlerTest.java
@@ -84,7 +84,6 @@ class PeggedOrderHandlerTest {
 
   @Test
   void rejectsBuyPriceCapTooLow() {
-    // BUY cap at 30 when reference is ~100 → "almost certainly a misconfiguration"
     var result =
         handler.validate(
             order(Side.BUY, 100, PegType.MIDPOINT, 0, new BigDecimal("30.00")),

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinatorIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinatorIntegrationTest.java
@@ -27,11 +27,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 
-/**
- * End-to-end iceberg parent → multi-slice flow against the in-process simulated adapter and a
- * Testcontainers Kafka. Verifies that the coordinator submits each subsequent slice on child
- * completion and that the parent transitions through PARTIALLY_FILLED to FILLED.
- */
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("simulated")
@@ -51,7 +46,6 @@ class IcebergCoordinatorIntegrationTest {
   @DynamicPropertySource
   static void props(DynamicPropertyRegistry registry) {
     registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
-    // Make the simulator fill near-instantly so awaitility doesn't have to wait long
     registry.add("execution-engine.simulated.fill-latency-ms", () -> 5);
     registry.add("execution-engine.redis.enabled", () -> "false");
     registry.add("management.health.redis.enabled", () -> "false");
@@ -75,7 +69,6 @@ class IcebergCoordinatorIntegrationTest {
         .pollInterval(Duration.ofMillis(50))
         .until(() -> parent.getStatus() == OrderStatus.FILLED);
 
-    // The progress entry is removed on parent completion; the parent itself should be FILLED.
     assertThat(parent.getStatus()).isEqualTo(OrderStatus.FILLED);
     assertThat(registry.progress(parent.getOrderId())).isEmpty();
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinatorTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/iceberg/IcebergCoordinatorTest.java
@@ -197,7 +197,6 @@ class IcebergCoordinatorTest {
         new ExecutionReport(
             "EX-1", new BigDecimal("150.00"), 1000, 0, "PRIMARY", Instant.now(), null));
 
-    // After slice 1 fills, slice 2 was submitted; capture and fill it
     var secondChild = capturedChildren.get(1);
     coordinator.onChildFillIfApplicable(
         secondChild,
@@ -223,7 +222,6 @@ class IcebergCoordinatorTest {
         new ExecutionReport(
             "EX-2", new BigDecimal("150.00"), 1000, 0, "PRIMARY", Instant.now(), null));
 
-    // Third slice should be size 500
     assertThat(capturedChildren).hasSize(3);
     assertThat(capturedChildren.get(2).getQuantity()).isEqualTo(500);
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/lifecycle/OrderLifecycleManagerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/lifecycle/OrderLifecycleManagerTest.java
@@ -141,6 +141,7 @@ class OrderLifecycleManagerTest {
               manager.transition(order.getOrderId(), OrderStatus.FILLED, null, null);
               successCount.incrementAndGet();
             } catch (Exception ignored) {
+              // only one thread wins the FILLED transition; the losers throw
             }
           });
     }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/lifecycle/OrderLifecycleManagerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/lifecycle/OrderLifecycleManagerTest.java
@@ -118,7 +118,6 @@ class OrderLifecycleManagerTest {
     manager.transition(o2.getOrderId(), OrderStatus.FILLED, null, null);
     manager.transition(o3.getOrderId(), OrderStatus.REJECTED, null, "reason");
 
-    // Only o1 is open (SUBMITTED); o2 is FILLED, o3 is REJECTED
     assertThat(manager.getOpenOrderCount()).isEqualTo(1);
   }
 
@@ -142,14 +141,12 @@ class OrderLifecycleManagerTest {
               manager.transition(order.getOrderId(), OrderStatus.FILLED, null, null);
               successCount.incrementAndGet();
             } catch (Exception ignored) {
-              // Expected for losing threads
             }
           });
     }
     executor.shutdown();
     executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
 
-    // Exactly one thread should succeed
     assertThat(successCount.get()).isEqualTo(1);
     assertThat(order.getStatus()).isEqualTo(OrderStatus.FILLED);
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/pegged/PeggedCoordinatorIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/pegged/PeggedCoordinatorIntegrationTest.java
@@ -87,14 +87,11 @@ class PeggedCoordinatorIntegrationTest {
 
   @Test
   void parentRepegsOnNbboMove() {
-    // Use SELL side with the PRIMARY peg so the simulator won't immediately cross — we want the
-    // order to rest at the ask until we move the market, then re-peg.
     seedMarket("MSFT", "415.00", "415.20");
     var parent = createParent("MSFT", Side.SELL, 50, PegType.PRIMARY, 0);
 
     service.submitOrder(parent);
 
-    // First child registers
     await()
         .atMost(Duration.ofSeconds(5))
         .pollInterval(Duration.ofMillis(50))
@@ -107,7 +104,6 @@ class PeggedCoordinatorIntegrationTest {
     var beforeRepeg = registry.progress(parent.getOrderId()).orElseThrow();
     assertThat(beforeRepeg.repegsTotal()).isZero();
 
-    // Move the NBBO ask by ~30 bps (415.20 → 416.40) — well above the 5 bps repeg threshold
     seedMarket("MSFT", "416.20", "416.40");
 
     await()

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/pegged/PeggedCoordinatorTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/pegged/PeggedCoordinatorTest.java
@@ -95,7 +95,6 @@ class PeggedCoordinatorTest {
             lifecycleManager,
             marketStateTracker,
             metrics);
-    // @PostConstruct doesn't fire under plain unit tests — wire the listener manually.
     coordinator.subscribeToMarketStateTicks();
   }
 
@@ -133,7 +132,7 @@ class PeggedCoordinatorTest {
 
   @Test
   void onParentSubmitWithMidpointSubmitsLimitChildAtMidpoint() {
-    primeBook("100.00", "100.20"); // mid 100.10
+    primeBook("100.00", "100.20");
     var p = parent(Side.BUY, 100, PegType.MIDPOINT, 0);
     when(lifecycleManager.getOrder(p.getOrderId())).thenReturn(p);
 
@@ -172,20 +171,19 @@ class PeggedCoordinatorTest {
 
   @Test
   void nbboMoveBelowThresholdDoesNotRepeg() {
-    primeBook("100.00", "100.20"); // mid 100.10
+    primeBook("100.00", "100.20");
     var p = parent(Side.BUY, 100, PegType.MIDPOINT, 0);
     when(lifecycleManager.getOrder(p.getOrderId())).thenReturn(p);
     coordinator.onParentSubmit(p);
     assertThat(capturedChildren).hasSize(1);
 
-    // small wobble — mid moves from 100.10 to 100.11 = ~1 bps, below 5 bps threshold
     primeBook("100.01", "100.21");
     assertThat(capturedChildren).hasSize(1);
   }
 
   @Test
   void nbboMoveAboveThresholdRepegs() {
-    primeBook("100.00", "100.20"); // mid 100.10
+    primeBook("100.00", "100.20");
     var p = parent(Side.BUY, 100, PegType.MIDPOINT, 0);
     when(lifecycleManager.getOrder(p.getOrderId())).thenReturn(p);
     when(lifecycleManager.getOrder(any()))
@@ -195,7 +193,6 @@ class PeggedCoordinatorTest {
               if (id.equals(p.getOrderId())) {
                 return p;
               }
-              // Return a real child Order so cancelActiveChild can read exchangeOrderId
               var match =
                   capturedChildren.stream().filter(c -> c.getOrderId().equals(id)).findFirst();
               if (match.isPresent()) {
@@ -209,7 +206,6 @@ class PeggedCoordinatorTest {
     int firstSubmitCount = submitCounter;
     assertThat(capturedChildren).hasSize(1);
 
-    // mid jumps from 100.10 to 100.30 = ~20 bps move on the submitted price → triggers repeg
     primeBook("100.20", "100.40");
 
     assertThat(capturedChildren.size()).isGreaterThanOrEqualTo(2);
@@ -223,7 +219,7 @@ class PeggedCoordinatorTest {
 
   @Test
   void repegAfterPartialFillSubmitsOnlyRemainingQuantity() {
-    primeBook("100.00", "100.20"); // mid 100.10
+    primeBook("100.00", "100.20");
     var p = parent(Side.BUY, 100, PegType.MIDPOINT, 0);
     when(lifecycleManager.getOrder(any()))
         .thenAnswer(
@@ -240,14 +236,11 @@ class PeggedCoordinatorTest {
     coordinator.onParentSubmit(p);
     var child = capturedChildren.get(0);
 
-    // Child partially fills 40 of 100, stays working.
     coordinator.onChildFillIfApplicable(
         child,
         new ExecutionReport(
             "EX-1", new BigDecimal("100.10"), 40, 60, "PRIMARY", Instant.now(), null));
 
-    // Big NBBO move triggers a repeg — the fresh child must be sized at the REMAINING 60,
-    // not the full parent quantity (fills live on the children, never the parent Order).
     primeBook("100.20", "100.40");
 
     assertThat(capturedChildren).hasSize(2);
@@ -256,7 +249,7 @@ class PeggedCoordinatorTest {
 
   @Test
   void completedChildWithRemainingParentResubmitsOnNextTickWithoutThreshold() {
-    primeBook("100.00", "100.20"); // mid 100.10
+    primeBook("100.00", "100.20");
     var p = parent(Side.BUY, 100, PegType.MIDPOINT, 0);
     when(lifecycleManager.getOrder(any()))
         .thenAnswer(
@@ -272,19 +265,15 @@ class PeggedCoordinatorTest {
     coordinator.onParentSubmit(p);
     var child = capturedChildren.get(0);
 
-    // Child completes (remaining 0) after filling only 40 — parent still has 60 outstanding.
     coordinator.onChildFillIfApplicable(
         child,
         new ExecutionReport(
             "EX-1", new BigDecimal("100.10"), 40, 0, "PRIMARY", Instant.now(), null));
 
-    // A sub-threshold wobble must still spawn a fresh child for the residual — there is no
-    // active child to leave working, so waiting for a full repeg move would stall the parent.
     primeBook("100.01", "100.21");
 
     assertThat(capturedChildren).hasSize(2);
     assertThat(capturedChildren.get(1).getQuantity()).isEqualTo(60);
-    // No active child existed, so nothing should have been cancelled at the venue.
     verify(venueAdapter, never()).cancelOrder(any());
   }
 
@@ -296,14 +285,13 @@ class PeggedCoordinatorTest {
     coordinator.onParentSubmit(p);
     var child = capturedChildren.get(0);
 
-    // Full fill on the child
     coordinator.onChildFillIfApplicable(
         child,
         new ExecutionReport(
             "EX-1", new BigDecimal("100.10"), 100, 0, "PRIMARY", Instant.now(), null));
 
     int childrenBefore = capturedChildren.size();
-    primeBook("105.00", "105.20"); // huge move
+    primeBook("105.00", "105.20");
     assertThat(capturedChildren).hasSize(childrenBefore);
     verify(lifecycleManager)
         .transition(eq(p.getOrderId()), eq(OrderStatus.FILLED), eq(null), eq("pegged-complete"));
@@ -354,8 +342,6 @@ class PeggedCoordinatorTest {
     coordinator.onParentSubmit(p);
     assertThat(capturedChildren).hasSize(1);
 
-    // Update an unrelated symbol — even if mid is wildly different, the AAPL pegged order is
-    // untouched.
     marketStateTracker.update(
         new MarketState(
             "MSFT",

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/pegged/PeggedPriceCalculatorTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/pegged/PeggedPriceCalculatorTest.java
@@ -56,10 +56,8 @@ class PeggedPriceCalculatorTest {
 
   @Test
   void positiveOffsetMovesBuyUpAndSellDown() {
-    // BUY @ +5 bps → 100.10 × 1.0005 = 100.150
     var buy = calculator.peggedPrice(new BigDecimal("100.10"), Side.BUY, 5, null);
     assertThat(buy.doubleValue()).isCloseTo(100.150, within(1e-3));
-    // SELL @ +5 bps → 100.10 × 0.9995 = 100.050
     var sell = calculator.peggedPrice(new BigDecimal("100.10"), Side.SELL, 5, null);
     assertThat(sell.doubleValue()).isCloseTo(100.050, within(1e-3));
   }
@@ -74,7 +72,6 @@ class PeggedPriceCalculatorTest {
 
   @Test
   void priceCapClampsBuyAboveCap() {
-    // BUY @ +500 bps on 100 → 105.00; cap at 100.50 → must clamp.
     var price =
         calculator.peggedPrice(new BigDecimal("100.00"), Side.BUY, 500, new BigDecimal("100.50"));
     assertThat(price).isEqualByComparingTo("100.5000");

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/AdvParticipationCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/AdvParticipationCheckTest.java
@@ -29,14 +29,12 @@ class AdvParticipationCheckTest {
 
   @Test
   void passesWhenOrderIsSmallFractionOfAdv() {
-    // AAPL ADV = 60M; 1M shares = 1.67% ≪ 10%.
     var order = order("AAPL", 1_000_000);
     assertThat(check.check(order).passed()).isTrue();
   }
 
   @Test
   void failsWhenOrderExceedsParticipationLimit() {
-    // AAPL ADV = 60M; 7M shares = 11.67% > 10%.
     var order = order("AAPL", 7_000_000);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();
@@ -45,14 +43,13 @@ class AdvParticipationCheckTest {
 
   @Test
   void passesAtExactLimit() {
-    // AAPL ADV = 60M; 6M = 10% exactly → passes (strict >).
     var order = order("AAPL", 6_000_000);
     assertThat(check.check(order).passed()).isTrue();
   }
 
   @Test
   void rejectsWhenAdvUnavailable() {
-    var order = order("ZZZZ", 100); // ZZZZ unmapped → ADV defaults to 0
+    var order = order("ZZZZ", 100);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();
     assertThat(result.reason()).contains("ADV unavailable");

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/BetaExposureCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/BetaExposureCheckTest.java
@@ -41,9 +41,7 @@ class BetaExposureCheckTest {
   @Test
   void passesWhenProjectedBetaExposureBelowLimit() {
     when(tracker.getMarketState("MSFT")).thenReturn(market("MSFT", "400"));
-    // Current portfolio: $1M MSFT × β0.95 = $950K beta-weighted.
     when(positions.snapshot()).thenReturn(Map.of("MSFT", new BigDecimal("1000000")));
-    // +250 MSFT × $400 = $100K notional × β0.95 = $95K → projected $1.045M < $2.5M.
     var order = order("MSFT", Side.BUY, 250);
     assertThat(check.check(order).passed()).isTrue();
   }
@@ -51,8 +49,6 @@ class BetaExposureCheckTest {
   @Test
   void failsWhenProjectedBetaExposureBreachesLimit() {
     when(tracker.getMarketState("TSLA")).thenReturn(market("TSLA", "250"));
-    // Existing $1M TSLA × β1.8 = $1.8M. +5000 TSLA × $250 = $1.25M × 1.8 = $2.25M.
-    // Projected $1.8M + $2.25M = $4.05M > $2.5M.
     when(positions.snapshot()).thenReturn(Map.of("TSLA", new BigDecimal("1000000")));
     var order = order("TSLA", Side.BUY, 5000);
     var result = check.check(order);
@@ -62,8 +58,6 @@ class BetaExposureCheckTest {
 
   @Test
   void sellsThatReduceBetaExposurePass() {
-    // Long $5M TSLA × β1.8 = $9M beta exposure (way over). SELL should still pass — it pulls
-    // exposure toward zero.
     when(tracker.getMarketState("TSLA")).thenReturn(market("TSLA", "250"));
     when(positions.snapshot()).thenReturn(Map.of("TSLA", new BigDecimal("5000000")));
     var order = order("TSLA", Side.SELL, 1000);
@@ -86,7 +80,6 @@ class BetaExposureCheckTest {
   void unknownSymbolUsesDefaultBeta() {
     when(tracker.getMarketState("ZZZZ")).thenReturn(market("ZZZZ", "100"));
     when(positions.snapshot()).thenReturn(Map.of());
-    // Default β = 1.0. Order = 30K × $100 = $3M × 1.0 = $3M projected. > $2.5M → fail.
     var order = order("ZZZZ", Side.BUY, 30_000);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/CorrelatedPositionsCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/CorrelatedPositionsCheckTest.java
@@ -46,7 +46,6 @@ class CorrelatedPositionsCheckTest {
             Map.of(
                 "AAPL", new BigDecimal("500000"),
                 "MSFT", new BigDecimal("400000")));
-    // +1000 AAPL × $200 = $200K → MEGACAP_TECH projection $200K + $500K + $400K = $1.1M < $1.75M
     assertThat(check.check(order("AAPL", Side.BUY, 1000)).passed()).isTrue();
   }
 
@@ -58,7 +57,6 @@ class CorrelatedPositionsCheckTest {
             Map.of(
                 "AAPL", new BigDecimal("800000"),
                 "MSFT", new BigDecimal("600000")));
-    // +5000 AAPL × $200 = $1M → MEGACAP_TECH projection $1M + $800K + $600K = $2.4M > $1.75M
     var result = check.check(order("AAPL", Side.BUY, 5000));
     assertThat(result.passed()).isFalse();
     assertThat(result.reason()).contains("MEGACAP_TECH");
@@ -67,8 +65,6 @@ class CorrelatedPositionsCheckTest {
   @Test
   void sellThatReducesClusterGrossPasses() {
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "200"));
-    // Cluster is already over the cap ($2M AAPL + $400K MSFT = $2.4M > $1.75M). A SELL that pulls
-    // AAPL down should still pass — projection grows toward zero, never above the current $2.4M.
     when(positions.snapshot())
         .thenReturn(
             Map.of(
@@ -79,11 +75,6 @@ class CorrelatedPositionsCheckTest {
 
   @Test
   void crossClusterMembershipIsCheckedIndependently() {
-    // MSFT belongs to both MEGACAP_TECH ($1.75M cap) and AI_TRADE ($1.5M cap). Position:
-    //   MSFT $1M + GOOGL $400K + NVDA $1.2M.
-    //   MEGACAP_TECH gross = MSFT + GOOGL = $1.4M; +400K MSFT BUY → $1.8M > $1.75M  ✗
-    //   AI_TRADE gross = MSFT + GOOGL + NVDA = $2.6M; +400K MSFT BUY → $3M > $1.5M  ✗
-    // First cluster checked fails — we accept either reason but require failure.
     when(tracker.getMarketState("MSFT")).thenReturn(market("MSFT", "400"));
     when(positions.snapshot())
         .thenReturn(
@@ -103,8 +94,7 @@ class CorrelatedPositionsCheckTest {
         .thenReturn(
             Map.of(
                 "AAPL", new BigDecimal("1700000"),
-                "MSFT", new BigDecimal("40000"))); // MEGACAP_TECH at $1.74M (near cap)
-    // AMZN isn't in any cluster → check passes unconditionally regardless of other positions.
+                "MSFT", new BigDecimal("40000")));
     assertThat(check.check(order("AMZN", Side.BUY, 1_000_000)).passed()).isTrue();
   }
 
@@ -127,14 +117,12 @@ class CorrelatedPositionsCheckTest {
 
   @Test
   void freshSymbolGetsAddedToProjection() {
-    // No existing AAPL position. Cluster already at $1.7M from MSFT + GOOGL.
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "200"));
     when(positions.snapshot())
         .thenReturn(
             Map.of(
                 "MSFT", new BigDecimal("1000000"),
                 "GOOGL", new BigDecimal("700000")));
-    // +500 AAPL × $200 = $100K → projection $1.8M > $1.75M cap → reject.
     var result = check.check(order("AAPL", Side.BUY, 500));
     assertThat(result.passed()).isFalse();
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/DailyLossMonitorTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/DailyLossMonitorTest.java
@@ -56,7 +56,6 @@ class DailyLossMonitorTest {
 
   @Test
   void haltsOnLossBreachCritical() {
-    // Bought at $170, sold at $140 → realized loss = -$30 × 1000 = -$30K > $25K limit
     monitor.onFill(fill("AAPL", Side.BUY, "170.00", 1000));
     monitor.onFill(fill("AAPL", Side.SELL, "140.00", 1000));
 
@@ -66,7 +65,6 @@ class DailyLossMonitorTest {
 
   @Test
   void doesNotHaltWhenWithinLimit() {
-    // Small loss: bought at $150, sold at $149 → loss = -$1 × 100 = -$100
     monitor.onFill(fill("AAPL", Side.BUY, "150.00", 100));
     monitor.onFill(fill("AAPL", Side.SELL, "149.00", 100));
 
@@ -76,7 +74,6 @@ class DailyLossMonitorTest {
 
   @Test
   void shortCoverRealizesPnl() {
-    // Sold short at $150, covered at $160 → loss = -$10 × 500 = -$5000
     monitor.onFill(fill("TSLA", Side.SELL, "150.00", 500));
     monitor.onFill(fill("TSLA", Side.BUY, "160.00", 500));
 
@@ -85,12 +82,10 @@ class DailyLossMonitorTest {
 
   @Test
   void flipRealizesOnlyClosedPortion() {
-    // Long 100 @ $100; sell 300 @ $90 → realize -$10 × 100 = -$1000, now short 200 @ $90.
     monitor.onFill(fill("MSFT", Side.BUY, "100.00", 100));
     monitor.onFill(fill("MSFT", Side.SELL, "90.00", 300));
     assertThat(monitor.getDailyPnl()).isEqualByComparingTo(new BigDecimal("-1000"));
 
-    // Cover the short at $80 → +$10 × 200 = +$2000; total = +$1000.
     monitor.onFill(fill("MSFT", Side.BUY, "80.00", 200));
     assertThat(monitor.getDailyPnl()).isEqualByComparingTo(new BigDecimal("1000"));
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/ExtendedRiskChainIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/ExtendedRiskChainIntegrationTest.java
@@ -21,11 +21,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 
-/**
- * Verifies that the sector / beta / ADV-participation risk checks are wired into the chain in the
- * expected order and the configured limits from {@code application.yml} (mode {@code simulated})
- * load via the standard {@code @ConfigurationProperties} path.
- */
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("simulated")
@@ -44,7 +39,6 @@ class ExtendedRiskChainIntegrationTest {
   @DynamicPropertySource
   static void props(DynamicPropertyRegistry registry) {
     registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
-    // No Redis container — the cache is exercised in RedisPositionCacheIntegrationTest.
     registry.add("execution-engine.redis.enabled", () -> "false");
     registry.add("management.health.redis.enabled", () -> "false");
     registry.add(
@@ -66,15 +60,12 @@ class ExtendedRiskChainIntegrationTest {
 
   @Test
   void chainIncludesExtendedChecks() {
-    // Inspect the chain by triggering every check on a passing order — each of the sector, beta,
-    // and ADV-participation checks must appear at least once in the bean container.
     var names = chainCheckNames();
     assertThat(names).contains("SectorExposure", "BetaExposure", "AdvParticipation");
   }
 
   @Test
   void chainRejectsOrderBreachingAdvParticipation() {
-    // AAPL ADV = 60M; 10% participation = 6M; an 8M-share parent breaches the cap.
     tracker.update(
         new MarketState(
             "AAPL",
@@ -95,10 +86,6 @@ class ExtendedRiskChainIntegrationTest {
                 Instant.now()));
     var result = chain.evaluate(order);
     assertThat(result.passed()).isFalse();
-    // MaxOrderNotional fires before ADV in the chain; assert it's at least one of the
-    // configured checks that gates a clearly-too-large order. We assert the failure reason names a
-    // known
-    // check rather than ADV specifically so the test stays robust if ordering shifts.
     assertThat(result.checkName())
         .as("expected a hard pre-trade reject, regardless of which check fires first")
         .isIn(
@@ -119,7 +106,6 @@ class ExtendedRiskChainIntegrationTest {
             new BigDecimal("178.54"),
             new BigDecimal("178.52"),
             Instant.now()));
-    // A 100-share AAPL order is well below every configured limit and the chain should pass.
     var order =
         new com.mariaalpha.executionengine.model.Order(
             new com.mariaalpha.executionengine.model.OrderSignal(
@@ -136,9 +122,6 @@ class ExtendedRiskChainIntegrationTest {
   }
 
   private Set<String> chainCheckNames() {
-    // RiskCheckChain doesn't expose the list directly. We use reflection to grab it for the test
-    // assertion — the cleanest alternative would have been a public accessor, but the production
-    // API doesn't need one.
     try {
       var field = RiskCheckChain.class.getDeclaredField("checks");
       field.setAccessible(true);

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/IntradayVarCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/IntradayVarCheckTest.java
@@ -40,7 +40,6 @@ class IntradayVarCheckTest {
     check = new IntradayVarCheck(config, tracker, positions, refData);
   }
 
-  /** Sanity-check the inlined z-score table against the standard normal reference values. */
   @Test
   void zscoreMatchesStandardConfidenceLevels() {
     assertThat(IntradayVarCheck.zscore(0.95)).isCloseTo(1.6449, within(0.001));
@@ -50,21 +49,16 @@ class IntradayVarCheckTest {
 
   @Test
   void passesWhenProjectedVarBelowLimit() {
-    // 1000 AAPL × $200 = $200K notional × σ0.28 / √252 × 1.645 ≈ $5.8K per-position VaR
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "200"));
     when(positions.snapshot()).thenReturn(Map.of("AAPL", new BigDecimal("200000")));
-    // +100 AAPL = $20K more → new position $220K → ~$6.4K VaR, well below $750K cap
     var order = order("AAPL", Side.BUY, 100);
     assertThat(check.check(order).passed()).isTrue();
   }
 
   @Test
   void failsWhenProjectedVarBreachesLimit() {
-    // TSLA σ = 0.55, so per-$1 of position notional VaR ≈ 1 × 0.55 / √252 × 1.645 ≈ $0.057
-    // A $20M TSLA position → ~$1.14M VaR, well over the $750K cap
     when(tracker.getMarketState("TSLA")).thenReturn(market("TSLA", "250"));
     when(positions.snapshot()).thenReturn(Map.of("TSLA", new BigDecimal("1000000")));
-    // +80000 TSLA × $250 = $20M notional → existing $1M + $20M = $21M → ~$1.2M VaR > $750K cap
     var order = order("TSLA", Side.BUY, 80_000);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();
@@ -73,8 +67,6 @@ class IntradayVarCheckTest {
 
   @Test
   void sellsThatReduceVarPass() {
-    // Sitting on a $20M TSLA long → ~$1.14M VaR, already above the cap. A SELL that pulls it
-    // toward zero must still pass — the check only fires when the projection grows.
     when(tracker.getMarketState("TSLA")).thenReturn(market("TSLA", "250"));
     when(positions.snapshot()).thenReturn(Map.of("TSLA", new BigDecimal("20000000")));
     var order = order("TSLA", Side.SELL, 1000);
@@ -99,8 +91,6 @@ class IntradayVarCheckTest {
 
   @Test
   void unknownSymbolVolatilityContributesZero() {
-    // ZZZZ has no reference data → default σ = 0 → check sees $0 VaR contribution. A BUY of any
-    // size therefore passes even with massive notional.
     when(tracker.getMarketState("ZZZZ")).thenReturn(market("ZZZZ", "100"));
     when(positions.snapshot()).thenReturn(Map.of());
     assertThat(check.check(order("ZZZZ", Side.BUY, 100_000_000)).passed()).isTrue();
@@ -118,16 +108,11 @@ class IntradayVarCheckTest {
   @Test
   void portfolioVarAccumulatesAcrossSymbols() {
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "200"));
-    // Two existing positions accumulate VaR; we want to push the projection just past the cap.
-    // NVDA: σ=0.48 — $10M position → 10_000_000 × 0.48 / √252 × 1.645 ≈ $497K VaR.
-    // TSLA: σ=0.55 — $5M position → 5_000_000 × 0.55 / √252 × 1.645 ≈ $285K VaR.
-    // Sum ≈ $782K — already over the $750K cap.
     when(positions.snapshot())
         .thenReturn(
             Map.of(
                 "NVDA", new BigDecimal("10000000"),
                 "TSLA", new BigDecimal("5000000")));
-    // BUY 100 AAPL adds tiny extra → projection grows → must fail.
     var result = check.check(order("AAPL", Side.BUY, 100));
     assertThat(result.passed()).isFalse();
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/MaxOrderNotionalCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/MaxOrderNotionalCheckTest.java
@@ -40,7 +40,7 @@ class MaxOrderNotionalCheckTest {
                 new BigDecimal("151"),
                 new BigDecimal("150"),
                 Instant.now()));
-    var order = createOrder("AAPL", 333); // 333 * $150 = $49,950
+    var order = createOrder("AAPL", 333);
     assertThat(check.check(order).passed()).isTrue();
   }
 
@@ -54,7 +54,7 @@ class MaxOrderNotionalCheckTest {
                 new BigDecimal("151"),
                 new BigDecimal("150"),
                 Instant.now()));
-    var order = createOrder("AAPL", 1000); // 1000 * $150 = $150,000
+    var order = createOrder("AAPL", 1000);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();
     assertThat(result.checkName()).isEqualTo("MaxOrderNotional");

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/MaxPortfolioExposureCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/MaxPortfolioExposureCheckTest.java
@@ -44,7 +44,7 @@ class MaxPortfolioExposureCheckTest {
                 new BigDecimal("150"),
                 Instant.now()));
     when(positionTracker.getTotalGrossExposure()).thenReturn(new BigDecimal("1800000"));
-    var order = createOrder("AAPL", 1000); // $150K → total $1.95M < $2M
+    var order = createOrder("AAPL", 1000);
     assertThat(check.check(order).passed()).isTrue();
   }
 
@@ -59,7 +59,7 @@ class MaxPortfolioExposureCheckTest {
                 new BigDecimal("150"),
                 Instant.now()));
     when(positionTracker.getTotalGrossExposure()).thenReturn(new BigDecimal("1900000"));
-    var order = createOrder("AAPL", 1000); // $150K → total $2.05M > $2M
+    var order = createOrder("AAPL", 1000);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();
     assertThat(result.checkName()).isEqualTo("MaxPortfolioExposure");

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/MaxPositionPerSymbolCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/MaxPositionPerSymbolCheckTest.java
@@ -44,7 +44,7 @@ class MaxPositionPerSymbolCheckTest {
                 new BigDecimal("150"),
                 Instant.now()));
     when(positionTracker.getPositionNotional("AAPL")).thenReturn(new BigDecimal("200000"));
-    var order = createOrder("AAPL", 666); // 666 * $150 = $99,900 → total $299,900
+    var order = createOrder("AAPL", 666);
     assertThat(check.check(order).passed()).isTrue();
   }
 
@@ -59,7 +59,7 @@ class MaxPositionPerSymbolCheckTest {
                 new BigDecimal("150"),
                 Instant.now()));
     when(positionTracker.getPositionNotional("AAPL")).thenReturn(new BigDecimal("400000"));
-    var order = createOrder("AAPL", 1000); // 1000 * $150 = $150K → total $550K > $500K
+    var order = createOrder("AAPL", 1000);
     var result = check.check(order);
     assertThat(result.passed()).isFalse();
     assertThat(result.checkName()).isEqualTo("MaxPositionPerSymbol");

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/SectorExposureCheckTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/SectorExposureCheckTest.java
@@ -51,7 +51,7 @@ class SectorExposureCheckTest {
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "150"));
     when(positions.snapshot())
         .thenReturn(Map.of("AAPL", new BigDecimal("500000"), "MSFT", new BigDecimal("400000")));
-    var order = order("AAPL", Side.BUY, 1000); // $150K → TECH projected $1.05M < $1.5M
+    var order = order("AAPL", Side.BUY, 1000);
     assertThat(check.check(order).passed()).isTrue();
   }
 
@@ -60,7 +60,6 @@ class SectorExposureCheckTest {
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "150"));
     when(positions.snapshot())
         .thenReturn(Map.of("AAPL", new BigDecimal("500000"), "NVDA", new BigDecimal("900000")));
-    // TECH exposure already 1.4M; +200K NVDA order pushes to 1.6M, breaches 1.5M TECH cap.
     when(tracker.getMarketState("NVDA")).thenReturn(market("NVDA", "200"));
     var order = order("NVDA", Side.BUY, 1000);
     var result = check.check(order);
@@ -70,19 +69,17 @@ class SectorExposureCheckTest {
 
   @Test
   void sellsThatReduceSectorExposurePass() {
-    // Position is at 1.4M; selling some doesn't push past limit even if limit were tighter.
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "150"));
     when(positions.snapshot()).thenReturn(Map.of("AAPL", new BigDecimal("1400000")));
-    var order = order("AAPL", Side.SELL, 1000); // reduces by $150K
+    var order = order("AAPL", Side.SELL, 1000);
     assertThat(check.check(order).passed()).isTrue();
   }
 
   @Test
   void unknownSectorFallsBackToDefaultLimit() {
-    // ZZZZ → UNKNOWN sector → falls back to default 1M cap.
     when(tracker.getMarketState("ZZZZ")).thenReturn(market("ZZZZ", "100"));
     when(positions.snapshot()).thenReturn(Map.of());
-    var bigOrder = order("ZZZZ", Side.BUY, 20_000); // $2M > $1M default
+    var bigOrder = order("ZZZZ", Side.BUY, 20_000);
     var result = check.check(bigOrder);
     assertThat(result.passed()).isFalse();
     assertThat(result.reason()).contains("UNKNOWN");
@@ -96,7 +93,7 @@ class SectorExposureCheckTest {
     var disabled = new SectorExposureCheck(disabledConfig, tracker, positions, refData);
     when(tracker.getMarketState("AAPL")).thenReturn(market("AAPL", "150"));
     when(positions.snapshot()).thenReturn(Map.of());
-    var order = order("AAPL", Side.BUY, 100_000); // huge order, would breach if checked
+    var order = order("AAPL", Side.BUY, 100_000);
     assertThat(disabled.check(order).passed()).isTrue();
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/SymbolReferenceDataTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/risk/SymbolReferenceDataTest.java
@@ -23,7 +23,6 @@ class SymbolReferenceDataTest {
     var data = build(new SymbolRef("AAPL", "TECH", 1.2, 60_000_000L));
     assertThat(data.sectorOf("ZZZZ")).isEqualTo("UNKNOWN");
     assertThat(data.betaOf("ZZZZ")).isEqualTo(1.0);
-    // Default ADV is conservatively 0 so the ADV check rejects until reference data is added.
     assertThat(data.advOf("ZZZZ")).isZero();
     assertThat(data.isMapped("ZZZZ")).isFalse();
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/MultiVenueRoutingIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/MultiVenueRoutingIntegrationTest.java
@@ -102,11 +102,6 @@ class MultiVenueRoutingIntegrationTest {
             new BigDecimal("178.52"),
             Instant.now()));
 
-    // Burst 50 orders. SOR scoring is deterministic, so all orders with identical inputs
-    // route to the highest-scoring venue. We assert two stronger properties:
-    //   (a) every audit record carries a non-null venue from the configured set
-    //   (b) every audit record evaluated all 3 venues (candidateScores.size == 3)
-    // proving multi-venue routing is active end-to-end.
     int orderCount = 50;
     for (int i = 0; i < orderCount; i++) {
       service.executeSignal(

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/RoutingDecisionCacheTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/RoutingDecisionCacheTest.java
@@ -32,7 +32,7 @@ class RoutingDecisionCacheTest {
     var cache = cacheOfSize(2);
     cache.put(decision("o-1"));
     cache.put(decision("o-2"));
-    assertThat(cache.get("o-1")).isPresent(); // touch
+    assertThat(cache.get("o-1")).isPresent();
     cache.put(decision("o-3"));
     assertThat(cache.get("o-1")).isPresent();
     assertThat(cache.get("o-2")).isEmpty();

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/ScoredRouterKafkaIntegrationTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/ScoredRouterKafkaIntegrationTest.java
@@ -73,8 +73,6 @@ class ScoredRouterKafkaIntegrationTest {
     consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    // Refresh topic metadata aggressively so we discover routing.decisions soon after the
-    // producer auto-creates it on first send (default metadata.max.age.ms is 5 min).
     consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 1000);
     consumer = new KafkaConsumer<>(consumerProps);
     consumer.subscribe(java.util.List.of("routing.decisions"));
@@ -147,12 +145,11 @@ class ScoredRouterKafkaIntegrationTest {
     var node = MAPPER.readTree(record.value());
 
     assertThat(node.get("orderId").asText()).isEqualTo(order.getOrderId());
-    assertThat(node.has("selectedVenue")).isFalse(); // legacy `venue` field is the canonical name
+    assertThat(node.has("selectedVenue")).isFalse();
     assertThat(node.get("venue").asText()).isIn("PRIMARY", "DARK_POOL_A", "INTERNAL_CROSS");
     assertThat(node.get("candidateScores").size()).isEqualTo(3);
     assertThat(node.get("weights").size()).isEqualTo(5);
     assertThat(node.get("marketSnapshot").get("bid").decimalValue()).isEqualByComparingTo("178.50");
-    // Each candidate has all 5 criteria
     for (JsonNode cs : node.get("candidateScores")) {
       assertThat(cs.get("criteria").size()).isEqualTo(5);
     }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/ScoredSmartOrderRouterTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/ScoredSmartOrderRouterTest.java
@@ -149,7 +149,6 @@ class ScoredSmartOrderRouterTest {
     var dark = venue("DARK_POOL_A", VenueType.DARK, true);
     var scorer = stubScorer(Map.of("PRIMARY", 0.4, "DARK_POOL_A", 0.8));
     var router = router(List.of(lit, dark), scorer);
-    // Mark DARK_POOL_A as unhealthy: drop it from the healthy set
     healthyVenues.remove("DARK_POOL_A");
     when(tracker.getMarketState(anyString())).thenReturn(market());
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/VenueScorerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/VenueScorerTest.java
@@ -29,7 +29,6 @@ class VenueScorerTest {
     var scorer = new VenueScorer(List.of(c1, c2, c3, c4, c5), config);
 
     var b = scorer.score(order(), venue(), null);
-    // 0.2*(0.5+1.0+0.0+0.5+1.0) = 0.6
     assertThat(b.weightedScore()).isCloseTo(0.6, within(1e-9));
     assertThat(b.criteria()).containsEntry("PriceImprovement", 0.5);
     assertThat(b.criteria()).containsEntry("Liquidity", 1.0);
@@ -43,7 +42,6 @@ class VenueScorerTest {
     var pi = stub("PriceImprovement", 0.5);
     var scorer = new VenueScorer(List.of(rogue, pi), config);
     var b = scorer.score(order(), venue(), null);
-    // RogueCriterion contributes 0 (no weight); PriceImprovement contributes 1.0*0.5 = 0.5
     assertThat(b.weightedScore()).isCloseTo(0.5, within(1e-9));
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/FeeScorerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/FeeScorerTest.java
@@ -31,14 +31,12 @@ class FeeScorerTest {
 
   @Test
   void marketOrderUsesTakerFee() {
-    // taker=3 bps, max=10 → 1 - 0.3 = 0.7
     var ctx = ctxMarket(3, 2);
     assertThat(scorer.score(ctx)).isCloseTo(0.7, within(1e-9));
   }
 
   @Test
   void passiveLimitUsesMakerRebate() {
-    // rebate=2 → effective=-2 → 1 - (-0.2) = 1.2 → cap 1.0
     var ctx = ctxLimitPassive(3, 2);
     assertThat(scorer.score(ctx)).isCloseTo(1.0, within(1e-9));
   }
@@ -139,12 +137,10 @@ class FeeScorerTest {
   }
 
   private ScoringContext ctxLimitPassive(int taker, int rebate) {
-    // BUY LIMIT @ 178.30 with ask=178.54 → does not cross → passive
     return ctx(OrderType.LIMIT, new BigDecimal("178.30"), taker, rebate, marketState());
   }
 
   private ScoringContext ctxLimitAggressive(int taker, int rebate) {
-    // BUY LIMIT @ 178.60 with ask=178.54 → crosses → aggressive
     return ctx(OrderType.LIMIT, new BigDecimal("178.60"), taker, rebate, marketState());
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/InformationLeakageScorerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/InformationLeakageScorerTest.java
@@ -49,13 +49,11 @@ class InformationLeakageScorerTest {
 
   @Test
   void clampsBelowZero() {
-    // Misconfigured venue with negative leakage → clamp to 0 → score 1.0
     assertThat(scorer.score(ctx(-0.5))).isCloseTo(1.0, within(1e-9));
   }
 
   @Test
   void clampsAboveOne() {
-    // Misconfigured venue with >1 leakage → clamp to 1 → score 0.0
     assertThat(scorer.score(ctx(1.5))).isCloseTo(0.0, within(1e-9));
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/LatencyScorerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/LatencyScorerTest.java
@@ -29,7 +29,6 @@ class LatencyScorerTest {
 
   @Test
   void linearScale() {
-    // latency 50, max 200 → 1 - 0.25 = 0.75
     assertThat(scorer.score(ctx(50))).isCloseTo(0.75, within(1e-9));
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/LiquidityScorerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/LiquidityScorerTest.java
@@ -29,15 +29,13 @@ class LiquidityScorerTest {
 
   @Test
   void litFullCoverage() {
-    var ctx = ctxLit(100, /* topOfBook */ 10000, /* fillRate */ 0.95);
-    // coverage=min(1, 10000/100)=1; * 0.95 = 0.95
+    var ctx = ctxLit(100, 10000, 0.95);
     assertThat(scorer.score(ctx)).isCloseTo(0.95, within(1e-9));
   }
 
   @Test
   void litPartialCoverage() {
-    var ctx = ctxLit(10000, /* topOfBook */ 5000, /* fillRate */ 1.0);
-    // coverage=0.5; * 1.0 = 0.5
+    var ctx = ctxLit(10000, 5000, 1.0);
     assertThat(scorer.score(ctx)).isCloseTo(0.5, within(1e-9));
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/PriceImprovementScorerTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/router/scorer/PriceImprovementScorerTest.java
@@ -37,8 +37,6 @@ class PriceImprovementScorerTest {
 
   @Test
   void darkVenueGetsHalfSpread() {
-    // bid=178.50 ask=178.54 → spread=0.04, half=0.02, mid≈178.52, halfSpreadBps≈1.12
-    // max=5 bps → score ≈ 0.224
     var ctx = ctx(VenueType.DARK, market("178.50", "178.54"));
     assertThat(scorer.score(ctx)).isCloseTo(0.224, within(0.01));
   }
@@ -57,7 +55,6 @@ class PriceImprovementScorerTest {
 
   @Test
   void capsAtOneForWideSpread() {
-    // bid=100 ask=101 → halfSpreadBps≈49.75; max=5 → raw=9.95 → cap=1.0
     var ctx = ctx(VenueType.DARK, market("100.00", "101.00"));
     assertThat(scorer.score(ctx)).isEqualTo(1.0);
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/service/BasketTradingServiceTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/service/BasketTradingServiceTest.java
@@ -1,0 +1,158 @@
+package com.mariaalpha.executionengine.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.mariaalpha.executionengine.basket.BasketMetrics;
+import com.mariaalpha.executionengine.basket.BasketRegistry;
+import com.mariaalpha.executionengine.basket.BasketStatus;
+import com.mariaalpha.executionengine.controller.dto.BasketLegRequest;
+import com.mariaalpha.executionengine.controller.dto.BasketOrderRequest;
+import com.mariaalpha.executionengine.model.Order;
+import com.mariaalpha.executionengine.model.OrderStatus;
+import com.mariaalpha.executionengine.model.OrderType;
+import com.mariaalpha.executionengine.model.Side;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BasketTradingServiceTest {
+
+  private OrderExecutionService executionService;
+  private BasketRegistry registry;
+  private BasketTradingService service;
+
+  @BeforeEach
+  void setUp() {
+    executionService = mock(OrderExecutionService.class);
+    registry = new BasketRegistry();
+    service =
+        new BasketTradingService(
+            executionService, registry, new BasketMetrics(new SimpleMeterRegistry()));
+  }
+
+  private BasketLegRequest limitLeg(String symbol, Side side, int qty, String price) {
+    return new BasketLegRequest(
+        symbol, side, OrderType.LIMIT, qty, new BigDecimal(price), null, null);
+  }
+
+  @Test
+  void submit_allAccepted_returnsSubmittedBasketAndTracksIt() {
+    var request =
+        new BasketOrderRequest(
+            "rebalance",
+            List.of(
+                limitLeg("AAPL", Side.BUY, 100, "150.00"),
+                limitLeg("MSFT", Side.BUY, 50, "300.00")));
+
+    var view = service.submit(request);
+
+    assertThat(view.basketId()).isNotBlank();
+    assertThat(view.name()).isEqualTo("rebalance");
+    assertThat(view.totalLegs()).isEqualTo(2);
+    assertThat(view.acceptedLegs()).isEqualTo(2);
+    assertThat(view.status()).isEqualTo(BasketStatus.SUBMITTED);
+    assertThat(registry.trackedBaskets()).isEqualTo(1);
+    verify(executionService, times(2)).submitOrder(any(Order.class));
+  }
+
+  @Test
+  void submit_oneLegRejected_reflectsMixedStatus() {
+    rejectSymbol("MSFT");
+    var request =
+        new BasketOrderRequest(
+            null,
+            List.of(
+                limitLeg("AAPL", Side.BUY, 100, "150.00"),
+                limitLeg("MSFT", Side.BUY, 50, "300.00")));
+
+    var view = service.submit(request);
+
+    assertThat(view.acceptedLegs()).isEqualTo(1);
+    assertThat(view.rejectedLegs()).isEqualTo(1);
+    assertThat(view.status()).isEqualTo(BasketStatus.SUBMITTED);
+  }
+
+  @Test
+  void submit_allLegsRejected_basketRejected() {
+    rejectSymbol("AAPL");
+    var request = new BasketOrderRequest(null, List.of(limitLeg("AAPL", Side.BUY, 100, "150.00")));
+
+    var view = service.submit(request);
+
+    assertThat(view.status()).isEqualTo(BasketStatus.REJECTED);
+    assertThat(view.acceptedLegs()).isZero();
+  }
+
+  @Test
+  void submit_linksLegsSoFillsAttributeToBasket() {
+    var view =
+        service.submit(
+            new BasketOrderRequest(null, List.of(limitLeg("AAPL", Side.BUY, 100, "150.00"))));
+    var legId = view.legs().get(0).legOrderId();
+
+    assertThat(registry.recordLegFill(legId, 100, true)).contains(view.basketId());
+    assertThat(registry.view(view.basketId()).orElseThrow().status())
+        .isEqualTo(BasketStatus.FILLED);
+  }
+
+  @Test
+  void submit_limitLegWithoutPrice_isRejectedBeforeAnyVenueCall() {
+    var request =
+        new BasketOrderRequest(
+            null,
+            List.of(
+                new BasketLegRequest("AAPL", Side.BUY, OrderType.LIMIT, 100, null, null, null)));
+
+    assertThatThrownBy(() -> service.submit(request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("requires a limitPrice");
+    assertThat(registry.trackedBaskets()).isZero();
+  }
+
+  @Test
+  void submit_parentManagedOrderTypeLeg_isRejected() {
+    var request =
+        new BasketOrderRequest(
+            null,
+            List.of(
+                new BasketLegRequest(
+                    "AAPL",
+                    Side.BUY,
+                    OrderType.ICEBERG,
+                    100,
+                    new BigDecimal("150.00"),
+                    null,
+                    null)));
+
+    assertThatThrownBy(() -> service.submit(request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ICEBERG");
+  }
+
+  @Test
+  void submit_emptyBasket_isRejected() {
+    assertThatThrownBy(() -> service.submit(new BasketOrderRequest("empty", List.of())))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private void rejectSymbol(String symbol) {
+    doAnswer(
+            inv -> {
+              Order o = inv.getArgument(0);
+              if (o.getSymbol().equals(symbol)) {
+                o.compareAndSetStatus(OrderStatus.NEW, OrderStatus.REJECTED);
+              }
+              return o;
+            })
+        .when(executionService)
+        .submitOrder(any(Order.class));
+  }
+}

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/service/ManualOrderServiceTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/service/ManualOrderServiceTest.java
@@ -37,7 +37,6 @@ class ManualOrderServiceTest {
         new ManualOrderService(
             executionService, lifecycleManager, icebergCoordinator, null, venueAdapters);
 
-    // submitOrder returns the order passed in (simulates pipeline registration)
     when(executionService.submitOrder(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
   }
 
@@ -72,7 +71,6 @@ class ManualOrderServiceTest {
 
     service.submit(request);
 
-    // No exception; clientOrderId generated internally (UUID). Just verify submission happened.
     verify(executionService).submitOrder(any(Order.class));
   }
 
@@ -84,7 +82,6 @@ class ManualOrderServiceTest {
 
     service.submit(request);
 
-    // ClientOrderId is a signal-level concept; it's carried through as strategyName="MANUAL"
     verify(executionService).submitOrder(any(Order.class));
   }
 

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/service/OrderExecutionServiceTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/service/OrderExecutionServiceTest.java
@@ -91,6 +91,7 @@ class OrderExecutionServiceTest {
             dailyLossMonitor,
             metrics,
             icebergCoordinator,
+            null,
             null);
     service.registerCallbacks();
   }

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/service/OrderExecutionServiceTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/service/OrderExecutionServiceTest.java
@@ -131,8 +131,6 @@ class OrderExecutionServiceTest {
 
     verify(primaryVenueAdapter, never()).submitOrder(any());
     verify(metrics).recordRejection("TradingHalted");
-    // The rejection must be visible downstream: the order is registered and transitioned to
-    // REJECTED so order-manager / the UI see the drop instead of a silent no-op.
     verify(lifecycleManager).registerOrder(any());
     verify(lifecycleManager)
         .transition(any(), eq(OrderStatus.REJECTED), isNull(), eq("Trading halted"));

--- a/execution-engine/src/test/java/com/mariaalpha/executionengine/service/OrderExecutionServiceZeroQuantityCancelTest.java
+++ b/execution-engine/src/test/java/com/mariaalpha/executionengine/service/OrderExecutionServiceZeroQuantityCancelTest.java
@@ -59,6 +59,7 @@ class OrderExecutionServiceZeroQuantityCancelTest {
             dailyLossMonitor,
             metrics,
             mock(IcebergCoordinator.class),
+            null,
             null);
 
     order =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ resilience4j = "2.2.0"
 okhttp = "4.12.0"
 caffeine = "3.1.8"
 springdoc = "2.6.0"
+quickfixj = "2.3.2"
 pitest-plugin = "1.19.0"
 pitest-tool = "1.19.6"
 pitest-junit5 = "1.2.3"
@@ -48,6 +49,8 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 springdoc-openapi-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+quickfixj-core = { module = "org.quickfixj:quickfixj-core", version.ref = "quickfixj" }
+quickfixj-messages-fix44 = { module = "org.quickfixj:quickfixj-messages-fix44", version.ref = "quickfixj" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/adapter/SimulatedMarketDataAdapter.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/adapter/SimulatedMarketDataAdapter.java
@@ -44,7 +44,6 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
     this.resourceLoader = resourceLoader;
   }
 
-  /** Loads tick data from the CSV and subscribes to the given symbols. */
   @Override
   public void connect(List<String> symbols) {
     this.subscribedSymbols = Set.copyOf(symbols);
@@ -53,7 +52,6 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
     LOG.info("Loaded {} ticks from {}, subscribed to {}", ticks.size(), config.csvPath(), symbols);
   }
 
-  /** Stops the adapter; any in-progress replay will terminate. */
   @Override
   public void disconnect() {
     this.connected = false;
@@ -70,10 +68,6 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
     return subscribedSymbols == null ? List.of() : List.copyOf(subscribedSymbols);
   }
 
-  /**
-   * Returns a Flux that replays ticks for subscribed symbols, paced by the configured speed
-   * multiplier (0 = no delay).
-   */
   @Override
   public Flux<MarketTick> streamTicks() {
     if (!connected || ticks == null) {
@@ -86,32 +80,25 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
     Flux<MarketTick> singlePass =
         config.speedMultiplier() <= 0 ? Flux.fromIterable(filtered) : replayWithDelay(filtered);
     if (config.loopDelayMs() > 0) {
-      // Loop the CSV replay with a pause between iterations so strategies configured
-      // after startup still receive ticks. Stops immediately when disconnect() is called.
       singlePass =
           singlePass.repeatWhen(
               n ->
                   n.delayElements(Duration.ofMillis(config.loopDelayMs()))
                       .takeWhile(ignored -> connected));
     }
-    // The replay sleeps between ticks — keep it off the subscriber's thread so callers
-    // (ApplicationRunner, health indicators) aren't blocked for the duration of a pass.
     return singlePass.subscribeOn(Schedulers.boundedElastic());
   }
 
-  /** Returns only ticks whose symbol matches the subscription list. */
   private List<MarketTick> filterBySubscribedSymbols() {
     return ticks.stream().filter(tick -> subscribedSymbols.contains(tick.symbol())).toList();
   }
 
-  /** Not supported — historical bars are fetched via the Alpaca adapter. */
   @Override
   public List<HistoricalBar> getHistoricalBars(
       String symbol, LocalDate from, LocalDate to, BarTimeframe timeframe) {
     throw new UnsupportedOperationException("Historical bars not supported by simulated adapter");
   }
 
-  /** Reads and parses the CSV file into an ordered list of ticks. */
   private List<MarketTick> loadTicks() {
     var resource = resourceLoader.getResource(config.csvPath());
     try (var reader =
@@ -129,7 +116,6 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
     }
   }
 
-  /** Parses a single CSV row into a MarketTick. */
   private MarketTick parseLine(String line) {
     var parts = CSV_DELIMITER.split(line, -1);
     if (parts.length != 10) {
@@ -150,7 +136,6 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
         false);
   }
 
-  /** Emits ticks with inter-tick delays derived from CSV timestamps. */
   private Flux<MarketTick> replayWithDelay(List<MarketTick> filtered) {
     return Flux.create(
         sink -> {
@@ -165,7 +150,6 @@ public class SimulatedMarketDataAdapter implements MarketDataAdapter {
         });
   }
 
-  /** Sleeps for the scaled time delta between consecutive ticks. */
   private void sleepBetweenTicks(List<MarketTick> filtered, int index) {
     if (index >= filtered.size() - 1) {
       return;

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/adapter/alpaca/AlpacaMarketDataAdapter.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/adapter/alpaca/AlpacaMarketDataAdapter.java
@@ -76,8 +76,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
         new ObjectMapper()
             .registerModule(new JavaTimeModule())
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    // bridge imperative (WebSocket callback pushes data) to reactive (downstream consumers
-    // subscribe to a Flux)
     this.tickSink = Sinks.many().multicast().onBackpressureBuffer();
     this.webClient =
         WebClient.builder()
@@ -186,7 +184,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
     return allBars;
   }
 
-  /** Parses the JSON once, reads the type field, and dispatches to the appropriate handler. */
   @VisibleForTesting
   void handleMessage(String raw, WebSocketSession session, List<String> symbols) {
     try {
@@ -216,7 +213,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
     }
   }
 
-  /** Handles the auth handshake: connected → authenticate → authenticated → subscribe. */
   private void handleSuccess(JsonNode node, WebSocketSession session, List<String> symbols)
       throws JsonProcessingException {
     var control = objectMapper.treeToValue(node, AlpacaControl.class);
@@ -239,7 +235,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
     }
   }
 
-  /** Converts an Alpaca trade node into a MarketTick and pushes it to the sink. */
   private void handleTrade(JsonNode node) throws JsonProcessingException {
     var trade = objectMapper.treeToValue(node, AlpacaTrade.class);
     var tick =
@@ -260,7 +255,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
     tickSink.tryEmitNext(tick);
   }
 
-  /** Converts an Alpaca quote node into a MarketTick and pushes it to the sink. */
   private void handleQuote(JsonNode node) throws JsonProcessingException {
     var quote = objectMapper.treeToValue(node, AlpacaQuote.class);
     var tick =
@@ -281,7 +275,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
     tickSink.tryEmitNext(tick);
   }
 
-  /** Logs Alpaca error messages. */
   private void handleError(JsonNode node) throws JsonProcessingException {
     var control = objectMapper.treeToValue(node, AlpacaControl.class);
     LOG.error("Alpaca error — code: {}, message: {}", control.code(), control.message());
@@ -325,9 +318,6 @@ public class AlpacaMarketDataAdapter implements MarketDataAdapter {
 
   @VisibleForTesting
   void scheduleReconnect() {
-    // Retry forever with the backoff capped at the last rung — giving up permanently would
-    // leave the gateway tickless until the process is restarted. Last ticks are re-emitted as
-    // stale so downstream consumers know the feed is degraded while we reconnect.
     emitStaleTicks();
     reconnectCounter.increment();
     var attempt = reconnectAttempt.getAndIncrement();

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/book/OrderBookEntry.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/book/OrderBookEntry.java
@@ -18,15 +18,6 @@ public record OrderBookEntry(
         symbol, BigDecimal.ZERO, BigDecimal.ZERO, 0L, 0L, BigDecimal.ZERO, 0L, Instant.EPOCH);
   }
 
-  /**
-   * Returns a new entry with fields updated from the given tick. TRADE ticks update lastPrice and
-   * cumulativeVolume. QUOTE ticks update bid/ask prices and sizes. BAR ticks are ignored.
-   *
-   * <p>Cumulative volume: the simulated CSV feed carries a running total on each tick, but the
-   * Alpaca feed reports only the per-trade size (cumulativeVolume arrives as 0). Taking the max of
-   * "feed-reported total" and "our own running total + this trade's size" handles both without
-   * double-counting.
-   */
   public OrderBookEntry update(MarketTick tick) {
     return switch (tick.eventType()) {
       case TRADE ->

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/book/OrderBookManager.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/book/OrderBookManager.java
@@ -34,12 +34,6 @@ public class OrderBookManager {
     LOG.info("Order book manager started");
   }
 
-  /**
-   * Drops the current subscription and re-subscribes to the adapter's tick stream. Required in the
-   * simulated profile: the {@code @PostConstruct} subscription happens before the runner calls
-   * {@code adapter.connect()}, and the simulated adapter's pre-connect stream is an empty flux that
-   * completes immediately — without a re-subscribe the book would never see a tick.
-   */
   public void restart() {
     if (subscription != null && !subscription.isDisposed()) {
       subscription.dispose();
@@ -56,7 +50,6 @@ public class OrderBookManager {
     LOG.info("Order book manager stopped");
   }
 
-  /** Updates the in-memory book for the tick's symbol. */
   void onTick(MarketTick tick) {
     var updated =
         books.compute(
@@ -70,12 +63,10 @@ public class OrderBookManager {
     updateSink.tryEmitNext(updated);
   }
 
-  /** Returns the current snapshot for a symbol, or an empty entry if unknown. */
   public OrderBookEntry getSnapshot(String symbol) {
     return books.getOrDefault(symbol, OrderBookEntry.empty(symbol));
   }
 
-  /** Returns a reactive stream of book updates filtered to the requested symbols. */
   public Flux<OrderBookEntry> streamSnapshots(Set<String> symbols) {
     return updateSink.asFlux().filter(entry -> symbols.contains(entry.symbol()));
   }

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/health/TickReadinessIndicator.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/health/TickReadinessIndicator.java
@@ -29,11 +29,6 @@ public class TickReadinessIndicator implements HealthIndicator {
     subscribeForFirstTick();
   }
 
-  /**
-   * Drops the current subscription and re-arms the first-tick latch. Required in the simulated
-   * profile, where the {@code @PostConstruct} subscription fires before the runner calls {@code
-   * adapter.connect()} and therefore observes an empty, immediately-completing flux.
-   */
   public void restart() {
     if (subscription != null && !subscription.isDisposed()) {
       subscription.dispose();

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/publisher/TickKafkaPublisher.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/publisher/TickKafkaPublisher.java
@@ -68,7 +68,6 @@ public class TickKafkaPublisher {
   private void publishTick(MarketTick tick) {
     try {
       var json = objectMapper.writeValueAsString(tick);
-      // records are keyed by symbol
       kafkaTemplate.send(config.ticksTopic(), tick.symbol(), json);
       Counter.builder(METRIC_NAME)
           .description("Total market data ticks received")

--- a/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/websocket/SimulatedRunner.java
+++ b/market-data-gateway/src/main/java/com/mariaalpha/marketdatagateway/websocket/SimulatedRunner.java
@@ -41,9 +41,6 @@ public class SimulatedRunner implements ApplicationRunner {
   public void run(ApplicationArguments args) {
     LOG.info("Starting simulated market data for symbols: {}", symbols);
     adapter.connect(symbols);
-    // Every @PostConstruct subscriber saw the pre-connect empty flux — re-subscribe them all now
-    // that the adapter is connected, or the book / readiness probe / Kafka publisher never see a
-    // single tick in this profile.
     publisher.startStreaming();
     orderBookManager.restart();
     tickReadinessIndicator.restart();

--- a/market-data-gateway/src/test/java/com/mariaalpha/marketdatagateway/adapter/alpaca/AlpacaMarketDataAdapterTest.java
+++ b/market-data-gateway/src/test/java/com/mariaalpha/marketdatagateway/adapter/alpaca/AlpacaMarketDataAdapterTest.java
@@ -297,7 +297,6 @@ class AlpacaMarketDataAdapterTest {
     var testAdapter = new TestableAdapter(config, new SimpleMeterRegistry());
     testAdapter.connect(List.of("AAPL"));
 
-    // Simulate a received tick
     var tradeJson =
         "[{\"T\":\"t\",\"S\":\"AAPL\",\"p\":178.52,"
             + "\"s\":100,"
@@ -305,10 +304,8 @@ class AlpacaMarketDataAdapterTest {
             + "\"c\":[],\"z\":\"C\"}]";
     testAdapter.handleMessage(tradeJson, mockSession, List.of("AAPL"));
 
-    // Trigger reconnect
     testAdapter.scheduleReconnect();
 
-    // The second tick emitted should be stale
     StepVerifier.create(testAdapter.streamTicks().take(2))
         .assertNext(
             tick -> {
@@ -334,8 +331,6 @@ class AlpacaMarketDataAdapterTest {
     testAdapter.connect(List.of("AAPL"));
     IntStream.range(0, MAX_RETRIES).forEach(ignore -> testAdapter.scheduleReconnect());
 
-    // Past the end of the backoff table the adapter keeps retrying at the capped delay —
-    // giving up permanently would leave the gateway tickless until a restart.
     var countBefore =
         Objects.requireNonNull(registry.find("mariaalpha_md_websocket_reconnects_total").counter())
             .count();

--- a/market-data-gateway/src/test/java/com/mariaalpha/marketdatagateway/book/OrderBookManagerTest.java
+++ b/market-data-gateway/src/test/java/com/mariaalpha/marketdatagateway/book/OrderBookManagerTest.java
@@ -133,7 +133,6 @@ class OrderBookManagerTest {
     executor.shutdown();
 
     var snapshot = manager.getSnapshot("AAPL");
-    // The book must have a valid state — lastPrice must be one of the submitted prices
     assertThat(snapshot.lastPrice().doubleValue()).isBetween(100.0, 100.0 + ticksPerThread);
     assertThat(snapshot.symbol()).isEqualTo("AAPL");
   }

--- a/ml-signal-service/scripts/train_regime_model.py
+++ b/ml-signal-service/scripts/train_regime_model.py
@@ -50,17 +50,16 @@ from ml_signal.model.regime_model import (  # noqa: E402
 )
 
 OUTPUT_PATH = Path(__file__).parent.parent.parent / "ml-models" / "regime_model.joblib"
-WINDOW = MIN_BARS_FOR_REGIME  # 60 bars per training sample
+WINDOW = MIN_BARS_FOR_REGIME
 DEFAULT_SAMPLES_PER_CLASS = 2_000
 
 
-# Per-class generator parameters. Drifts and vols are per-bar, in log space.
 @dataclass(frozen=True)
 class _GeneratorParams:
     drift: float
     sigma: float
     ar1: float
-    kind: str  # "gbm" or "ar1"
+    kind: str
 
 
 _GENERATOR_PARAMS: dict[int, _GeneratorParams] = {
@@ -80,14 +79,12 @@ def _generate_path(
 ) -> np.ndarray:
     """Generate a single synthetic close-price path of length n_bars under the regime."""
     params = _GENERATOR_PARAMS[regime]
-    # Sprinkle a small parameter jitter so the model sees variation within each class.
     drift = params.drift * float(rng.uniform(0.7, 1.3))
     sigma = params.sigma * float(rng.uniform(0.7, 1.3))
 
     if params.kind == "gbm":
         log_returns = rng.normal(loc=drift, scale=sigma, size=n_bars - 1)
     elif params.kind == "ar1":
-        # AR(1) returns with negative coefficient → mean-reverting behaviour.
         log_returns = np.zeros(n_bars - 1, dtype=np.float64)
         prev = 0.0
         for i in range(n_bars - 1):
@@ -122,7 +119,6 @@ def _build_dataset(
     X = np.array(feature_rows, dtype=np.float64)
     y = np.array(labels, dtype=np.int64)
 
-    # Shuffle so the train/val split sees all classes uniformly.
     perm = rng.permutation(len(y))
     return X[perm], y[perm]
 

--- a/ml-signal-service/scripts/train_signal_model.py
+++ b/ml-signal-service/scripts/train_signal_model.py
@@ -24,7 +24,6 @@ import pandas as pd
 from lightgbm import LGBMClassifier
 from sklearn.metrics import accuracy_score, classification_report
 
-# Add src to path so we can import our indicator functions
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from ml_signal.features.indicators import atr, ema, macd, rsi  # noqa: E402
 
@@ -47,8 +46,8 @@ FEATURE_NAMES = [
 ]
 
 SYMBOLS = ["AAPL", "MSFT", "GOOGL", "AMZN", "META"]
-LOOKBACK_DAYS = 180  # 6 months
-LABEL_HORIZON = 5  # predict 5-bar (5-minute) return
+LOOKBACK_DAYS = 180
+LABEL_HORIZON = 5
 TRAIN_SPLIT = 0.8
 OUTPUT_PATH = Path(__file__).parent.parent.parent / "ml-models" / "signal_model.joblib"
 
@@ -130,16 +129,13 @@ def compute_features(df: pd.DataFrame) -> pd.DataFrame:
     macd_line, macd_sig, macd_hist = macd(closes)
     atr_14 = atr(highs, lows, closes, 14)
 
-    # Volume ratio: current / SMA(20)
     vol_sma = pd.Series(volumes).rolling(20).mean().values
     vol_ratio = np.where(vol_sma > 0, volumes / vol_sma, 1.0)
 
-    # Returns: (close[i] - close[i-1]) / close[i-1]  — must match engine.py
     prev_closes = np.roll(closes, 1)
-    prev_closes[0] = closes[0]  # first bar → return = 0
+    prev_closes[0] = closes[0]
     return_1 = (closes - prev_closes) / np.where(prev_closes > 0, prev_closes, 1.0)
 
-    # Realized volatility: std of 1-bar returns over 20 periods
     realized_vol = pd.Series(return_1).rolling(20).std().values
     close_shifted_5 = np.roll(closes, 5)
     close_shifted_5[:5] = closes[:5]
@@ -184,7 +180,6 @@ def main() -> None:
     print(f"Label horizon: {LABEL_HORIZON} bars (minutes)")
     print()
 
-    # 1. Fetch data
     dfs: list[pd.DataFrame] = []
     for symbol in SYMBOLS:
         df = fetch_bars(symbol, api_key, api_secret)
@@ -195,7 +190,6 @@ def main() -> None:
         print("ERROR: No data fetched. Check your API credentials and network.")
         sys.exit(1)
 
-    # 2. Compute features per symbol
     featured_dfs: list[pd.DataFrame] = []
     for df in dfs:
         featured = compute_features(df)
@@ -204,16 +198,13 @@ def main() -> None:
 
     all_data = pd.concat(featured_dfs, ignore_index=True)
 
-    # 3. Drop rows with NaN features or labels
     all_data = all_data.dropna(subset=FEATURE_NAMES + ["label"])
 
-    # Drop first 50 rows per symbol (warm-up period for indicators)
     all_data = all_data.groupby("symbol").apply(lambda g: g.iloc[50:]).reset_index(drop=True)
 
     print(f"\nTotal samples after cleanup: {len(all_data)}")
     print(f"Label distribution:\n{all_data['label'].value_counts().to_string()}")
 
-    # 4. Time-ordered train/val split
     split_idx = int(len(all_data) * TRAIN_SPLIT)
     X_train = all_data[FEATURE_NAMES].iloc[:split_idx].values
     y_train = all_data["label"].iloc[:split_idx].values
@@ -222,7 +213,6 @@ def main() -> None:
 
     print(f"\nTrain: {len(X_train)} samples, Val: {len(X_val)} samples")
 
-    # 5. Train LightGBM
     print("\nTraining LightGBM...")
     clf = LGBMClassifier(
         n_estimators=200,
@@ -240,7 +230,6 @@ def main() -> None:
         callbacks=[],
     )
 
-    # 6. Evaluate
     y_pred = clf.predict(X_val)
     accuracy = accuracy_score(y_val, y_pred)
     print(f"\nValidation accuracy: {accuracy:.4f}")
@@ -249,13 +238,11 @@ def main() -> None:
     if accuracy < 0.50:
         print("WARNING: Accuracy below 50% — model may not be better than random")
 
-    # 7. Feature importance
     print("Feature importance (gain):")
     importances = clf.feature_importances_
     for name, imp in sorted(zip(FEATURE_NAMES, importances, strict=False), key=lambda x: -x[1]):
         print(f"  {name:20s} {imp:8.1f}")
 
-    # 8. Save
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     version = datetime.now().strftime("%Y%m%d-%H%M%S")
     joblib.dump(

--- a/ml-signal-service/src/ml_signal/__main__.py
+++ b/ml-signal-service/src/ml_signal/__main__.py
@@ -17,7 +17,6 @@ import grpc
 import structlog
 import uvicorn
 
-# Add proto generated stubs to path (for local development)
 _proto_path = (
     Path(__file__).resolve().parent.parent.parent.parent / "proto" / "generated" / "python"
 )
@@ -47,17 +46,14 @@ def main() -> None:
         regime_model_path=settings.regime_model_path,
     )
 
-    # Core components
     feature_engine = FeatureEngine(settings)
     signal_model = SignalModel(settings.signal_model_path)
     regime_model = RegimeModel(settings.regime_model_path)
 
-    # Kafka consumer (daemon thread — dies when main thread exits)
     consumer = TickConsumer(settings, feature_engine)
     consumer_thread = threading.Thread(target=consumer.run, name="tick-consumer", daemon=True)
     consumer_thread.start()
 
-    # gRPC server
     grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=settings.grpc_max_workers))
     servicer = SignalServicer(feature_engine, signal_model, regime_model)
     signal_pb2_grpc.add_SignalServiceServicer_to_server(servicer, grpc_server)
@@ -65,7 +61,6 @@ def main() -> None:
     grpc_server.start()
     logger.info("grpc_server_started", port=settings.grpc_port)
 
-    # FastAPI (blocks on main thread)
     app = create_app(feature_engine, signal_model, regime_model, settings)
     uvicorn.run(app, host="0.0.0.0", port=settings.api_port, log_level="info")
 

--- a/ml-signal-service/src/ml_signal/api/app.py
+++ b/ml-signal-service/src/ml_signal/api/app.py
@@ -50,7 +50,6 @@ def create_app(
 
     @app.get("/metrics", response_class=PlainTextResponse)
     def metrics() -> bytes:
-        # Update staleness gauges before scrape
         now = time.time()
         for symbol, last_update in feature_engine.last_update_times().items():
             FEATURE_STALENESS.labels(symbol=symbol).set(now - last_update)

--- a/ml-signal-service/src/ml_signal/config.py
+++ b/ml-signal-service/src/ml_signal/config.py
@@ -6,30 +6,22 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Settings loaded from environment variables prefixed with ML_SIGNAL_."""
 
-    # Kafka
     kafka_bootstrap_servers: str = "localhost:9092"
     kafka_ticks_topic: str = "market-data.ticks"
     kafka_consumer_group: str = "ml-signal-service"
 
-    # gRPC
     grpc_port: int = 50051
     grpc_max_workers: int = 10
 
-    # FastAPI
     api_port: int = 8090
 
-    # Model
     signal_model_path: str = "ml-models/signal_model.joblib"
     regime_model_path: str = "ml-models/regime_model.joblib"
 
-    # Feature engine
     bar_interval_seconds: int = 60
     min_bars_for_features: int = 50
     max_bars_retained: int = 200
 
-    # Regime classifier window — minimum bars to compute regime features.
-    # Independent of the signal-model window because regime classification needs
-    # a longer horizon to differentiate trending/mean-reverting from noise.
     min_bars_for_regime: int = 60
 
     model_config = {"env_prefix": "ML_SIGNAL_"}

--- a/ml-signal-service/src/ml_signal/features/engine.py
+++ b/ml-signal-service/src/ml_signal/features/engine.py
@@ -48,7 +48,7 @@ FEATURE_NAMES: list[str] = [
 class Bar:
     """A completed 1-minute OHLCV bar."""
 
-    timestamp: float  # epoch seconds of bar start
+    timestamp: float
     open: float
     high: float
     low: float
@@ -87,7 +87,6 @@ class FeatureEngine:
         self._min_bars = settings.min_bars_for_features
         self._max_bars = settings.max_bars_retained
 
-        # Per-symbol state (protected by _lock)
         self._bars: dict[str, list[Bar]] = {}
         self._current_bar: dict[str, BarBuilder] = {}
         self._features: dict[str, dict[str, float]] = {}
@@ -95,8 +94,6 @@ class FeatureEngine:
 
         self._lock = threading.Lock()
 
-        # StreamSignals listeners: list of (queue, symbol_filter)
-        # symbol_filter is None for "all symbols"
         self._listeners: list[
             tuple[queue.Queue[tuple[str, dict[str, float]]], set[str] | None]
         ] = []
@@ -129,10 +126,8 @@ class FeatureEngine:
             current = self._current_bar[symbol]
 
             if bar_ts == current.timestamp:
-                # Same bar — accumulate
                 current.update(price, vol)
             else:
-                # Bar completed — finalize and start new
                 completed = current.to_bar()
                 bars = self._bars.setdefault(symbol, [])
                 bars.append(completed)
@@ -141,7 +136,6 @@ class FeatureEngine:
 
                 self._current_bar[symbol] = BarBuilder(bar_ts, price, price, price, price, vol)
 
-                # Recompute features if we have enough bars
                 if len(bars) >= self._min_bars:
                     features = self._compute_features(bars)
                     self._features[symbol] = features
@@ -193,7 +187,6 @@ class FeatureEngine:
         with self._lock:
             self._listeners = [(lq, ls) for lq, ls in self._listeners if lq is not q]
 
-    # --- private ---
 
     def _notify_listeners(self, symbol: str, features: dict[str, float]) -> None:
         for q, sym_filter in self._listeners:
@@ -205,8 +198,6 @@ class FeatureEngine:
     def _extract_price_and_volume(tick: dict[str, object]) -> tuple[float, int] | None:
         event_type = str(tick.get("eventType", ""))
         if event_type == "TRADE":
-            # market-data-gateway serializes MarketTick with `price` / `size`
-            # (see MarketTick.java) — not `tradePrice` / `tradeVolume`.
             price = float(tick.get("price", 0))  # type: ignore[arg-type]
             vol = int(tick.get("size", 0))  # type: ignore[call-overload]
             if price > 0:
@@ -244,12 +235,10 @@ class FeatureEngine:
 
         last_close = closes[-1]
 
-        # Volume ratio
         vol_window = volumes[-20:] if len(volumes) >= 20 else volumes
         vol_sma = float(np.mean(vol_window))
         vol_ratio = float(volumes[-1]) / vol_sma if vol_sma > 0 else 1.0
 
-        # Realized volatility (std of 1-bar returns, 20 periods)
         if len(closes) >= 2:
             returns = np.diff(closes) / closes[:-1]
             ret_window = returns[-20:] if len(returns) >= 20 else returns
@@ -257,7 +246,6 @@ class FeatureEngine:
         else:
             realized_vol = 0.0
 
-        # Returns
         return_1 = float(closes[-1] / closes[-2] - 1) if len(closes) >= 2 else 0.0
         return_5 = float(closes[-1] / closes[-6] - 1) if len(closes) >= 6 else 0.0
 

--- a/ml-signal-service/src/ml_signal/features/indicators.py
+++ b/ml-signal-service/src/ml_signal/features/indicators.py
@@ -44,7 +44,6 @@ def rsi(closes: NDArray[np.float64], period: int = 14) -> NDArray[np.float64]:
     gains = np.where(deltas > 0, deltas, 0.0)
     losses = np.where(deltas < 0, -deltas, 0.0)
 
-    # First averages: SMA over the first `period` changes
     avg_gain = float(np.mean(gains[:period]))
     avg_loss = float(np.mean(losses[:period]))
 
@@ -54,7 +53,6 @@ def rsi(closes: NDArray[np.float64], period: int = 14) -> NDArray[np.float64]:
         rs = avg_gain / avg_loss
         result[period] = 100.0 - 100.0 / (1.0 + rs)
 
-    # Wilder's smoothing for subsequent values
     for i in range(period, len(deltas)):
         avg_gain = (avg_gain * (period - 1) + gains[i]) / period
         avg_loss = (avg_loss * (period - 1) + losses[i]) / period
@@ -102,7 +100,6 @@ def atr(
     if n < 2:
         return result
 
-    # True Range: max(H-L, |H-prevC|, |L-prevC|)
     prev_close = np.roll(closes, 1)
     prev_close[0] = closes[0]
     tr = np.maximum(
@@ -111,14 +108,11 @@ def atr(
     )
 
     if n < period + 1:
-        # Not enough data for full ATR — return simple average of available TR
         result[-1] = float(np.mean(tr[1:]))
         return result
 
-    # First ATR: SMA of the first `period` true ranges (skip index 0)
     result[period] = float(np.mean(tr[1 : period + 1]))
 
-    # Wilder's smoothing
     for i in range(period + 1, n):
         result[i] = (result[i - 1] * (period - 1) + tr[i]) / period
 

--- a/ml-signal-service/src/ml_signal/features/regime_features.py
+++ b/ml-signal-service/src/ml_signal/features/regime_features.py
@@ -34,9 +34,6 @@ REGIME_FEATURE_NAMES: list[str] = [
 ]
 
 
-# The classifier needs at least this many bars to compute a stable feature
-# vector. Windows shorter than this would produce too-noisy estimates of the
-# slow features (long-window vol, autocorrelation).
 MIN_BARS_FOR_REGIME: int = 60
 
 
@@ -68,23 +65,17 @@ def compute_regime_features_from_closes(
         return None
 
     log_closes = np.log(np.maximum(closes, 1e-12))
-    returns = np.diff(log_closes)  # log returns
+    returns = np.diff(log_closes)
 
     trend_strength, trend_r2 = _trend_strength_and_r2(log_closes)
     short_vol = float(np.std(returns[-20:])) if len(returns) >= 20 else float(np.std(returns))
     long_vol = float(np.std(returns))
     vol_ratio = short_vol / long_vol if long_vol > 1e-12 else 1.0
 
-    # Mean reversion: sign-flipped first-order autocorrelation of returns.
-    # AR(1) < 0 → returns tend to reverse → score > 0 (mean-reverting).
-    # AR(1) ≈ 0 → random walk → score ≈ 0.
     mean_reversion_score = -_lag1_autocorrelation(returns)
 
     return_dispersion = float(np.quantile(returns, 0.75) - np.quantile(returns, 0.25))
 
-    # Directional strength: mean absolute return scaled by realised vol.
-    # High values indicate sustained directional moves (trending); low values
-    # indicate choppy/quiet markets.
     abs_mean = float(np.mean(np.abs(returns)))
     directional_strength = abs_mean / long_vol if long_vol > 1e-12 else 0.0
 

--- a/ml-signal-service/src/ml_signal/model/regime_model.py
+++ b/ml-signal-service/src/ml_signal/model/regime_model.py
@@ -22,7 +22,6 @@ from ml_signal.metrics import INFERENCE_DURATION, REGIME_MODEL_INFO
 
 logger = structlog.get_logger()
 
-# Regime label constants — must match the MarketRegime enum in signal.proto.
 REGIME_UNKNOWN = 0
 REGIME_TRENDING_UP = 1
 REGIME_TRENDING_DOWN = 2
@@ -75,8 +74,6 @@ class RegimeModel:
                 return REGIME_UNKNOWN, 0.0
             feature_names = list(self._feature_names)
 
-        # Build the feature row outside the lock — the model object itself is
-        # not mutated during predict, only the swap during reload needs locking.
         import numpy as np
 
         feature_array = np.array(
@@ -111,8 +108,6 @@ class RegimeModel:
         try:
             data = joblib.load(path)
             model = data["model"]
-            # classes_ comes from sklearn — preserve the training-time label
-            # ordering so we can map predict_proba columns back to enum values.
             class_labels = [int(c) for c in getattr(model, "classes_", [])]
             with self._lock:
                 self._model = model

--- a/ml-signal-service/src/ml_signal/model/signal_model.py
+++ b/ml-signal-service/src/ml_signal/model/signal_model.py
@@ -15,7 +15,6 @@ from ml_signal.metrics import INFERENCE_DURATION, MODEL_INFO
 
 logger = structlog.get_logger()
 
-# Direction constants matching proto enum values
 DIRECTION_NEUTRAL = 0
 DIRECTION_LONG = 1
 DIRECTION_SHORT = 2
@@ -53,7 +52,6 @@ class SignalModel:
             if self._model is None:
                 return DIRECTION_NEUTRAL, 0.0, 0.0, features
 
-        # Build feature array in the correct order
         feature_array = np.array(
             [[features.get(name, 0.0) for name in self._feature_names]],
             dtype=np.float64,
@@ -64,7 +62,6 @@ class SignalModel:
                 return DIRECTION_NEUTRAL, 0.0, 0.0, features
             proba = self._model.predict_proba(feature_array)[0]
 
-        # proba[1] = P(positive return)
         prob_up = float(proba[1])
 
         if prob_up > 0.55:
@@ -77,7 +74,6 @@ class SignalModel:
             direction = DIRECTION_NEUTRAL
             confidence = 0.5
 
-        # Position size: scale with confidence, max 10% of capital
         position_size = min(0.10, max(0.0, (confidence - 0.5) * 0.2))
 
         return direction, confidence, position_size, features

--- a/ml-signal-service/tests/conftest.py
+++ b/ml-signal-service/tests/conftest.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-# Ensure proto stubs are importable
 _proto_path = Path(__file__).resolve().parent.parent.parent / "proto" / "generated" / "python"
 if _proto_path.exists() and str(_proto_path) not in sys.path:
     sys.path.insert(0, str(_proto_path))
@@ -23,7 +22,7 @@ def settings(tmp_path: Path) -> Settings:
         kafka_bootstrap_servers="localhost:9092",
         signal_model_path=str(tmp_path / "nonexistent.joblib"),
         bar_interval_seconds=60,
-        min_bars_for_features=5,  # low threshold for testing
+        min_bars_for_features=5,
         max_bars_retained=200,
     )
 

--- a/ml-signal-service/tests/test_api.py
+++ b/ml-signal-service/tests/test_api.py
@@ -79,7 +79,6 @@ class TestReady:
     def test_ready_with_model_and_features(
         self, client_with_models: TestClient, feature_engine: FeatureEngine
     ) -> None:
-        # Inject a feature vector
         with feature_engine._lock:
             feature_engine._features["AAPL"] = {name: 0.0 for name in FEATURE_NAMES}
         response = client_with_models.get("/ready")

--- a/ml-signal-service/tests/test_feature_engine.py
+++ b/ml-signal-service/tests/test_feature_engine.py
@@ -51,10 +51,9 @@ def _make_quote_tick(symbol: str, bid: float, ask: float, epoch_seconds: float) 
 
 def _feed_n_bars(engine: FeatureEngine, symbol: str, n: int, start_price: float = 100.0) -> None:
     """Feed enough ticks to complete n bars (at 60s intervals)."""
-    base_ts = 1700000000.0  # arbitrary epoch
+    base_ts = 1700000000.0
     for i in range(n + 1):
         price = start_price + i * 0.1
-        # Two ticks per bar: one at start, one 30s in
         ts = base_ts + i * 60
         engine.on_tick(_make_trade_tick(symbol, price, 1000, ts))
         engine.on_tick(_make_trade_tick(symbol, price + 0.05, 500, ts + 30))
@@ -63,12 +62,12 @@ def _feed_n_bars(engine: FeatureEngine, symbol: str, n: int, start_price: float 
 class TestFeatureEngineBasic:
     def test_no_features_before_min_bars(self, feature_engine: FeatureEngine) -> None:
         """Features should not be available until min_bars bars have been completed."""
-        _feed_n_bars(feature_engine, "AAPL", 3)  # min is 5
+        _feed_n_bars(feature_engine, "AAPL", 3)
         assert feature_engine.get_features("AAPL") is None
 
     def test_features_available_after_min_bars(self, feature_engine: FeatureEngine) -> None:
         """After enough bars, features should be available."""
-        _feed_n_bars(feature_engine, "AAPL", 6)  # min is 5
+        _feed_n_bars(feature_engine, "AAPL", 6)
         features = feature_engine.get_features("AAPL")
         assert features is not None
 
@@ -118,7 +117,7 @@ class TestFeatureEngineListeners:
         q: queue.Queue[tuple[str, dict[str, float]]] = queue.Queue()
         feature_engine.add_listener(q, symbols={"MSFT"})
         _feed_n_bars(feature_engine, "AAPL", 6)
-        assert q.empty()  # AAPL updates should not reach a MSFT-only listener
+        assert q.empty()
 
     def test_remove_listener(self, feature_engine: FeatureEngine) -> None:
         q: queue.Queue[tuple[str, dict[str, float]]] = queue.Queue()
@@ -135,7 +134,6 @@ class TestGetBars:
     def test_returns_completed_bars(self, feature_engine: FeatureEngine) -> None:
         _feed_n_bars(feature_engine, "AAPL", 6)
         bars = feature_engine.get_bars("AAPL")
-        # 7 ticks at bar boundaries → 6 completed bars (the last is still open).
         assert len(bars) == 6
         assert bars[0].close > 0
 
@@ -143,7 +141,6 @@ class TestGetBars:
         _feed_n_bars(feature_engine, "AAPL", 10)
         bars = feature_engine.get_bars("AAPL", n=3)
         assert len(bars) == 3
-        # Truncation must keep the *most recent* bars.
         full = feature_engine.get_bars("AAPL")
         assert bars == full[-3:]
 

--- a/ml-signal-service/tests/test_indicators.py
+++ b/ml-signal-service/tests/test_indicators.py
@@ -14,7 +14,7 @@ class TestEMA:
     def test_known_values(self) -> None:
         """EMA(3) with alpha = 0.5 and known hand-computed values."""
         values = np.array([10.0, 11.0, 12.0, 13.0, 14.0])
-        result = ema(values, period=3)  # alpha = 2/(3+1) = 0.5
+        result = ema(values, period=3)
         assert result[0] == pytest.approx(10.0)
         assert result[1] == pytest.approx(10.5)
         assert result[2] == pytest.approx(11.25)

--- a/ml-signal-service/tests/test_regime_features.py
+++ b/ml-signal-service/tests/test_regime_features.py
@@ -44,14 +44,13 @@ class TestTrendingUp:
 
     def test_uptrend_signature(self) -> None:
         rng = np.random.default_rng(0)
-        # Strong drift + tiny noise → clean trend
         log_returns = rng.normal(loc=0.002, scale=0.0005, size=MIN_BARS_FOR_REGIME - 1)
         closes = 100.0 * np.exp(np.concatenate([[0.0], np.cumsum(log_returns)]))
         features = compute_regime_features_from_closes(closes)
         assert features is not None
         assert features["trend_strength"] > 0.001
         assert features["trend_r_squared"] > 0.8
-        assert features["price_distance_from_mean"] > 0.0  # ended above mean
+        assert features["price_distance_from_mean"] > 0.0
 
 
 class TestTrendingDown:
@@ -63,7 +62,7 @@ class TestTrendingDown:
         assert features is not None
         assert features["trend_strength"] < -0.001
         assert features["trend_r_squared"] > 0.8
-        assert features["price_distance_from_mean"] < 0.0  # ended below mean
+        assert features["price_distance_from_mean"] < 0.0
 
 
 class TestMeanReverting:
@@ -81,9 +80,7 @@ class TestMeanReverting:
         closes = 100.0 * np.exp(np.concatenate([[0.0], np.cumsum(log_returns)]))
         features = compute_regime_features_from_closes(closes)
         assert features is not None
-        # The mean-reversion score is -AR(1); a negative AR(1) ⇒ positive score.
         assert features["mean_reversion_score"] > 0.2
-        # The trend is weak → low R²
         assert features["trend_r_squared"] < 0.5
 
 
@@ -111,7 +108,6 @@ class TestNumericalEdgeCases:
         assert features is not None
         for name, value in features.items():
             assert np.isfinite(value), f"{name} = {value}"
-        # Constant series: no trend, no vol, no reversion signal
         assert features["trend_strength"] == pytest.approx(0.0, abs=1e-9)
         assert features["realized_vol"] == pytest.approx(0.0, abs=1e-9)
         assert features["return_dispersion"] == pytest.approx(0.0, abs=1e-9)

--- a/ml-signal-service/tests/test_regime_integration.py
+++ b/ml-signal-service/tests/test_regime_integration.py
@@ -48,7 +48,7 @@ def engine_with_real_models(tmp_path: Path) -> tuple[FeatureEngine, RegimeModel,
         min_bars_for_features=5,
     )
     feature_engine = FeatureEngine(settings)
-    signal_model = SignalModel(settings.signal_model_path)  # ok if unloaded
+    signal_model = SignalModel(settings.signal_model_path)
     regime_model = RegimeModel(settings.regime_model_path)
     assert regime_model.is_loaded, "production regime model must load"
     return feature_engine, regime_model, signal_model
@@ -154,5 +154,4 @@ class TestRegimeClassificationAccuracy:
         _inject_path(engine, "SPY", closes)
         response = stub.GetRegime(signal_pb2.RegimeRequest(symbol="SPY"))
         assert 0.0 <= response.confidence <= 1.0
-        # A clearly trending path should yield reasonable confidence (>1/5 baseline).
         assert response.confidence > 0.3

--- a/ml-signal-service/tests/test_regime_model.py
+++ b/ml-signal-service/tests/test_regime_model.py
@@ -78,7 +78,6 @@ class TestRegimeModel:
         model = RegimeModel(str(trained_model_path))
         assert model.is_loaded
 
-        # Feature 0 ≈ 0 is the TRENDING_UP centroid in the fixture (cls_idx == 0).
         features = {name: 0.0 for name in REGIME_FEATURE_NAMES}
         features[REGIME_FEATURE_NAMES[0]] = 0.0
         regime, confidence = model.predict(features)

--- a/ml-signal-service/tests/test_servicer.py
+++ b/ml-signal-service/tests/test_servicer.py
@@ -118,7 +118,6 @@ class TestGetSignal:
     def test_with_features_returns_prediction(
         self, grpc_channel: grpc.Channel, feature_engine: FeatureEngine
     ) -> None:
-        # Inject features directly (bypass tick aggregation)
         rng = np.random.default_rng(42)
         features = {name: float(rng.standard_normal()) for name in FEATURE_NAMES}
         with feature_engine._lock:
@@ -140,7 +139,6 @@ class TestGetRegime:
         assert response.symbol == "AAPL"
         assert response.regime == signal_pb2.UNKNOWN
         assert response.confidence == 0.0
-        # Timestamp should be set even on the degenerate path.
         assert response.timestamp.seconds > 0
 
     def test_returns_classification_with_full_window(
@@ -155,7 +153,6 @@ class TestGetRegime:
         stub = signal_pb2_grpc.SignalServiceStub(grpc_channel)
         response = stub.GetRegime(signal_pb2.RegimeRequest(symbol="AAPL"))
         assert response.symbol == "AAPL"
-        # The fixture classifier maps every input to *some* regime — never UNKNOWN.
         assert response.regime in {
             signal_pb2.TRENDING_UP,
             signal_pb2.TRENDING_DOWN,

--- a/ml-signal-service/tests/test_signal_model.py
+++ b/ml-signal-service/tests/test_signal_model.py
@@ -23,7 +23,7 @@ def trained_model_path(tmp_path: Path) -> Path:
     """Train a tiny LightGBM model and save it."""
     rng = np.random.default_rng(42)
     X = rng.standard_normal((200, 15))
-    y = (X[:, 0] > 0).astype(int)  # simple rule: feature 0 > 0 → class 1
+    y = (X[:, 0] > 0).astype(int)
 
     clf = LGBMClassifier(n_estimators=10, num_leaves=4, verbose=-1)
     clf.fit(X, y)
@@ -49,9 +49,8 @@ class TestSignalModel:
         model = SignalModel(str(trained_model_path))
         assert model.is_loaded
 
-        # Feature 0 strongly positive → model should predict LONG (class 1)
         features = {name: 0.0 for name in FEATURE_NAMES}
-        features[FEATURE_NAMES[0]] = 5.0  # strong positive
+        features[FEATURE_NAMES[0]] = 5.0
         direction, confidence, pos_size, _ = model.predict(features)
         assert direction in (DIRECTION_LONG, DIRECTION_NEUTRAL, DIRECTION_SHORT)
         assert 0.0 <= confidence <= 1.0

--- a/ml-signal-service/tests/test_stream_signals.py
+++ b/ml-signal-service/tests/test_stream_signals.py
@@ -36,7 +36,6 @@ def model_and_engine(settings, tmp_path: Path) -> tuple[SignalModel, FeatureEngi
 @pytest.fixture
 def stream_setup(model_and_engine: tuple[SignalModel, FeatureEngine], tmp_path: Path):
     signal_model, feature_engine = model_and_engine
-    # StreamSignals doesn't touch the regime model, so an unloaded stub suffices.
     regime_model = RegimeModel(str(tmp_path / "regime-absent.joblib"))
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
     servicer = SignalServicer(feature_engine, signal_model, regime_model)
@@ -61,17 +60,15 @@ class TestStreamSignals:
             try:
                 for resp in stub.StreamSignals(request, timeout=5):
                     responses.append(resp)
-                    break  # one response is enough
+                    break
             except grpc.RpcError:
                 pass
 
         reader = threading.Thread(target=stream_reader, daemon=True)
         reader.start()
 
-        # Give the stream time to register
         time.sleep(0.3)
 
-        # Trigger a feature update by injecting directly
         features = {name: 0.0 for name in FEATURE_NAMES}
         with feature_engine._lock:
             feature_engine._features["AAPL"] = features
@@ -100,9 +97,8 @@ class TestStreamSignals:
 
         time.sleep(0.3)
 
-        # Push AAPL features (should NOT reach the MSFT-only stream)
         features = {name: 0.0 for name in FEATURE_NAMES}
         feature_engine._notify_listeners("AAPL", features)
 
         reader.join(timeout=4)
-        assert len(responses) == 0  # MSFT filter should exclude AAPL
+        assert len(responses) == 0

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/cache/RedisPositionCachePublisher.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/cache/RedisPositionCachePublisher.java
@@ -76,7 +76,6 @@ public class RedisPositionCachePublisher {
           e.getMessage());
       writeFailuresTotal.increment();
     } catch (DataAccessException e) {
-      // Never let Redis hiccups fail a fill — Kafka is the authoritative path.
       LOG.warn(
           "Redis cache write failed for {}: {}; continuing without cache update",
           snapshot.symbol(),

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/config/CurrencyConfig.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/config/CurrencyConfig.java
@@ -6,19 +6,6 @@ import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
-/**
- * Per-symbol currency reference data used by the currency-exposure aggregator (roadmap 3.5.3).
- *
- * <p>Each symbol that ever appears in a fill must resolve to one of the {@link #known()}
- * currencies; symbols not explicitly listed under {@link #overrides()} fall back to {@link
- * #defaultCurrency()}. Currency codes are normalised to uppercase ISO-4217 (e.g. {@code USD},
- * {@code EUR}, {@code JPY}). FX conversion is deliberately not part of this config — exposures are
- * reported in their native currency. A future ticket can add a rates map for portfolio-base
- * conversion.
- *
- * <p>The structure mirrors {@code execution-engine.risk.reference-data.*}: a tiny static config
- * works for the simulator's fixed universe; production deployments would back this with a feed.
- */
 @ConfigurationProperties(prefix = "order-manager.currency")
 public record CurrencyConfig(
     String defaultCurrency, Map<String, String> overrides, List<String> known) {
@@ -30,7 +17,6 @@ public record CurrencyConfig(
     known = normaliseList(known);
   }
 
-  /** Resolves the currency for {@code symbol}, defaulting when no override is configured. */
   public String currencyFor(String symbol) {
     if (symbol == null) {
       return defaultCurrency;

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/config/RedisConfig.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/config/RedisConfig.java
@@ -3,10 +3,6 @@ package com.mariaalpha.ordermanager.config;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Distributed position cache configuration. {@code enabled=false} disables publishing entirely so
- * unit tests and minimal local stacks can run without a Redis instance.
- */
 @ConfigurationProperties(prefix = "order-manager.redis")
 public record RedisConfig(
     boolean enabled,

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/consumer/MarketDataConsumer.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/consumer/MarketDataConsumer.java
@@ -51,9 +51,6 @@ public class MarketDataConsumer {
     }
   }
 
-  // Prefer the last traded price as the most direct mark. Fall back to the mid-price
-  // (bid + ask) / 2 when only quote data is available (e.g. pre-market or illiquid symbols).
-  // Returns null if neither is present, in which case the mark price cache is left unchanged.
   private BigDecimal pickPrice(MarketTickEvent tick) {
     if (tick.price() != null) {
       return tick.price();

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumer.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumer.java
@@ -9,11 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-/**
- * Thin Kafka shim: deserializes each record and delegates to {@link LifecycleEventHandler}, whose
- * {@code @Transactional} boundary actually applies because the call crosses a bean proxy (a
- * same-class {@code @Transactional} method would be self-invoked and run without a transaction).
- */
 @Component
 public class OrderLifecycleConsumer {
 

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/OrderController.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/OrderController.java
@@ -51,7 +51,6 @@ public class OrderController {
       throw new ResponseStatusException(
           BAD_REQUEST, "'from' timestamp must be before 'to' timestamp");
     }
-    // Clamp caller-supplied limit to [1, MAX_LIMIT] to guard against invalid or abusive page sizes.
     int clamped = Math.clamp(limit, 1, MAX_LIMIT);
     return orderRepository
         .search(symbol, status, strategy, from, to, PageRequest.of(0, clamped))
@@ -60,12 +59,6 @@ public class OrderController {
         .toList();
   }
 
-  /**
-   * Returns every fill recorded on a calendar date (UTC). Powers the post-trade EOD reconciliation
-   * engine. Each row is enriched with the parent order's {@code clientOrderId} and {@code
-   * exchangeOrderId} so the consumer can match against external venue activity without a follow-up
-   * call.
-   */
   @GetMapping("/fills/by-date")
   public List<FillForReconResponse> fillsByDate(
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/PortfolioController.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/PortfolioController.java
@@ -26,7 +26,6 @@ public class PortfolioController {
     return portfolioService.summary();
   }
 
-  /** Per-currency breakdown of gross / net exposure and realized / unrealized P&L. */
   @GetMapping("/currency-exposure")
   public CurrencyExposureResponse currencyExposure() {
     return currencyExposureService.exposureByCurrency();

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/dto/CurrencyExposureResponse.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/dto/CurrencyExposureResponse.java
@@ -5,21 +5,9 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
-/**
- * Aggregated portfolio exposure broken down per ISO-4217 currency code. Each {@link Row} represents
- * the sum of position exposures for symbols that resolve (via {@link
- * com.mariaalpha.ordermanager.config.CurrencyConfig}) to that currency at the time of the request.
- * Exposures are reported in their native currency — no FX conversion is performed.
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CurrencyExposureResponse(List<Row> rows, int openPositions, Instant asOf) {
 
-  /**
-   * Per-currency aggregation: {@code grossExposure} sums {@code |netQty × mark|} across symbols in
-   * this currency; {@code netExposure} sums the signed product (longs minus shorts). {@code
-   * realizedPnl} and {@code unrealizedPnl} are the corresponding column sums from the position
-   * table — useful for FX-aware P&L attribution downstream.
-   */
   public record Row(
       String currency,
       int positionCount,

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/dto/FillForReconResponse.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/controller/dto/FillForReconResponse.java
@@ -7,11 +7,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Recon-tailored fill projection — fill rows plus the parent order's client/exchange ids, which the
- * post-trade reconciliation engine needs to match against external venue activity. Mirrors {@link
- * com.mariaalpha.posttrade.model.FillForReconRecord} on the consumer side.
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record FillForReconResponse(
     UUID fillId,

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/repository/FillRepository.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/repository/FillRepository.java
@@ -18,11 +18,6 @@ public interface FillRepository extends JpaRepository<FillEntity, UUID> {
 
   List<FillEntity> findBySymbolOrderByFilledAtDesc(String symbol);
 
-  /**
-   * Fetches fills whose {@code filledAt} falls in {@code [from, to)}. Used by the post-trade EOD
-   * reconciliation engine — the JOIN FETCH pulls the parent order eagerly so the response can
-   * include {@code clientOrderId} and {@code exchangeOrderId} without a per-fill round trip.
-   */
   @Query(
       """
       SELECT f FROM FillEntity f

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/service/CurrencyExposureService.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/service/CurrencyExposureService.java
@@ -13,16 +13,6 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Aggregates open-position exposure by currency. Mirrors {@link PortfolioService}'s gross/net
- * exposure logic but groups by the currency resolved from {@link CurrencyConfig}, so a desk trading
- * mixed-currency books can see (for example) JPY exposure separately from USD without needing FX
- * rates to collapse them into a single base.
- *
- * <p>No FX conversion: exposures are reported in their native currency. Adding a rates map and a
- * portfolio-base option is a deliberate follow-up — keeps this ticket small and avoids baking in a
- * choice about which leg of an FX rate the system should consume.
- */
 @Service
 public class CurrencyExposureService {
 
@@ -46,7 +36,6 @@ public class CurrencyExposureService {
       var ccy = config.currencyFor(position.getSymbol());
       var agg = byCurrency.computeIfAbsent(ccy, Aggregator::new);
 
-      // P&L is always aggregated (even for flat positions, realized P&L stays on the books).
       agg.realizedPnl = agg.realizedPnl.add(position.getRealizedPnl());
       agg.unrealizedPnl = agg.unrealizedPnl.add(position.getUnrealizedPnl());
 

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/service/LifecycleEventHandler.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/service/LifecycleEventHandler.java
@@ -11,15 +11,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Applies one order-lifecycle event: upserts the order, persists the fill (idempotently), updates
- * the position, and fans the snapshot out to Kafka/Redis.
- *
- * <p>Lives in its own bean (rather than as a {@code @Transactional} method on the Kafka consumer)
- * because Spring transactions are proxy-based: a listener calling a {@code @Transactional} method
- * on {@code this} bypasses the proxy and silently runs without a surrounding transaction. Routing
- * the call through this bean makes order + fill + position updates atomic.
- */
 @Service
 public class LifecycleEventHandler {
 

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/service/OrderPersistenceService.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/service/OrderPersistenceService.java
@@ -78,7 +78,6 @@ public class OrderPersistenceService {
     }
   }
 
-  // Guard: every lifecycle event must carry a full order snapshot
   private OrderSnapshotEvent requireSnapshot(OrderLifecycleEvent event) {
     if (event.order() == null) {
       throw new IllegalArgumentException(
@@ -87,7 +86,6 @@ public class OrderPersistenceService {
     return event.order();
   }
 
-  // Populate the immutable identity fields that are set once at order creation
   private OrderEntity createOrderFromSnapshot(OrderSnapshotEvent snapshot) {
     var order = new OrderEntity();
     order.setOrderId(UUID.fromString(snapshot.orderId()));
@@ -106,14 +104,12 @@ public class OrderPersistenceService {
     return order;
   }
 
-  // Reject transitions that violate the order status state machine (e.g. FILLED -> NEW)
   private boolean isIllegalTransition(OrderEntity order, boolean isNew, OrderLifecycleEvent event) {
     return !isNew
         && order.getStatus() != null
         && !order.getStatus().canTransitionTo(event.status());
   }
 
-  // Update the fields that can legitimately change with each lifecycle event
   private void applyMutableFields(
       OrderEntity order, OrderSnapshotEvent snapshot, OrderLifecycleEvent event) {
     order.setStatus(event.status());
@@ -140,8 +136,6 @@ public class OrderPersistenceService {
     return Optional.of(saved);
   }
 
-  // Idempotency guard: if the exchange already reported this fill ID, skip it to avoid
-  // double-counting
   private boolean isDuplicateFill(FillEvent fillEvent, OrderEntity order) {
     if (fillEvent.exchangeFillId() != null
         && fillRepository.existsByExchangeFillId(fillEvent.exchangeFillId())) {
@@ -154,8 +148,6 @@ public class OrderPersistenceService {
     return false;
   }
 
-  // Map the fill event onto a new FillEntity; fall back to a generated ID / current time if the
-  // exchange omitted them
   private FillEntity buildFillEntity(OrderEntity order, FillEvent fillEvent) {
     var fill = new FillEntity();
     if (fillEvent.fillId() != null) {

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/service/PortfolioService.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/service/PortfolioService.java
@@ -95,9 +95,6 @@ public class PortfolioService {
     }
 
     var totalPnl = realizedPnl.add(unrealizedPnl);
-    // Equity = cash + market value of open positions. Cash already reflects every fill's
-    // entry/exit flow and netExposure is marked to market, so unrealized P&L is embedded in the
-    // sum — adding it again would double-count it.
     var totalValue = cash.add(netExposure);
 
     return new PortfolioSummaryResponse(

--- a/order-manager/src/main/java/com/mariaalpha/ordermanager/service/PositionService.java
+++ b/order-manager/src/main/java/com/mariaalpha/ordermanager/service/PositionService.java
@@ -26,27 +26,6 @@ public class PositionService {
     this.positionRepository = positionRepository;
   }
 
-  /**
-   * Applies a trade fill to the position for its symbol, handling all position accounting in a
-   * single transaction with a pessimistic row lock.
-   *
-   * <p>Three cases are covered:
-   *
-   * <ul>
-   *   <li><b>Flat position</b> — opens a new position at the fill price.
-   *   <li><b>Same-direction fill</b> — accumulates quantity and recalculates a weighted average
-   *       entry price.
-   *   <li><b>Opposite-direction fill</b> — realizes P&L on the closed portion; if the fill
-   *       overshoots and flips the position, the new average entry is set to the fill price.
-   * </ul>
-   *
-   * <p>Commission is deducted from realized P&L in all cases. Unrealized P&L is recomputed using
-   * the latest mark price from the cache, falling back to the fill price if no tick has been
-   * received yet.
-   *
-   * @param fill the executed fill to apply
-   * @return the updated and persisted {@link PositionEntity}
-   */
   @Transactional
   public PositionEntity applyFill(FillEntity fill) {
     var symbol = fill.getSymbol();
@@ -79,26 +58,20 @@ public class PositionService {
     return saved;
   }
 
-  // Lock the row for this symbol to prevent concurrent fill races; create a flat position on first
-  // fill
   private PositionEntity resolveOrCreatePosition(String symbol) {
     return positionRepository.findForUpdate(symbol).orElseGet(() -> new PositionEntity(symbol));
   }
 
-  // BUY fills are positive quantity, SELL fills are negative
   private BigDecimal toSignedQuantity(FillEntity fill) {
     return fill.getSide() == Side.BUY ? fill.getFillQuantity() : fill.getFillQuantity().negate();
   }
 
-  // Case 1: no existing holding — open a new position at the fill price
   private void openFreshPosition(
       PositionEntity position, BigDecimal signedFillQty, BigDecimal fillPrice) {
     position.setNetQuantity(signedFillQty);
     position.setAvgEntryPrice(fillPrice);
   }
 
-  // Case 2: same direction — accumulate quantity and recalculate weighted average entry price
-  // new_avg = (old_avg × old_qty + fill_price × fill_qty) / new_qty
   private void scaleIntoPosition(
       PositionEntity position, BigDecimal signedFillQty, BigDecimal fillPrice) {
     var absCurrentQty = position.getNetQuantity().abs();
@@ -114,15 +87,11 @@ public class PositionService {
     position.setAvgEntryPrice(newAvgPrice);
   }
 
-  // Case 3: opposite direction — realize P&L on the closed portion, then update quantity
-  // If the fill overshoots (flip), the new avg entry becomes the fill price
   private void closeOrFlipPosition(
       PositionEntity position, BigDecimal signedFillQty, BigDecimal fillPrice) {
     var currentQty = position.getNetQuantity();
     int currentSign = currentQty.signum();
-    // Close only up to the existing size; any excess flips the position
     var closingQty = signedFillQty.abs().min(currentQty.abs());
-    // P&L per unit: (fill_price - avg_entry) × sign; sign flips the formula correctly for shorts
     var realizedDelta =
         fillPrice
             .subtract(position.getAvgEntryPrice())
@@ -130,7 +99,6 @@ public class PositionService {
             .multiply(closingQty);
     var newQty = currentQty.add(signedFillQty);
     position.setNetQuantity(newQty);
-    // Flat: reset avg to zero; flipped: new avg is fill price; partial close: preserve existing avg
     BigDecimal newAvg =
         newQty.signum() == 0
             ? BigDecimal.ZERO
@@ -139,12 +107,10 @@ public class PositionService {
     position.setRealizedPnl(position.getRealizedPnl().add(realizedDelta));
   }
 
-  // Deduct commission, stamp mark price, and recompute unrealized P&L
   private void applyCommissionAndMark(
       PositionEntity position, String symbol, BigDecimal commission, BigDecimal fillPrice) {
     var realized = position.getRealizedPnl().subtract(commission);
     position.setRealizedPnl(realized.setScale(SCALE, RoundingMode.HALF_UP));
-    // Use latest tick from cache; fall back to fill price if no tick has arrived yet
     var mark = markPriceCache.getOrDefault(symbol, fillPrice);
     position.setLastMarkPrice(mark);
     position.setUnrealizedPnl(computeUnrealized(position, mark));
@@ -163,7 +129,6 @@ public class PositionService {
     }
   }
 
-  // Unrealized P&L: (mark_price - avg_entry_price) × net_quantity
   private BigDecimal computeUnrealized(PositionEntity position, BigDecimal mark) {
     if (position.isFlat() || mark == null) {
       return BigDecimal.ZERO;

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/cache/RedisPositionCacheIntegrationTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/cache/RedisPositionCacheIntegrationTest.java
@@ -20,10 +20,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-/**
- * Integration test that exercises the publisher against a real Redis, verifying the SET + TTL +
- * PUBLISH path end-to-end.
- */
 @Tag("integration")
 @Testcontainers
 class RedisPositionCacheIntegrationTest {

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumerIntegrationTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/consumer/OrderLifecycleConsumerIntegrationTest.java
@@ -68,8 +68,6 @@ class OrderLifecycleConsumerIntegrationTest {
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
     registry.add(
         "spring.liquibase.change-log", () -> "classpath:db/changelog/db.changelog-master.yaml");
-    // No Redis container here — the cache is exercised in
-    // RedisPositionCachePublisherIntegrationTest.
     registry.add("order-manager.redis.enabled", () -> "false");
     registry.add("management.health.redis.enabled", () -> "false");
     registry.add(

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/publisher/PositionUpdatePublisherTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/publisher/PositionUpdatePublisherTest.java
@@ -73,8 +73,6 @@ class PositionUpdatePublisherTest {
 
   @Test
   void publishSkipsWhenSerializationFails() {
-    // Serialization cannot actually fail for PositionSnapshot (all fields serializable);
-    // this test ensures no exception propagates even for a normal payload.
     PositionSnapshot snap =
         new PositionSnapshot(
             "GOOG",

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/repository/FillRepositoryIntegrationTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/repository/FillRepositoryIntegrationTest.java
@@ -113,7 +113,6 @@ class FillRepositoryIntegrationTest {
     List<FillEntity> result = fillRepository.findFillsBetween(from, to);
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getExchangeFillId()).isEqualTo("EX-F-INSIDE");
-    // JOIN FETCH means the parent order's clientOrderId is populated without a lazy lookup.
     assertThat(result.get(0).getOrder().getClientOrderId()).isEqualTo("c1");
   }
 

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/repository/IcebergParentRepositoryTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/repository/IcebergParentRepositoryTest.java
@@ -21,10 +21,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * Verifies PR-B persistence additions: the new {@code parent_order_id} column from migration 006
- * and the {@code ck_orders_display_quantity} CHECK constraint from migration 005.
- */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/repository/IocFokOrderTypePersistenceTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/repository/IocFokOrderTypePersistenceTest.java
@@ -19,11 +19,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * Verifies that the IOC and FOK order types round-trip correctly through the JPA layer. The {@code
- * order_type} column is a {@code varchar(16)} mapped via {@code @Enumerated(EnumType.STRING)} so
- * each new enum value must be writable and readable without altering the column definition.
- */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/service/CurrencyExposureServiceIntegrationTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/service/CurrencyExposureServiceIntegrationTest.java
@@ -20,11 +20,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * Drives {@link CurrencyExposureService} against a real Postgres so the aggregation by currency
- * survives a real JPA round-trip (transactional view of the position table). Mirrors the pattern
- * the repository integration tests use.
- */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
@@ -70,9 +65,9 @@ class CurrencyExposureServiceIntegrationTest {
     var resp = service.exposureByCurrency();
 
     assertThat(resp.rows()).extracting(r -> r.currency()).containsExactly("EUR", "JPY", "USD");
-    assertThat(resp.rows().get(0).grossExposure()).isEqualByComparingTo("6000"); // EUR
-    assertThat(resp.rows().get(1).grossExposure()).isEqualByComparingTo("500000"); // JPY
-    assertThat(resp.rows().get(2).grossExposure()).isEqualByComparingTo("15000"); // USD
+    assertThat(resp.rows().get(0).grossExposure()).isEqualByComparingTo("6000");
+    assertThat(resp.rows().get(1).grossExposure()).isEqualByComparingTo("500000");
+    assertThat(resp.rows().get(2).grossExposure()).isEqualByComparingTo("15000");
     assertThat(resp.openPositions()).isEqualTo(3);
   }
 

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/service/CurrencyExposureServiceTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/service/CurrencyExposureServiceTest.java
@@ -73,11 +73,10 @@ class CurrencyExposureServiceTest {
     when(positionRepository.findAll()).thenReturn(List.of(aapl, sap, toyota));
 
     var resp = service.exposureByCurrency();
-    // Rows are sorted alphabetically (EUR, JPY, USD) for stable UI ordering.
     assertThat(resp.rows()).extracting(r -> r.currency()).containsExactly("EUR", "JPY", "USD");
-    assertThat(resp.rows().get(0).grossExposure()).isEqualByComparingTo("6000"); // EUR
-    assertThat(resp.rows().get(1).grossExposure()).isEqualByComparingTo("500000"); // JPY
-    assertThat(resp.rows().get(2).grossExposure()).isEqualByComparingTo("15000"); // USD
+    assertThat(resp.rows().get(0).grossExposure()).isEqualByComparingTo("6000");
+    assertThat(resp.rows().get(1).grossExposure()).isEqualByComparingTo("500000");
+    assertThat(resp.rows().get(2).grossExposure()).isEqualByComparingTo("15000");
     assertThat(resp.openPositions()).isEqualTo(3);
   }
 

--- a/order-manager/src/test/java/com/mariaalpha/ordermanager/service/PortfolioServiceTest.java
+++ b/order-manager/src/test/java/com/mariaalpha/ordermanager/service/PortfolioServiceTest.java
@@ -135,9 +135,6 @@ class PortfolioServiceTest {
 
   @Test
   void totalValueDoesNotDoubleCountUnrealizedPnl() {
-    // Buy 100 AAPL @ 150: cash 1,000,000 → 985,000. Mark rises to 160 → unrealized +1,000 and
-    // market value 16,000. Equity must be 985,000 + 16,000 = 1,001,000 (initial + unrealized),
-    // NOT 1,002,000 (which would count the unrealized gain twice).
     var order = new OrderEntity();
     order.setOrderId(UUID.randomUUID());
     var buy = newFill(order, "AAPL", Side.BUY, BigDecimal.valueOf(150), BigDecimal.valueOf(100));

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationCalculator.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationCalculator.java
@@ -8,27 +8,6 @@ import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/**
- * Pure allocation math (roadmap 3.4.2). No I/O, no persistence — given a parent {@code
- * filledQuantity}, {@code avgPrice}, and a list of weighted sub-accounts plus a method, returns the
- * per-sub-account split.
- *
- * <p>The two algorithms differ only in how they distribute shares:
- *
- * <ul>
- *   <li>{@link AllocationMethod#PRO_RATA} — each sub-account gets {@code weight / Σ weights ×
- *       parent_quantity}, rounded down to a whole share. Any rounding remainder is awarded to the
- *       highest-weighted account first (ties broken by declaration order), so {@code Σ allocations
- *       == parent_quantity} exactly. Sub-accounts with weight = 0 are skipped.
- *   <li>{@link AllocationMethod#FIFO} — sub-accounts are filled in declaration order. Each gets
- *       {@code min(weight, remaining)} where {@code weight} is interpreted as a share cap and
- *       {@code remaining} is the parent quantity not yet allocated. Useful for waterfall structures
- *       (first sub-account fills first, leftovers spill to the next).
- * </ul>
- *
- * <p>Behaviour with a zero parent quantity: returns an empty list (nothing to allocate). With an
- * empty sub-account list: returns an empty list (allocation is unconfigured).
- */
 @Component
 public class AllocationCalculator {
 
@@ -64,7 +43,6 @@ public class AllocationCalculator {
       if (acct.weight() <= 0) {
         continue;
       }
-      // Floor-divide to whole shares so the running total never overshoots the parent.
       BigDecimal share =
           filledQuantity
               .multiply(BigDecimal.valueOf(acct.weight()))
@@ -72,8 +50,6 @@ public class AllocationCalculator {
       results.add(new AllocationResult(acct.name(), share, avgPrice, AllocationMethod.PRO_RATA));
       allocatedSoFar = allocatedSoFar.add(share);
     }
-    // Award the rounding remainder to the largest-weighted account that received an allocation —
-    // ties broken by original declaration order, since stream-sorted is stable.
     var remainder = filledQuantity.subtract(allocatedSoFar);
     if (remainder.signum() > 0 && !results.isEmpty()) {
       var topIndex = findHeaviestAccountIndex(subAccounts, results);
@@ -126,9 +102,6 @@ public class AllocationCalculator {
       remaining = remaining.subtract(share);
     }
     if (remaining.signum() > 0 && !results.isEmpty()) {
-      // Parent quantity exceeded the sum of waterfall caps — the last filled sub-account absorbs
-      // the overflow so the parent fully allocates. This keeps the FIFO contract aligned with
-      // pro-rata: Σ allocations == parent_quantity.
       var lastIdx = results.size() - 1;
       var last = results.get(lastIdx);
       results.set(
@@ -142,12 +115,10 @@ public class AllocationCalculator {
     return List.copyOf(results);
   }
 
-  /** Total weight across non-zero-weight sub-accounts. Test helper. */
   static double totalWeight(List<SubAccount> subAccounts) {
     return subAccounts.stream().filter(s -> s.weight() > 0).mapToDouble(SubAccount::weight).sum();
   }
 
-  /** Comparator that sorts sub-accounts heaviest-first (test helper). */
   static Comparator<SubAccount> byWeightDescending() {
     return Comparator.comparingDouble(SubAccount::weight).reversed();
   }

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationMethod.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationMethod.java
@@ -1,18 +1,5 @@
 package com.mariaalpha.posttrade.allocation;
 
-/**
- * Algorithm used to split a parent fill across sub-accounts.
- *
- * <ul>
- *   <li>{@link #PRO_RATA} — quantity allocated to each sub-account is proportional to its
- *       configured weight (weight ÷ Σ weights × parent_quantity). Rounded down to a whole number of
- *       shares; the unallocated remainder is awarded to the highest-weighted sub-account so the sum
- *       of allocations equals the parent fill exactly. This is the industry-standard default.
- *   <li>{@link #FIFO} — sub-accounts are filled in declaration order until the parent quantity is
- *       exhausted. Each sub-account is awarded at most its weight (interpreted as a share cap) of
- *       the parent. Useful for waterfall arrangements where the first sub-account has priority.
- * </ul>
- */
 public enum AllocationMethod {
   PRO_RATA,
   FIFO

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationMetrics.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationMetrics.java
@@ -5,7 +5,6 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
-/** Per-component instrumentation for the trade-allocation engine (roadmap 3.4.2). */
 @Component
 public class AllocationMetrics {
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationRequest.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationRequest.java
@@ -4,13 +4,6 @@ import com.mariaalpha.posttrade.model.Side;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-/**
- * Service-layer input for an allocation run (roadmap 3.4.2).
- *
- * <p>The controller bridges from a REST DTO into this record; the service+calculator pair never
- * sees the HTTP types. {@code method} is nullable — when null, the {@link SubAccountRegistry}'s
- * configured default is used.
- */
 public record AllocationRequest(
     UUID orderId,
     String symbol,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationResult.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationResult.java
@@ -2,15 +2,6 @@ package com.mariaalpha.posttrade.allocation;
 
 import java.math.BigDecimal;
 
-/**
- * Per-sub-account result of a single allocation run.
- *
- * <p>{@code allocatedQuantity} is a whole-share integer (modelled as {@code BigDecimal} to match
- * the schema and to support future fractional-share workflows). {@code allocatedAvgPrice} is always
- * the parent's executed average price — pro-rata and FIFO both inherit the parent's realised price;
- * only batch/bunched-order workflows would differentiate per-account pricing, which is out of scope
- * for the MVP.
- */
 public record AllocationResult(
     String subAccount,
     BigDecimal allocatedQuantity,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationService.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/AllocationService.java
@@ -8,14 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-/**
- * Orchestrates the allocation flow: pick the method (request override → registry default), run the
- * pure {@link AllocationCalculator}, persist the {@link AllocationEntity} rows, emit metrics.
- *
- * <p>Re-running allocation for the same {@code orderId} is idempotent: the prior rows are deleted
- * before the new ones are written, so re-allocating with a different method or after a re-fill is
- * safe. Tests assert this round-trip.
- */
 @Service
 public class AllocationService {
 
@@ -37,13 +29,6 @@ public class AllocationService {
     this.metrics = metrics;
   }
 
-  /**
-   * Allocate a parent order's fills across sub-accounts and persist the result. Returns the
-   * persisted rows in sub-account name order.
-   *
-   * @throws IllegalStateException if the sub-account registry is empty (no accounts configured)
-   * @throws IllegalArgumentException if {@code request} carries invalid quantity / price
-   */
   @Transactional
   public List<AllocationEntity> allocate(AllocationRequest request) {
     if (!registry.isConfigured()) {
@@ -71,11 +56,6 @@ public class AllocationService {
       return List.of();
     }
 
-    // Idempotent re-allocation: clear any prior rows for this parent before persisting.
-    // Force-flush the delete before the saveAll. Without this, Hibernate may batch the insert
-    // ahead of the delete in the action queue and trip the UNIQUE(order_id, sub_account) constraint
-    // when re-allocating the same parent — even though both ops are in the same @Transactional
-    // block. Manifested as a 500 on the e2e idempotency test.
     repository.deleteByOrderId(request.orderId());
     repository.flush();
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/SubAccountConfig.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/SubAccountConfig.java
@@ -3,18 +3,6 @@ package com.mariaalpha.posttrade.allocation;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Sub-account roster used by the allocation engine (roadmap 3.4.2).
- *
- * <p>For the MVP, sub-accounts are statically configured under {@code post-trade.allocation}.
- * Production deployments would back this with a desk-management service or vendor data; the
- * abstraction is intentionally shallow so adding a richer source later means swapping the {@link
- * SubAccountRegistry} bean.
- *
- * <p>The {@code defaultMethod} applies when an allocation request doesn't specify one. Per-account
- * {@code weight} is unitless: pro-rata divides by the sum of weights, FIFO interprets weight as a
- * share cap.
- */
 @ConfigurationProperties(prefix = "post-trade.allocation")
 public record SubAccountConfig(AllocationMethod defaultMethod, List<SubAccount> subAccounts) {
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/SubAccountRegistry.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/allocation/SubAccountRegistry.java
@@ -7,13 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Read-only access to the configured sub-account roster.
- *
- * <p>Validates the configuration at startup (positive weights, unique names) and exposes the
- * registered list in declaration order — important for {@link AllocationMethod#FIFO} which needs
- * stable ordering.
- */
 @Component
 public class SubAccountRegistry {
 
@@ -55,17 +48,14 @@ public class SubAccountRegistry {
         orderedAccounts.stream().map(SubAccount::name).toList());
   }
 
-  /** Configured sub-accounts in declaration order. Empty list when allocation is unconfigured. */
   public List<SubAccount> accounts() {
     return orderedAccounts;
   }
 
-  /** Allocation method to use when the request leaves it unspecified. */
   public AllocationMethod defaultMethod() {
     return defaultMethod;
   }
 
-  /** True iff the registry has at least one configured account. */
   public boolean isConfigured() {
     return !orderedAccounts.isEmpty();
   }

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/controller/AllocationController.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/controller/AllocationController.java
@@ -19,16 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-/**
- * REST surface for the trade-allocation engine (roadmap 3.4.2).
- *
- * <ul>
- *   <li>{@code GET /api/allocations/sub-accounts} — list the configured roster.
- *   <li>{@code POST /api/allocations/run} — allocate a parent order across sub-accounts.
- *   <li>{@code GET /api/allocations/order/{orderId}} — fetch allocations for a parent.
- *   <li>{@code GET /api/allocations/sub-account/{name}} — fetch allocations for a sub-account.
- * </ul>
- */
 @RestController
 @RequestMapping("/api/allocations")
 public class AllocationController {

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/controller/ReconController.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/controller/ReconController.java
@@ -20,12 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Read + write reconciliation API consumed by the UI Reconciliation page and any automation that
- * needs to trigger an ad-hoc run. The {@code POST /api/recon/run} endpoint runs synchronously —
- * fast enough for the simulated stack, and useful in production for re-running after a known-bad
- * earlier attempt.
- */
 @RestController
 @RequestMapping("/api/recon")
 public class ReconController {
@@ -43,7 +37,6 @@ public class ReconController {
     this.service = service;
   }
 
-  /** List reconciliation breaks for a date (defaults to today). */
   @GetMapping("/breaks")
   public List<ReconBreakResponse> breaks(
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
@@ -54,7 +47,6 @@ public class ReconController {
         .toList();
   }
 
-  /** Per-date summary plus the matching run record (if any) so the UI can render run status. */
   @GetMapping("/summary")
   public ReconSummaryResponse summary(
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
@@ -71,7 +63,6 @@ public class ReconController {
     return new ReconSummaryResponse(target, rows.size(), bySeverity, byBreakType, run);
   }
 
-  /** Most recent reconciliation runs (regardless of whether they produced breaks). */
   @GetMapping("/runs")
   public List<ReconRunResponse> runs(@RequestParam(defaultValue = "30") int limit) {
     int clamped = Math.min(Math.max(limit, 1), 365);
@@ -80,7 +71,6 @@ public class ReconController {
         .toList();
   }
 
-  /** All breaks recorded against a given order id, across dates. */
   @GetMapping("/breaks/order/{orderId}")
   public List<ReconBreakResponse> breaksForOrder(@PathVariable UUID orderId) {
     return breakRepository.findByOrderIdOrderByReconDateDesc(orderId).stream()
@@ -88,7 +78,6 @@ public class ReconController {
         .toList();
   }
 
-  /** Trigger an EOD reconciliation run for the given date (defaults to today). Synchronous. */
   @PostMapping("/run")
   public ReconRunResponse run(
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/AllocationRequestDto.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/AllocationRequestDto.java
@@ -5,10 +5,6 @@ import com.mariaalpha.posttrade.model.Side;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-/**
- * Request body for {@code POST /api/allocations/run} (roadmap 3.4.2). {@code method} is nullable —
- * server falls back to the configured default when omitted.
- */
 public record AllocationRequestDto(
     UUID orderId,
     String symbol,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/AllocationResponse.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/AllocationResponse.java
@@ -7,7 +7,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/** Per-row allocation record returned by the {@code /api/allocations} REST surface. */
 public record AllocationResponse(
     UUID allocationId,
     UUID orderId,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/ReconSummaryResponse.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/ReconSummaryResponse.java
@@ -4,12 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.util.Map;
 
-/**
- * Per-date reconciliation summary consumed by the UI Reconciliation page. The {@code run} field
- * surfaces the matching {@link com.mariaalpha.posttrade.entity.ReconciliationRunEntity} row so the
- * UI can render "ran clean" (run=SUCCESS, totalBreaks=0) vs. "never ran" (run=null) vs. "ran with
- * breaks".
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReconSummaryResponse(
     LocalDate reconDate,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/SubAccountResponse.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/controller/dto/SubAccountResponse.java
@@ -5,7 +5,6 @@ import com.mariaalpha.posttrade.allocation.SubAccountConfig.SubAccount;
 import com.mariaalpha.posttrade.allocation.SubAccountRegistry;
 import java.util.List;
 
-/** Roster of configured sub-accounts plus the registry-level default method. */
 public record SubAccountResponse(AllocationMethod defaultMethod, List<SubAccountRow> subAccounts) {
 
   public record SubAccountRow(String name, double weight) {}

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/entity/ReconciliationBreakEntity.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/entity/ReconciliationBreakEntity.java
@@ -11,17 +11,6 @@ import java.time.LocalDate;
 import java.util.Objects;
 import java.util.UUID;
 
-/**
- * Row from the {@code reconciliation_breaks} table populated by the EOD reconciliation engine. One
- * row per discrepancy detected between internal fills and the external venue's day-of-trade
- * activity report. Exposed for the UI Reconciliation page via {@link
- * com.mariaalpha.posttrade.controller.ReconController}.
- *
- * <p>{@code internalQty}/{@code externalQty}/{@code internalPrice}/{@code externalPrice} are
- * populated for {@code QUANTITY_MISMATCH} / {@code PRICE_MISMATCH} types. For {@code MISSING_FILL}
- * the external side is populated and the internal side is null; for {@code EXTRA_FILL} it's the
- * other way round.
- */
 @Entity
 @Table(name = "reconciliation_breaks")
 public class ReconciliationBreakEntity {

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/entity/ReconciliationRunEntity.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/entity/ReconciliationRunEntity.java
@@ -10,11 +10,6 @@ import java.time.LocalDate;
 import java.util.Objects;
 import java.util.UUID;
 
-/**
- * One row per EOD reconciliation run. A run record exists regardless of whether breaks were found,
- * so the UI can tell "ran clean" from "never ran". Keyed by {@code reconDate} — re-running for the
- * same date upserts (see §7.3 idempotency).
- */
 @Entity
 @Table(name = "reconciliation_runs")
 public class ReconciliationRunEntity {

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/model/FillForReconRecord.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/model/FillForReconRecord.java
@@ -5,11 +5,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Recon-tailored fill record returned by order-manager's {@code /api/orders/fills/by-date} endpoint
- * — fill fields plus the parent order's exchange/client ids needed to match against external venue
- * activity.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FillForReconRecord(
     UUID fillId,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/AlpacaActivitiesClient.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/AlpacaActivitiesClient.java
@@ -3,7 +3,6 @@ package com.mariaalpha.posttrade.recon;
 import java.time.LocalDate;
 import java.util.List;
 
-/** Sources the day's external fill activities. Two impls — HTTP (real Alpaca) and mirror (sim). */
 public interface AlpacaActivitiesClient {
 
   List<ExternalFill> activitiesForDate(LocalDate date, List<InternalFill> internalFills);

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/AlpacaActivitiesException.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/AlpacaActivitiesException.java
@@ -1,6 +1,5 @@
 package com.mariaalpha.posttrade.recon;
 
-/** Wraps any failure talking to Alpaca's activities API. */
 public class AlpacaActivitiesException extends RuntimeException {
 
   public AlpacaActivitiesException(String message) {

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/EodReconciliationService.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/EodReconciliationService.java
@@ -19,20 +19,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Top-level orchestrator for end-of-day reconciliation. Implements the sequence diagram in §2.6.3:
- *
- * <pre>
- *   fetch internal fills(date)
- *   fetch external activities(date) via {@link AlpacaActivitiesClient}
- *   delete prior breaks for date (idempotency §7.3)
- *   compare → persist breaks, publish RECON_BREAK alerts, upsert run record
- * </pre>
- *
- * <p>The run record exists regardless of outcome — it's what tells the UI "ran clean" from "never
- * ran". On exceptions the run is persisted with status=FAILED + error message; this is so that the
- * scheduler doesn't silently re-attempt the same broken run forever.
- */
 @Service
 public class EodReconciliationService {
 
@@ -76,7 +62,6 @@ public class EodReconciliationService {
 
       List<ReconciliationBreak> breaks = comparator.compare(date, internal, external);
 
-      // §7.3 idempotency: clear any prior breaks for this date before writing the new ones.
       breakRepository.deleteByReconDate(date);
 
       List<ReconciliationBreakEntity> entities = new ArrayList<>(breaks.size());
@@ -86,7 +71,6 @@ public class EodReconciliationService {
         metrics.recordBreak(b.breakType().name(), b.severity().name());
       }
       breakRepository.saveAll(entities);
-      // Publish alerts after persistence so a Kafka outage can't cause a divergence between the
       // table and the alert stream (Kafka failures log but do not roll back the recon run).
       for (ReconciliationBreak b : breaks) {
         alertPublisher.publishBreak(b);

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ExternalFill.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ExternalFill.java
@@ -4,11 +4,6 @@ import com.mariaalpha.posttrade.model.Side;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-/**
- * Venue-confirmed fill record used by the reconciliation comparator. Built from Alpaca's {@code
- * /v2/account/activities/FILL} response in {@link Mode#EXTERNAL}, or mirrored from internal fills
- * in {@link Mode#MIRROR}.
- */
 public record ExternalFill(
     String externalFillId,
     String exchangeOrderId,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/HttpAlpacaActivitiesClient.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/HttpAlpacaActivitiesClient.java
@@ -16,14 +16,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Pulls fill activities from Alpaca for a given calendar date. Wraps {@code GET
- * /v2/account/activities?activity_types=FILL&date=...}.
- *
- * <p>This class makes a network call and is constructed by {@link ReconBeansConfig} only when
- * {@code post-trade.recon.mode=EXTERNAL}. Failures surface as {@link AlpacaActivitiesException} so
- * the orchestrator can mark the run FAILED rather than silently emitting bogus MISSING_FILL breaks.
- */
 public class HttpAlpacaActivitiesClient implements AlpacaActivitiesClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpAlpacaActivitiesClient.class);

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/InternalFill.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/InternalFill.java
@@ -5,10 +5,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Internal fill snapshot used by the reconciliation comparator. Built from order-manager's {@code
- * /api/orders/fills/by-date} endpoint, one row per fill (a single order may have many).
- */
 public record InternalFill(
     UUID fillId,
     UUID orderId,

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/MirroredAlpacaActivitiesClient.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/MirroredAlpacaActivitiesClient.java
@@ -4,12 +4,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Simulated mode: every internal fill is echoed back as an external fill, so the comparator always
- * produces zero breaks. This is what keeps the local docker-compose stack runnable without Alpaca
- * credentials — a recon run exercises the full code path (schedule, persistence, alert publish) but
- * does not invent spurious EXTRA_FILL breaks.
- */
 public class MirroredAlpacaActivitiesClient implements AlpacaActivitiesClient {
 
   @Override

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconBeansConfig.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconBeansConfig.java
@@ -4,10 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Spring wiring for the reconciliation engine. The {@link AlpacaActivitiesClient} bean is selected
- * at startup based on {@code post-trade.recon.mode}; the rest of the engine is mode-agnostic.
- */
 @Configuration
 public class ReconBeansConfig {
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconConfig.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconConfig.java
@@ -3,15 +3,6 @@ package com.mariaalpha.posttrade.recon;
 import java.math.BigDecimal;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Configuration for the EOD reconciliation engine.
- *
- * <p>{@link Mode#EXTERNAL} pulls the day's activity report from Alpaca and compares against
- * internal fills. {@link Mode#MIRROR} is the simulated-stack mode — every internal fill is treated
- * as if it had been confirmed by the external venue, so the comparator path runs end-to-end and
- * always produces zero breaks. Switching modes never changes the engine's logic, only the source
- * the external fills are drawn from.
- */
 @ConfigurationProperties(prefix = "post-trade.recon")
 public record ReconConfig(
     boolean enabled,
@@ -26,9 +17,7 @@ public record ReconConfig(
     Alpaca alpaca) {
 
   public enum Mode {
-    /** Pull fills from the configured exchange (Alpaca) and compare against internal records. */
     EXTERNAL,
-    /** Mirror internal fills as external — for simulated / dev stacks. */
     MIRROR
   }
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconMetrics.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconMetrics.java
@@ -5,11 +5,6 @@ import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import org.springframework.stereotype.Component;
 
-/**
- * Reconciliation engine metrics. {@code mariaalpha_recon_breaks_total} is the headline counter
- * called out in §8.2 of the TDD; the duration timer and run counters back the dashboards added in
- * 2.6.4.
- */
 @Component
 public class ReconMetrics {
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconciliationBreak.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconciliationBreak.java
@@ -4,11 +4,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
-/**
- * Comparator output — one record per detected discrepancy. The orchestrator persists these as
- * {@link com.mariaalpha.posttrade.entity.ReconciliationBreakEntity} rows and publishes one {@code
- * RECON_BREAK} alert per row to {@code analytics.risk-alerts}.
- */
 public record ReconciliationBreak(
     LocalDate reconDate,
     UUID orderId,
@@ -23,13 +18,9 @@ public record ReconciliationBreak(
     BigDecimal notional) {
 
   public enum BreakType {
-    /** External venue reported a fill that has no internal counterpart. */
     MISSING_FILL,
-    /** Internal records contain a fill that the external venue did not report. */
     EXTRA_FILL,
-    /** Both sides report a fill for the same order but quantities differ beyond tolerance. */
     QUANTITY_MISMATCH,
-    /** Both sides report a fill for the same order but average prices differ beyond tolerance. */
     PRICE_MISMATCH
   }
 

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconciliationComparator.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconciliationComparator.java
@@ -13,12 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-/**
- * Pure comparator that turns two lists of fills (internal vs. external) into a list of breaks. No
- * I/O, no Spring — drives unit-test coverage of every break-type / severity combination from
- * fixtures. Matching is per-order: fills are aggregated by {@code exchangeOrderId} (falling back to
- * {@code clientOrderId}) and the resulting (qty, vwap) pair is compared between sides.
- */
 public final class ReconciliationComparator {
 
   private static final MathContext MC = new MathContext(20, RoundingMode.HALF_UP);
@@ -46,7 +40,6 @@ public final class ReconciliationComparator {
 
     List<ReconciliationBreak> breaks = new ArrayList<>();
 
-    // Anything internal but missing externally = EXTRA_FILL
     for (var entry : internalByKey.entrySet()) {
       if (!externalByKey.containsKey(entry.getKey())) {
         Aggregate a = entry.getValue();
@@ -73,7 +66,6 @@ public final class ReconciliationComparator {
       }
     }
 
-    // Anything external but missing internally = MISSING_FILL
     for (var entry : externalByKey.entrySet()) {
       if (!internalByKey.containsKey(entry.getKey())) {
         Aggregate a = entry.getValue();
@@ -100,7 +92,6 @@ public final class ReconciliationComparator {
       }
     }
 
-    // Both sides present — compare quantity and price.
     for (var entry : internalByKey.entrySet()) {
       Aggregate ext = externalByKey.get(entry.getKey());
       if (ext == null) {
@@ -166,7 +157,7 @@ public final class ReconciliationComparator {
     for (InternalFill f : fills) {
       String key = matchKey(f.exchangeOrderId(), f.clientOrderId());
       if (key == null) {
-        continue; // can't aggregate without a key — drop defensively
+        continue;
       }
       Aggregate agg =
           map.computeIfAbsent(
@@ -246,7 +237,6 @@ public final class ReconciliationComparator {
     if (diffBps == null) {
       return Severity.LOW;
     }
-    // 10x tolerance = HIGH; 100x = CRITICAL. Otherwise MEDIUM.
     BigDecimal high = priceToleranceBps.multiply(BigDecimal.TEN);
     BigDecimal critical = priceToleranceBps.multiply(BigDecimal.valueOf(100));
     if (diffBps.compareTo(critical) >= 0) {
@@ -285,7 +275,7 @@ public final class ReconciliationComparator {
     final String symbol;
     final Side side;
     BigDecimal qty;
-    BigDecimal notional; // sum(price * qty)
+    BigDecimal notional;
     BigDecimal vwap;
 
     Aggregate(UUID orderId, String symbol, Side side, BigDecimal qty, BigDecimal notional) {

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconciliationScheduler.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/ReconciliationScheduler.java
@@ -11,12 +11,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * Fires {@link EodReconciliationService#runForDate} on the cron defined in {@code
- * post-trade.recon.cron}. Disabled by default unless {@code post-trade.recon.enabled=true}; the
- * docker-compose stack runs with it on (in MIRROR mode), production deployments turn it on with
- * EXTERNAL mode + a 22:00 ET cron.
- */
 @Component
 @ConditionalOnProperty(prefix = "post-trade.recon", name = "enabled", havingValue = "true")
 public class ReconciliationScheduler {

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/recon/RiskAlertPublisher.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/recon/RiskAlertPublisher.java
@@ -11,11 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-/**
- * Publishes one {@code RECON_BREAK} alert per break to {@code analytics.risk-alerts}, the same
- * topic the api-gateway forwards over {@code /ws/alerts}. The schema mirrors what the analytics
- * service emits for toxicity/drawdown alerts so the UI {@code AlertsBanner} can render either.
- */
 @Component
 public class RiskAlertPublisher {
 
@@ -34,7 +29,6 @@ public class RiskAlertPublisher {
     this.topic = kafkaConfig.riskAlertsTopic();
   }
 
-  // Visible for tests — bypasses KafkaConfig so unit tests can supply a topic literal.
   static RiskAlertPublisher forTest(
       KafkaTemplate<String, String> kafkaTemplate, ObjectMapper objectMapper, String topic) {
     var p =

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/repository/ReconciliationBreakRepository.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/repository/ReconciliationBreakRepository.java
@@ -15,10 +15,6 @@ public interface ReconciliationBreakRepository
 
   List<ReconciliationBreakEntity> findByOrderIdOrderByReconDateDesc(UUID orderId);
 
-  /**
-   * Returns the distinct reconciliation dates that produced at least one break, newest first. Used
-   * by the UI to populate the "recent runs" picker.
-   */
   @Query(
       """
       SELECT DISTINCT r.reconDate FROM ReconciliationBreakEntity r
@@ -26,11 +22,6 @@ public interface ReconciliationBreakRepository
       """)
   List<LocalDate> findRecentReconDates();
 
-  /**
-   * Idempotency support — recon results are keyed by {@code reconDate} (§7.3): re-running for the
-   * same date wipes prior breaks before writing new ones, so a partial earlier run can't leave
-   * stale rows.
-   */
   @Modifying
   long deleteByReconDate(LocalDate reconDate);
 }

--- a/post-trade/src/main/java/com/mariaalpha/posttrade/service/OrderManagerClient.java
+++ b/post-trade/src/main/java/com/mariaalpha/posttrade/service/OrderManagerClient.java
@@ -50,10 +50,6 @@ public class OrderManagerClient {
     }
   }
 
-  /**
-   * Fetches every fill recorded on a given calendar date (by {@code filled_at}, UTC). Used by the
-   * EOD recon engine to assemble the internal side of the comparison.
-   */
   public List<FillForReconRecord> fetchFillsForDate(LocalDate date) {
     try {
       String body =

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/allocation/AllocationCalculatorTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/allocation/AllocationCalculatorTest.java
@@ -22,7 +22,6 @@ class AllocationCalculatorTest {
 
   @Test
   void proRataNoRemainderSplitsCleanly() {
-    // 1000 shares across 50/30/20 → 500/300/200, no rounding
     var results =
         calculator.allocate(ACCOUNTS, AllocationMethod.PRO_RATA, new BigDecimal("1000"), AVG_PRICE);
     assertThat(results).hasSize(3);
@@ -39,7 +38,6 @@ class AllocationCalculatorTest {
 
   @Test
   void proRataRemainderGoesToHeaviestAccount() {
-    // 1003 shares: 501.5/301/200.6 floored to 501/300/200 = 1001. Remainder 2 → heaviest (HOUSE).
     var results =
         calculator.allocate(ACCOUNTS, AllocationMethod.PRO_RATA, new BigDecimal("1003"), AVG_PRICE);
     assertThat(results.get(0).allocatedQuantity()).isEqualByComparingTo("503");
@@ -73,7 +71,6 @@ class AllocationCalculatorTest {
 
   @Test
   void fifoFillsInDeclarationOrderUntilCapsReached() {
-    // 600 shares, caps 50/30/20 → HOUSE 50, HF_A 30, HF_B 20 = 100. Remainder 500 → last (HF_B).
     var results =
         calculator.allocate(ACCOUNTS, AllocationMethod.FIFO, new BigDecimal("600"), AVG_PRICE);
     assertThat(results).hasSize(3);

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/e2e/TcaE2eIT.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/e2e/TcaE2eIT.java
@@ -105,9 +105,6 @@ class TcaE2eIT {
         "AAPL",
         objectMapper.writeValueAsString(trade("AAPL", orderTs.plusSeconds(300), 180.04, 500)));
 
-    // MarketDataConsumer and OrderLifecycleConsumer run on separate listener threads — wait for
-    // all 3 ticks to land in the cache before publishing the lifecycle event so that
-    // ArrivalSnapshotService.captureIfAbsent() finds a tick and creates the arrival snapshot.
     await().atMost(Duration.ofSeconds(10)).until(() -> marketDataCache.size("AAPL") >= 3);
 
     publish(

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/observability/GrafanaDashboardTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/observability/GrafanaDashboardTest.java
@@ -19,20 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Sanity-checks every provisioned Grafana dashboard (issues 2.6.2 / 2.6.3 / 2.6.4):
- *
- * <ul>
- *   <li>parses as JSON
- *   <li>declares a stable {@code uid} and a recent {@code schemaVersion}
- *   <li>has unique panel ids inside one dashboard, and a unique uid across the set
- *   <li>every PromQL expression references a Prometheus metric that this codebase actually
- *       registers — so a renamed metric breaks the build instead of silently producing a "No data"
- *       panel in production
- *   <li>the Helm-chart copies (`charts/.../files/grafana-dashboards/`) match the compose-mounted
- *       originals byte-for-byte (no drift between local and k8s deployments)
- * </ul>
- */
 class GrafanaDashboardTest {
 
   private static final Path REPO_ROOT = repoRoot();
@@ -42,8 +28,6 @@ class GrafanaDashboardTest {
       REPO_ROOT.resolve("charts/mariaalpha/files/grafana-dashboards");
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  // Metrics whose names are produced by Prometheus / infrastructure itself, not registered in our
-  // source. Allow-list them so the test doesn't false-positive on standard infrastructure queries.
   private static final Set<String> INFRA_METRICS =
       Set.of(
           "up",
@@ -52,7 +36,6 @@ class GrafanaDashboardTest {
           "process_cpu_seconds_total",
           "process_resident_memory_bytes");
 
-  // Metric suffixes Micrometer/Prometheus appends automatically.
   private static final List<String> SYNTHETIC_SUFFIXES =
       List.of(
           "_total",
@@ -133,12 +116,6 @@ class GrafanaDashboardTest {
         .isEmpty();
   }
 
-  /**
-   * Histogram-class instruments (python Histogram, Micrometer DistributionSummary/Timer/summary
-   * helper) expose `_bucket`/`_sum`/`_count`/`_max` time series only — Prometheus has no sample at
-   * the bare metric name. Catch dashboards that query a histogram by its bare name (renders "No
-   * data" silently in production).
-   */
   @ParameterizedTest(name = "{0} histogram-class metrics are queried with a suffix")
   @MethodSource("dashboardFiles")
   void histogramQueriesUseSuffix(Path file) throws IOException {
@@ -206,7 +183,6 @@ class GrafanaDashboardTest {
     if (registered.contains(metric)) {
       return true;
     }
-    // Try stripping known Prometheus/Micrometer suffixes.
     for (String suffix : SYNTHETIC_SUFFIXES) {
       if (metric.endsWith(suffix)) {
         String stripped = metric.substring(0, metric.length() - suffix.length());
@@ -218,16 +194,9 @@ class GrafanaDashboardTest {
     return false;
   }
 
-  /**
-   * Walks every Java + Python file once and harvests {@code mariaalpha.*} / {@code mariaalpha_*}
-   * literals. Cheap (~50 ms on this repo) and avoids hard-coding a list that goes stale on every
-   * new metric.
-   */
   static Set<String> collectRegisteredMetrics() throws IOException {
     Set<String> out = new HashSet<>();
-    // Dotted Micrometer names → convert to underscores (Prometheus format).
     Pattern dotted = Pattern.compile("\"(mariaalpha\\.[a-zA-Z0-9._]+)\"");
-    // Underscored Prometheus names (python prometheus_client / micrometer with raw names).
     Pattern underscored = Pattern.compile("\"(mariaalpha_[a-zA-Z0-9_]+)\"");
     Path[] scanRoots =
         new Path[] {
@@ -273,18 +242,6 @@ class GrafanaDashboardTest {
     }
   }
 
-  /**
-   * Histogram-class instruments expose only `_bucket`/`_sum`/`_count`/`_max` series in Prometheus —
-   * never the bare name. Returns the set of bare names for which a bare-name query is invalid:
-   *
-   * <ul>
-   *   <li>python {@code Histogram("mariaalpha_x_y", ...)} → {@code mariaalpha_x_y}
-   *   <li>Java {@code DistributionSummary.builder("mariaalpha.x.y")} → {@code mariaalpha_x_y}
-   *   <li>Java {@code summary("mariaalpha.x.y", ...)} → {@code mariaalpha_x_y}
-   *   <li>Java {@code Timer.builder("mariaalpha.x.ms")} → {@code mariaalpha_x_ms_seconds} (the
-   *       Micrometer Prometheus exporter always appends {@code _seconds} to Timer names)
-   * </ul>
-   */
   static Set<String> collectHistogramBaseNames() throws IOException {
     Set<String> out = new HashSet<>();
     Pattern pyHistogram =
@@ -355,8 +312,6 @@ class GrafanaDashboardTest {
       m = javaTimer.matcher(content);
       while (m.find()) {
         String base = m.group(1).replace('.', '_');
-        // Micrometer's Prometheus exporter always appends `_seconds` to Timer names (even when
-        // the metric author named the Timer in milliseconds).
         out.add(base.endsWith("_seconds") ? base : base + "_seconds");
       }
     } catch (IOException e) {
@@ -365,7 +320,6 @@ class GrafanaDashboardTest {
   }
 
   private static Path repoRoot() {
-    // Tests run from each module's directory (e.g. post-trade/). Walk up until we find the marker.
     Path p = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
     while (p != null && !Files.exists(p.resolve("settings.gradle.kts"))) {
       p = p.getParent();

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/recon/EodReconciliationIT.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/recon/EodReconciliationIT.java
@@ -46,12 +46,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-/**
- * Full-stack reconciliation integration test: real Postgres + Kafka via Testcontainers, real Spring
- * context, mocked {@link OrderManagerClient} and {@link AlpacaActivitiesClient}. Exercises the
- * persistence path (breaks + run record), the Kafka publish path ({@code analytics.risk-alerts}),
- * and the {@code POST /api/recon/run} controller wiring.
- */
 @Tag("integration")
 @Testcontainers
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
@@ -59,8 +53,8 @@ import org.testcontainers.utility.DockerImageName;
     classes = {Application.class, EodReconciliationIT.TestConfig.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {
-      "post-trade.recon.enabled=false", // disable scheduler — tests trigger manually
-      "post-trade.recon.mode=EXTERNAL", // exercise the alpaca client path (mocked)
+      "post-trade.recon.enabled=false",
+      "post-trade.recon.mode=EXTERNAL",
       "post-trade.recon.price-tolerance-bps=1.0",
       "post-trade.recon.quantity-tolerance=0.001",
       "post-trade.recon.high-severity-notional=10000",
@@ -109,7 +103,7 @@ class EodReconciliationIT {
     LocalDate d = LocalDate.of(2026, 6, 1);
     var internal = internalFill("alpaca-1", "AAPL", "180.05", "100");
     when(orderManagerClient.fetchFillsForDate(d)).thenReturn(List.of(internal));
-    stubExternal.set(List.of(extFromInternal(internal))); // perfect match — no breaks
+    stubExternal.set(List.of(extFromInternal(internal)));
 
     var run = service.runForDate(d, Source.MANUAL);
 
@@ -124,7 +118,7 @@ class EodReconciliationIT {
     LocalDate d = LocalDate.of(2026, 6, 2);
     when(orderManagerClient.fetchFillsForDate(d))
         .thenReturn(List.of(internalFill("alpaca-1", "AAPL", "180.05", "100")));
-    stubExternal.set(List.of()); // alpaca silent
+    stubExternal.set(List.of());
 
     try (var consumer = riskAlertConsumer()) {
       consumer.subscribe(List.of("analytics.risk-alerts"));
@@ -156,14 +150,12 @@ class EodReconciliationIT {
   @Test
   void rerunningSameDateOverwritesPriorBreaks() {
     LocalDate d = LocalDate.of(2026, 6, 3);
-    // First run: 1 break (extra fill — alpaca silent)
     when(orderManagerClient.fetchFillsForDate(d))
         .thenReturn(List.of(internalFill("alpaca-1", "AAPL", "180.05", "100")));
     stubExternal.set(List.of());
     service.runForDate(d, Source.MANUAL);
     assertThat(breakRepository.findByReconDateOrderBySeverityDesc(d)).hasSize(1);
 
-    // Second run: same internal, but alpaca now reports it → 0 breaks
     stubExternal.set(List.of(extFromInternal(internalFill("alpaca-1", "AAPL", "180.05", "100"))));
     when(orderManagerClient.fetchFillsForDate(d))
         .thenReturn(List.of(internalFill("alpaca-1", "AAPL", "180.05", "100")));
@@ -171,7 +163,6 @@ class EodReconciliationIT {
 
     assertThat(rerun.getBreaksCount()).isEqualTo(0);
     assertThat(breakRepository.findByReconDateOrderBySeverityDesc(d)).isEmpty();
-    // Only one run row should exist for that date
     assertThat(runRepository.findByReconDate(d)).isPresent();
   }
 
@@ -180,8 +171,7 @@ class EodReconciliationIT {
     LocalDate d = LocalDate.of(2026, 6, 4);
     when(orderManagerClient.fetchFillsForDate(d)).thenReturn(List.of());
 
-    // Force the stub Alpaca client to throw
-    stubExternal.set(null); // null is sentinel for "throw" in our test stub below
+    stubExternal.set(null);
 
     var run = service.runForDate(d, Source.SCHEDULED);
 

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/recon/EodReconciliationServiceTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/recon/EodReconciliationServiceTest.java
@@ -57,7 +57,6 @@ class EodReconciliationServiceTest {
             new BigDecimal("10000"),
             new BigDecimal("100000"));
 
-    // upsertRun creates fresh runs; saveAll/save just echoes back the input.
     when(runRepository.findByReconDate(any())).thenReturn(Optional.empty());
     when(runRepository.save(any()))
         .thenAnswer(inv -> inv.getArgument(0, ReconciliationRunEntity.class));
@@ -124,7 +123,7 @@ class EodReconciliationServiceTest {
                     "AAPL",
                     Side.BUY,
                     new BigDecimal("180.05"),
-                    new BigDecimal("80"), // qty mismatch
+                    new BigDecimal("80"),
                     Instant.parse("2026-06-01T15:30:00Z"))));
 
     var run = service.runForDate(d, Source.MANUAL);

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/recon/HttpAlpacaActivitiesClientTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/recon/HttpAlpacaActivitiesClientTest.java
@@ -57,7 +57,7 @@ class HttpAlpacaActivitiesClientTest {
             + "\"client_order_id\":\"c-1\",\"symbol\":\"AAPL\","
             + "\"side\":\"buy\",\"price\":\"180.05\",\"qty\":\"100\","
             + "\"transaction_time\":\"2026-06-01T15:30:00Z\"},"
-            + "{\"id\":\"act-2\"}]"; // missing required fields
+            + "{\"id\":\"act-2\"}]";
     var result = client.parseActivities(body);
     assertThat(result).hasSize(1);
     assertThat(result.get(0).externalFillId()).isEqualTo("act-1");

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/recon/ReconciliationComparatorTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/recon/ReconciliationComparatorTest.java
@@ -17,7 +17,6 @@ class ReconciliationComparatorTest {
   private static final LocalDate D = LocalDate.of(2026, 6, 1);
   private static final Instant TS = Instant.parse("2026-06-01T15:30:00Z");
 
-  // 1 bps tolerance on price, 0.001 tolerance on qty, $10k HIGH / $100k CRITICAL severity.
   private final ReconciliationComparator comparator =
       new ReconciliationComparator(
           new BigDecimal("1.0"),
@@ -78,7 +77,6 @@ class ReconciliationComparatorTest {
 
   @Test
   void priceMismatchAboveToleranceIsDetected() {
-    // 180.05 vs 180.08 → 1.66 bps, above 1.0 bps tolerance
     var internal = List.of(fill("alpaca-1", "AAPL", Side.BUY, "180.05", "100"));
     var external = List.of(ext("alpaca-1", "AAPL", Side.BUY, "180.08", "100"));
     var breaks = comparator.compare(D, internal, external);
@@ -90,7 +88,6 @@ class ReconciliationComparatorTest {
 
   @Test
   void priceDifferenceBelowToleranceIgnored() {
-    // 180.05 vs 180.06 → 0.555 bps, below 1.0 bps tolerance
     var internal = List.of(fill("alpaca-1", "AAPL", Side.BUY, "180.05", "100"));
     var external = List.of(ext("alpaca-1", "AAPL", Side.BUY, "180.06", "100"));
     assertThat(comparator.compare(D, internal, external)).isEmpty();
@@ -98,7 +95,6 @@ class ReconciliationComparatorTest {
 
   @Test
   void aggregatesMultipleFillsPerOrder() {
-    // Two internal fills for same alpaca-1 order, total = 100 @ vwap 180.05
     var internal =
         List.of(
             fill("alpaca-1", "AAPL", Side.BUY, "180.00", "50"),
@@ -109,7 +105,6 @@ class ReconciliationComparatorTest {
 
   @Test
   void severityScalesWithNotionalForMissingFill() {
-    // $1k → MEDIUM, $10k → HIGH, $100k → CRITICAL
     var lowBreak =
         comparator.compare(D, List.of(), List.of(ext("o1", "AAPL", Side.BUY, "10", "100"))).get(0);
     var highBreak =
@@ -125,9 +120,7 @@ class ReconciliationComparatorTest {
 
   @Test
   void severityScalesWithPriceDiffMagnitudeForPriceMismatch() {
-    // 1.66 bps diff → just above tolerance → MEDIUM (less than 10× = 10 bps)
     var medium = priceMismatch("180.05", "180.08");
-    // 100 vs 110 → 909 bps diff → way above 100× tolerance (100 bps) → CRITICAL
     var critical = priceMismatch("100", "110");
     assertThat(medium.severity()).isEqualTo(Severity.MEDIUM);
     assertThat(critical.severity()).isEqualTo(Severity.CRITICAL);
@@ -170,7 +163,7 @@ class ReconciliationComparatorTest {
             fill("alpaca-2", "MSFT", Side.SELL, "415.00", "50"));
     var external = List.of(ext("alpaca-3", "GOOGL", Side.BUY, "140.00", "200"));
     var breaks = comparator.compare(D, internal, external);
-    assertThat(breaks).hasSize(3); // 2 EXTRA_FILL + 1 MISSING_FILL
+    assertThat(breaks).hasSize(3);
     long extra = breaks.stream().filter(b -> b.breakType() == BreakType.EXTRA_FILL).count();
     long missing = breaks.stream().filter(b -> b.breakType() == BreakType.MISSING_FILL).count();
     assertThat(extra).isEqualTo(2);
@@ -195,7 +188,7 @@ class ReconciliationComparatorTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 null,
-                null, // no client or exchange id
+                null,
                 "AAPL",
                 Side.BUY,
                 new BigDecimal("180.05"),
@@ -203,8 +196,6 @@ class ReconciliationComparatorTest {
                 TS));
     assertThat(comparator.compare(D, internal, List.of())).isEmpty();
   }
-
-  // --- helpers ---
 
   private static InternalFill fill(
       String exchangeOrderId, String symbol, Side side, String price, String qty) {

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/recon/ReconciliationSchedulerTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/recon/ReconciliationSchedulerTest.java
@@ -9,14 +9,12 @@ class ReconciliationSchedulerTest {
 
   @Test
   void previousTradingDaySkipsWeekends() {
-    // Monday → previous trading day is Friday
     assertThat(ReconciliationScheduler.previousTradingDay(LocalDate.of(2026, 6, 1)))
         .isEqualTo(LocalDate.of(2026, 5, 29));
   }
 
   @Test
   void previousTradingDayForMidWeekIsPreviousDay() {
-    // Wednesday → previous trading day is Tuesday
     assertThat(ReconciliationScheduler.previousTradingDay(LocalDate.of(2026, 6, 3)))
         .isEqualTo(LocalDate.of(2026, 6, 2));
   }

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/repository/ReconciliationRepositoryIT.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/repository/ReconciliationRepositoryIT.java
@@ -22,10 +22,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * Validates the schema migrations + JPA mappings for the recon engine work end-to-end on a real
- * Postgres. Pure JPA — no Spring beans for the orchestrator or downstream services.
- */
 @Tag("integration")
 @Testcontainers
 @DataJpaTest(
@@ -82,7 +78,7 @@ class ReconciliationRepositoryIT {
   void missingFillBreakAllowsNullOrderId() {
     var b = new ReconciliationBreakEntity();
     b.setReconDate(LocalDate.of(2026, 6, 4));
-    b.setOrderId(null); // 2.6.1 migration relaxed NOT NULL
+    b.setOrderId(null);
     b.setBreakType("MISSING_FILL");
     b.setSeverity("HIGH");
     b.setSymbol("AAPL");

--- a/post-trade/src/test/java/com/mariaalpha/posttrade/tca/TcaCalculatorTest.java
+++ b/post-trade/src/test/java/com/mariaalpha/posttrade/tca/TcaCalculatorTest.java
@@ -47,7 +47,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("BUY paying above arrival yields positive slippage")
     void buyAboveArrival() {
-      // arrival=100, avgFill=100.10 → (100.10 - 100)/100 * 10000 = 10 bps
       TcaInputs in = inputs(Side.BUY, 1000, 100.00, 99.99, 100.01, 100.10, 0.0, 100.05);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.slippageBps()).isCloseTo(new BigDecimal("10.0000"), within(EPS));
@@ -56,7 +55,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("BUY paying below arrival yields negative slippage (price improvement)")
     void buyBelowArrival() {
-      // arrival=100, avgFill=99.95 → -5 bps
       TcaInputs in = inputs(Side.BUY, 1000, 100.00, 99.99, 100.01, 99.95, 0.0, 99.97);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.slippageBps()).isCloseTo(new BigDecimal("-5.0000"), within(EPS));
@@ -65,7 +63,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("SELL receiving below arrival yields positive slippage")
     void sellBelowArrival() {
-      // arrival=100, avgFill=99.90 → (100 - 99.90)/100 * 10000 = 10 bps
       TcaInputs in = inputs(Side.SELL, 1000, 100.00, 99.99, 100.01, 99.90, 0.0, 99.95);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.slippageBps()).isCloseTo(new BigDecimal("10.0000"), within(EPS));
@@ -116,11 +113,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("BUY: IS = price slippage + commission, normalized")
     void buyIsWithCommission() {
-      // arrival=100, avgFill=100.10, qty=1000, commission=$20
-      // price component = (100.10-100)*1000 = 100
-      // total $ cost = 100 + 20 = 120
-      // notional = 100 * 1000 = 100000
-      // IS_bps = 120/100000 * 10000 = 12 bps
       TcaInputs in = inputs(Side.BUY, 1000, 100.00, 99.99, 100.01, 100.10, 20.0, 100.05);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.implShortfallBps()).isCloseTo(new BigDecimal("12.0000"), within(EPS));
@@ -129,11 +121,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("SELL: price improvement almost offsets commission")
     void sellIsWithCommission() {
-      // signedCost(SELL, 50.02, 50.00) = (50.00 - 50.02) = -0.02
-      // priceComponent = -0.02 * 1000 = -20
-      // totalCost = -20 + 15 = -5
-      // notional = 50 * 1000 = 50000
-      // IS_bps = -5/50000 * 10000 = -1 bps
       TcaInputs in = inputs(Side.SELL, 1000, 50.00, 49.99, 50.01, 50.02, 15.0, 50.01);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.implShortfallBps()).isCloseTo(new BigDecimal("-1.0000"), within(EPS));
@@ -142,7 +129,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("IS equals commission-bps when avgFill equals arrival")
     void isEqualsCommissionOnly() {
-      // IS_$ = 0 + 10 = 10; notional = 100000; IS_bps = 1 bps
       TcaInputs in = inputs(Side.BUY, 1000, 100.00, 99.99, 100.01, 100.00, 10.0, 100.00);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.implShortfallBps()).isCloseTo(new BigDecimal("1.0000"), within(EPS));
@@ -164,7 +150,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("BUY above market VWAP is a cost")
     void buyAboveVwap() {
-      // vwap=100, avgFill=100.05 → 5 bps
       TcaInputs in = inputs(Side.BUY, 1000, 100.00, 99.99, 100.01, 100.05, 0.0, 100.00);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.vwapBenchmarkBps()).isCloseTo(new BigDecimal("5.0000"), within(EPS));
@@ -207,7 +192,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("half of a 2c spread on a $100 mid is 1 bps")
     void twoCentSpreadOnHundredDollarMid() {
-      // (0.02 / 100) / 2 * 10000 = 1 bps
       TcaInputs in = inputs(Side.BUY, 1000, 100.00, 99.99, 100.01, 100.00, 0.0, 100.00);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.spreadCostBps()).isCloseTo(new BigDecimal("1.0000"), within(EPS));
@@ -224,7 +208,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("wide spread on a penny stock yields many bps")
     void wideSpreadPennyStock() {
-      // mid=$1.00, spread=$0.02 → (0.02/1.00)/2 * 10000 = 100 bps
       TcaInputs in = inputs(Side.BUY, 1000, 1.00, 0.99, 1.01, 1.00, 0.0, 1.00);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.spreadCostBps()).isCloseTo(new BigDecimal("100.0000"), within(EPS));
@@ -259,13 +242,6 @@ class TcaCalculatorTest {
     @Test
     @DisplayName("consolidated textbook example: BUY 1000 AAPL with all four metrics")
     void buyTextbook() {
-      // arrival_mid=$180.00, bid=$179.98, ask=$180.02, avgFill=$180.05
-      // qty=1000, commission=$5, interval VWAP=$180.03
-      //
-      // slippage = (180.05 - 180.00)/180.00 * 10000 = 2.7778 bps
-      // IS = ((180.05-180)*1000 + 5)/(180*1000) * 10000 = 55/180000 * 10000 = 3.0556 bps
-      // vwap_bench = (180.05 - 180.03)/180.03 * 10000 = 1.1109 bps
-      // spread_cost = (0.04 / 180.00) / 2 * 10000 = 1.1111 bps
       TcaInputs in = inputs(Side.BUY, 1000, 180.00, 179.98, 180.02, 180.05, 5.0, 180.03);
       TcaComputation r = TcaCalculator.compute(in);
       assertThat(r.slippageBps()).isCloseTo(new BigDecimal("2.7778"), within(EPS));

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrder.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrder.java
@@ -5,16 +5,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
-/**
- * In-memory record of an algorithmic parent order submitted through the REST surface (roadmap
- * 3.4.4). Each algo order binds the named strategy to the requested symbol and applies the caller's
- * parameters. Lifecycle transitions are emitted to the {@code algo.progress} Kafka topic for
- * downstream WebSocket consumers (roadmap 3.4.5).
- *
- * <p>Filled-quantity / progress tracking is intentionally out of scope here — it requires
- * propagating {@code algoOrderId} through the signal → execution → order-manager chain. Captured in
- * the docs as a future-work item.
- */
 public record AlgoOrder(
     UUID algoOrderId,
     String symbol,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderController.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderController.java
@@ -14,15 +14,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * REST surface for programmatic algorithmic-order submission (roadmap 3.4.4). Sits alongside the
- * strategy-binding endpoints under {@code /api/strategies/*}: where those bind a strategy to a
- * symbol persistently, this one submits a single named parent order with target quantity and gets a
- * UUID back that the caller can poll / cancel.
- *
- * <p>The contract is intentionally simple — POST to create, GET to query, DELETE to cancel. Lives
- * under the api-gateway's {@code /api/algo/**} route (configured in api-gateway/application.yml).
- */
 @RestController
 @RequestMapping("/api/algo/orders")
 public class AlgoOrderController {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderRegistry.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderRegistry.java
@@ -8,16 +8,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
-/**
- * In-memory store of active and recently-terminal algo orders (roadmap 3.4.4). A single instance is
- * sufficient because the strategy-engine itself is the source of truth for live algos — once
- * persistence is needed (e.g. crash recovery, multi-replica HA), this would move behind a
- * repository interface backed by Postgres alongside the orders table.
- *
- * <p>The registry deliberately retains terminal (cancelled / completed) algos so a downstream UI
- * can replay the final state via {@code GET /api/algo/orders/{id}} after the WebSocket event has
- * already fired. A future eviction policy can age them out — not needed at desk volumes.
- */
 @Component
 public class AlgoOrderRegistry {
 
@@ -36,17 +26,12 @@ public class AlgoOrderRegistry {
     return List.copyOf(byId.values());
   }
 
-  /** Returns every algo order currently in {@link AlgoOrder.Status#ACTIVE} for a symbol. */
   public List<AlgoOrder> activeForSymbol(String symbol) {
     return byId.values().stream()
         .filter(a -> a.status() == AlgoOrder.Status.ACTIVE && a.symbol().equalsIgnoreCase(symbol))
         .toList();
   }
 
-  /**
-   * Transitions an algo order to a new status and stores it back. Returns the updated record or
-   * empty if the id is unknown.
-   */
   public Optional<AlgoOrder> transition(UUID id, AlgoOrder.Status newStatus) {
     var current = byId.get(id);
     if (current == null) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderRequest.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderRequest.java
@@ -6,14 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
-/**
- * Request body for {@code POST /api/algo/orders} — submits a new algorithmic parent order (roadmap
- * 3.4.4). {@code strategyName} must match a registered {@link
- * com.mariaalpha.strategyengine.strategy.TradingStrategy}; {@code parameters} is forwarded verbatim
- * to that strategy's {@code updateParameters} (so it must contain whatever shape that strategy
- * expects — e.g. for VWAP: {@code targetQuantity}, {@code startTime}, {@code endTime}, {@code
- * volumeProfile}).
- */
 public record AlgoOrderRequest(
     @NotBlank String symbol,
     @NotNull Side side,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderResponse.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderResponse.java
@@ -5,11 +5,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
-/**
- * Response payload for the algo-execution REST surface (roadmap 3.4.4). A direct projection of
- * {@link AlgoOrder} that is safe to serialise — keeps the internal record free to evolve without
- * leaking implementation detail into the API.
- */
 public record AlgoOrderResponse(
     UUID algoOrderId,
     String symbol,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderService.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoOrderService.java
@@ -10,24 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-/**
- * Orchestrates the submit / cancel side of the algo-execution REST surface (roadmap 3.4.4):
- *
- * <ol>
- *   <li>Validate that the requested strategy exists.
- *   <li>Apply the caller's parameters to the strategy (via {@link
- *       com.mariaalpha.strategyengine.strategy.TradingStrategy#updateParameters}).
- *   <li>Bind the strategy to the symbol so the tick-driven evaluation path picks it up.
- *   <li>Register the algo order in the in-memory {@link AlgoOrderRegistry}.
- *   <li>Fan out a {@code CREATED} (or {@code CANCELLED}) event to the {@code algo.progress} Kafka
- *       topic for WebSocket consumers (roadmap 3.4.5).
- * </ol>
- *
- * <p>This is a v1 surface — it deliberately doesn't yet track child-fill progress against the
- * algo's {@code targetQuantity}. That work needs {@code algoOrderId} propagation through
- * SignalPublisher → execution-engine → order-manager → orders.lifecycle, which is captured in the
- * docs as a future ticket.
- */
 @Service
 public class AlgoOrderService {
 
@@ -49,10 +31,6 @@ public class AlgoOrderService {
     this.progressPublisher = progressPublisher;
   }
 
-  /**
-   * Submit a new algo order. Throws {@link IllegalArgumentException} if {@code strategyName} is not
-   * registered — the controller maps this to a 400.
-   */
   public AlgoOrder submit(AlgoOrderRequest request) {
     var strategyOpt = strategyRegistry.get(request.strategyName());
     if (strategyOpt.isEmpty()) {
@@ -61,9 +39,6 @@ public class AlgoOrderService {
     var strategy = strategyOpt.get();
 
     var params = request.parameters() == null ? Map.<String, Object>of() : request.parameters();
-    // The order's own side / targetQuantity drive the strategy unless the caller explicitly
-    // overrides them in `parameters` — otherwise an order could execute with whatever side or
-    // quantity a previous algo order left behind on the singleton strategy instance.
     var effectiveParams = new java.util.HashMap<String, Object>(params);
     effectiveParams.putIfAbsent("side", request.side().name());
     effectiveParams.putIfAbsent("targetQuantity", request.targetQuantity());
@@ -94,18 +69,13 @@ public class AlgoOrderService {
     return order;
   }
 
-  /**
-   * Cancel an algo order. Unbinds the strategy from the symbol so no further signals fire and emits
-   * the {@code CANCELLED} lifecycle event. Returns the updated record or empty if the id is unknown
-   * / already terminal.
-   */
   public Optional<AlgoOrder> cancel(UUID id) {
     var current = orderRegistry.find(id);
     if (current.isEmpty()) {
       return Optional.empty();
     }
     if (current.get().status() != AlgoOrder.Status.ACTIVE) {
-      return current; // already terminal — caller can re-read for the final state.
+      return current;
     }
     var updated = orderRegistry.transition(id, AlgoOrder.Status.CANCELLED).orElseThrow();
     router.clearActiveStrategy(updated.symbol());

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoProgressEvent.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoProgressEvent.java
@@ -6,17 +6,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Event emitted on the {@code algo.progress} topic each time an {@link AlgoOrder}'s lifecycle
- * advances or a strategy signal fires for its symbol. Subscribers (api-gateway WebSocket, future UI
- * tape) consume this to render real-time parent-order progress.
- *
- * <p>{@code eventType} carries the transition that caused the emission ({@code CREATED} when the
- * algo order is submitted, {@code CANCELLED} on DELETE, {@code SIGNAL_EMITTED} when the bound
- * strategy publishes a signal). The signal-level fields ({@code signalSide}, {@code
- * signalQuantity}, {@code signalLimitPrice}) are populated only on {@code SIGNAL_EMITTED}; null
- * otherwise.
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record AlgoProgressEvent(
     UUID algoOrderId,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoProgressPublisher.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/algo/AlgoProgressPublisher.java
@@ -10,14 +10,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-/**
- * Producer for the {@code algo.progress} Kafka topic (roadmap 3.4.5). Strategy lifecycle and
- * signal-level events flow through here on their way to the API gateway's WebSocket fan-out.
- *
- * <p>Failures to publish are logged at WARN — the algo order itself is the source of truth and the
- * REST GET surface always returns the current state, so a dropped progress event degrades the UI
- * smoothness without affecting correctness.
- */
 @Component
 public class AlgoProgressPublisher {
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/config/MlConfig.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/config/MlConfig.java
@@ -2,19 +2,6 @@ package com.mariaalpha.strategyengine.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Wiring + policy knobs for the ML Signal Service gRPC client and the {@link
- * com.mariaalpha.strategyengine.ml.MlSignalGate} that consumes its output.
- *
- * <p>{@link #confidenceThreshold()} is the confidence floor below which the ML signal is treated as
- * uninformative; the strategy proceeds on its own per FR-12. Above it the gate applies the {@link
- * #vetoMode()} policy (STRICT — suppress contradictions; PERMISSIVE — log only; OFF — ML never
- * suppresses). {@link #neutralSuppress()} controls whether a high-confidence NEUTRAL prediction is
- * treated as contradicting any side (true) or as a non-opinion (false; the default and the relaxed
- * TDD §5.2.2 reading). {@link #sizingMode()} drives the quantity adjustment: NONE leaves quantity
- * untouched; SCALED multiplies it by {@code clamp(recommendedSize / sizingNeutralFraction, lower,
- * upper)} when ML agrees with high confidence.
- */
 @ConfigurationProperties(prefix = "strategy-engine.ml")
 public record MlConfig(
     String host,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/config/RegimeAutoSelectConfig.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/config/RegimeAutoSelectConfig.java
@@ -7,15 +7,6 @@ import java.util.Locale;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * FR-17 — regime-driven strategy selection. When {@link #enabled()} is true the strategy engine
- * routes a tick to the strategy the regime map prescribes (default: TRENDING_UP/DOWN → MOMENTUM,
- * MEAN_REVERTING/LOW_VOLATILITY → VWAP) instead of the manually-bound one in {@code
- * SymbolStrategyRouter}, provided the ML service returns a regime with confidence at least {@link
- * #confidenceThreshold()}. When confidence is below the threshold or no mapping exists for the
- * regime (e.g. HIGH_VOLATILITY by default), the engine falls back to the manual binding — making
- * this a safe, opt-in feature.
- */
 @ConfigurationProperties(prefix = "strategy-engine.regime")
 public record RegimeAutoSelectConfig(
     boolean enabled, double confidenceThreshold, Map<String, String> map) {
@@ -24,15 +15,9 @@ public record RegimeAutoSelectConfig(
     if (confidenceThreshold <= 0.0) {
       confidenceThreshold = 0.6;
     }
-    // Defensive copy so external mutation can't reach our internal map (SpotBugs EI rule).
     map = (map == null) ? Map.of() : Map.copyOf(map);
   }
 
-  /**
-   * Default regime → strategy name mapping per TDD §3.3 FR-17. Used when a regime is not present in
-   * the config-supplied {@link #map()}. HIGH_VOLATILITY intentionally omits a default so the engine
-   * falls through to the manually bound strategy when the market is most uncertain.
-   */
   public static EnumMap<MarketRegime, String> defaults() {
     var defaults = new EnumMap<MarketRegime, String>(MarketRegime.class);
     defaults.put(MarketRegime.TRENDING_UP, "MOMENTUM");
@@ -42,11 +27,8 @@ public record RegimeAutoSelectConfig(
     return defaults;
   }
 
-  /** Resolved (regime → strategy name) lookup, applying defaults under any unmapped regime. */
   public EnumMap<MarketRegime, String> resolvedMap() {
     var resolved = defaults();
-    // Coerce keys to upper-case to match the proto enum names — config files often use kebab/snake
-    // case or mixed case for readability.
     var normalized = new HashMap<String, String>();
     map.forEach((k, v) -> normalized.put(k.toUpperCase(Locale.ROOT).replace('-', '_'), v));
     for (var regime : MarketRegime.values()) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/controller/StrategyController.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/controller/StrategyController.java
@@ -79,11 +79,6 @@ public class StrategyController {
         .orElse(ResponseEntity.notFound().build());
   }
 
-  /**
-   * Aggregated per-symbol state for the UI Strategy Control page. Returns one row per routed symbol
-   * when {@code symbol} is omitted, or just that symbol when provided. ML signal / regime fields
-   * are nullable so the UI can render "—" when the model is unavailable.
-   */
   @GetMapping("/state")
   public List<StrategyStateResponse> state(@RequestParam(required = false) String symbol) {
     if (symbol != null && !symbol.isBlank()) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/controller/StrategyStateResponse.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/controller/StrategyStateResponse.java
@@ -2,11 +2,6 @@ package com.mariaalpha.strategyengine.controller;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-/**
- * Aggregated per-symbol view consumed by the Strategy Control page: the active strategy binding
- * plus the latest ML signal and regime classification. All ML fields are nullable — when the model
- * is unavailable or the symbol has no rolling window yet, the UI gracefully degrades to "—".
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record StrategyStateResponse(
     String symbol, String activeStrategy, Signal mlSignal, Regime mlRegime) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/metrics/StrategyMetrics.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/metrics/StrategyMetrics.java
@@ -67,10 +67,6 @@ public class StrategyMetrics {
         .record(scale);
   }
 
-  /**
-   * Counts ticks dropped before reaching a strategy. {@code reason=market_closed} is the 3.1.3
-   * trading-hours gate; other reasons can land on the same meter later (e.g. data quality).
-   */
   public void recordTickSuppressed(String symbol, String reason) {
     Counter.builder(TICKS_SUPPRESSED)
         .description("Ticks dropped before reaching a strategy, by reason")

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlGateDecision.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlGateDecision.java
@@ -3,28 +3,14 @@ package com.mariaalpha.strategyengine.ml;
 import com.mariaalpha.strategyengine.model.OrderSignal;
 import java.util.Optional;
 
-/**
- * Structured outcome from {@link MlSignalGate#decide}.
- *
- * <p>{@code outcome} captures the policy reason (CONFIRMED, VETOED, NO_ML, LOW_CONFIDENCE,
- * NEUTRAL_PASS). {@code signal} is the (possibly resized) signal to publish — empty when the gate
- * suppresses. {@code quantityScale} is the ratio applied to the strategy's original quantity (1.0
- * when no sizing adjustment ran).
- */
 public record MlGateDecision(Outcome outcome, Optional<OrderSignal> signal, double quantityScale) {
 
   public enum Outcome {
-    /** ML agreed with high confidence; signal proceeds, possibly resized. */
     CONFIRMED,
-    /** ML contradicted with high confidence; STRICT mode suppresses. */
     VETOED,
-    /** ML call failed / circuit breaker open / no result. Signal proceeds unchanged. */
     NO_ML,
-    /** ML confidence below threshold; signal proceeds unchanged. */
     LOW_CONFIDENCE,
-    /** ML returned NEUTRAL with high confidence and {@code neutral-suppress=false}. */
     NEUTRAL_PASS,
-    /** ML contradicted but {@code veto-mode=PERMISSIVE} or OFF; signal proceeds. */
     OVERRIDDEN
   }
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlRegimeResult.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlRegimeResult.java
@@ -2,5 +2,4 @@ package com.mariaalpha.strategyengine.ml;
 
 import com.mariaalpha.proto.signal.MarketRegime;
 
-/** Outcome of a {@code GetRegime} call (FR-16). */
 public record MlRegimeResult(MarketRegime regime, double confidence) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlSignalClient.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlSignalClient.java
@@ -47,10 +47,6 @@ public class MlSignalClient {
     registerCircuitBreakerGauge(meterRegistry);
   }
 
-  /**
-   * Calls {@code GetSignal} on the ML service for the given symbol. Returns empty if the circuit
-   * breaker is open, the call times out, or any other error occurs.
-   */
   public Optional<MlSignalResult> getSignal(String symbol) {
     try {
       return circuitBreaker.executeSupplier(
@@ -73,11 +69,6 @@ public class MlSignalClient {
     }
   }
 
-  /**
-   * Calls {@code GetRegime} on the ML service. Reuses the same circuit breaker as {@link
-   * #getSignal} so the strategy engine has a single ML-availability gate. Returns empty on any
-   * failure.
-   */
   public Optional<MlRegimeResult> getRegime(String symbol) {
     try {
       return circuitBreaker.executeSupplier(

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlSignalGate.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlSignalGate.java
@@ -11,26 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Confirmation / veto gate (FR-12, TDD §5.2.2).
- *
- * <p>The TDD specifies: <em>"if the ML signal confidence &gt; 0.7 and agrees with the strategy
- * direction, proceed. If &gt; 0.7 and contradicts, suppress. If ≤ 0.7, proceed with strategy signal
- * alone. Configurable via {@code config/strategy.yml}."</em>
- *
- * <p>Two additional configurable behaviours layer on top:
- *
- * <ul>
- *   <li>{@link VetoMode}: STRICT (default) suppresses contradictions; PERMISSIVE logs but lets the
- *       signal through; OFF disables the gate entirely.
- *   <li>{@link SizingMode}: when ML <strong>agrees</strong> with high confidence the gate can
- *       optionally <em>scale</em> the strategy's quantity by {@code recommendedSize /
- *       sizingNeutralFraction} (clamped between {@code sizingLowerBound} and {@code
- *       sizingUpperBound}), expressing the "adjusting urgency" half of FR-12.
- * </ul>
- *
- * <p>Pure decision logic — no I/O, no side effects other than the SLF4J log line. Stateless.
- */
 @Component
 public class MlSignalGate {
 
@@ -71,7 +51,6 @@ public class MlSignalGate {
       return MlGateDecision.confirmed(resized, scale);
     }
 
-    // Contradiction
     return switch (config.vetoMode()) {
       case STRICT -> {
         LOG.info(

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlSignalResult.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/ml/MlSignalResult.java
@@ -2,11 +2,6 @@ package com.mariaalpha.strategyengine.ml;
 
 import com.mariaalpha.proto.signal.Direction;
 
-/**
- * Outcome of a {@code GetSignal} call. {@code recommendedSize} is the ML model's recommended
- * position size as a fraction of available capital, used by the {@link MlSignalGate} to optionally
- * scale the strategy's order quantity when the ML side agrees with high confidence.
- */
 public record MlSignalResult(Direction direction, double confidence, double recommendedSize) {
 
   public MlSignalResult(Direction direction, double confidence) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/BlackScholesPricer.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/BlackScholesPricer.java
@@ -2,30 +2,9 @@ package com.mariaalpha.strategyengine.options;
 
 import org.springframework.stereotype.Component;
 
-/**
- * Black-Scholes-Merton European option pricer with a continuous dividend yield (FR roadmap 3.2.1).
- *
- * <p>The standard generalised formulas:
- *
- * <pre>
- *   d1 = (ln(S/K) + (r − q + σ²/2)·T) / (σ·√T)
- *   d2 = d1 − σ·√T
- *   Call = S·e^(−q·T)·Φ(d1) − K·e^(−r·T)·Φ(d2)
- *   Put  = K·e^(−r·T)·Φ(−d2) − S·e^(−q·T)·Φ(−d1)
- * </pre>
- *
- * <p>Setting {@code q = 0} recovers the original Black-Scholes equity formulas. The result is the
- * undiscounted theoretical fair value of one option contract on one unit of underlying — multiply
- * by the contract size (typically 100 shares) at the caller for a dollar premium.
- *
- * <p>The class is pure: it holds no state and is safe to call concurrently. It is registered as a
- * Spring {@link Component} so {@link OptionPricingService} and {@link GreeksCalculator} can be
- * autowired with it; the math is also reachable from tests via the public {@link #price} method.
- */
 @Component
 public class BlackScholesPricer {
 
-  /** Theoretical fair value of {@code contract}. */
   public double price(OptionContract contract) {
     DiscountedTerms terms = DiscountedTerms.from(contract);
     return switch (contract.type()) {
@@ -38,12 +17,6 @@ public class BlackScholesPricer {
     };
   }
 
-  /**
-   * Bundle of intermediate Black-Scholes terms shared by the pricer and {@link GreeksCalculator}.
-   *
-   * <p>Computing these once per contract keeps the Greek formulas readable and avoids recomputing
-   * {@code √T} or {@code e^(−q·T)} in every Greek getter.
-   */
   record DiscountedTerms(
       double d1,
       double d2,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/Greeks.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/Greeks.java
@@ -1,20 +1,3 @@
 package com.mariaalpha.strategyengine.options;
 
-/**
- * Bundle of first-order Black-Scholes-Merton sensitivities for a European option (roadmap 3.2.2).
- *
- * <ul>
- *   <li>{@code delta} (Δ) — change in option value per +1.00 change in the underlying.
- *       Dimensionless in {@code [−1, 1]}.
- *   <li>{@code gamma} (Γ) — change in {@link #delta} per +1.00 change in the underlying. Same for
- *       calls and puts.
- *   <li>{@code vega} — change in option value per +1 percentage-point change in volatility ({@code
- *       0.01} of σ). Reported per-1%-vol so the UI can show "vega = 0.18 per 1% vol".
- *   <li>{@code theta} — change in option value per one passing day. Sign convention: typically
- *       negative for long options. Day count comes from {@link
- *       OptionsPricingConfig#thetaDayCount()}.
- *   <li>{@code rho} — change in option value per +1 percentage-point change in the risk-free rate.
- *       Reported per-1%-rate so the UI can show "rho = 0.12 per 1% rate".
- * </ul>
- */
 public record Greeks(double delta, double gamma, double vega, double theta, double rho) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/GreeksCalculator.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/GreeksCalculator.java
@@ -3,27 +3,6 @@ package com.mariaalpha.strategyengine.options;
 import com.mariaalpha.strategyengine.options.BlackScholesPricer.DiscountedTerms;
 import org.springframework.stereotype.Component;
 
-/**
- * Analytic first-order Black-Scholes-Merton Greeks (roadmap 3.2.2).
- *
- * <p>All formulas use the dividend-adjusted variant (continuous yield {@code q}). Vega and Rho are
- * reported per 1-percentage-point move in their underlying input so the displayed numbers match the
- * scale traders expect. Theta is reported per day using the {@link
- * OptionsPricingConfig#thetaDayCount()} convention.
- *
- * <pre>
- *   Δ_call = e^(−q·T)·Φ(d1)
- *   Δ_put  = e^(−q·T)·(Φ(d1) − 1)
- *   Γ      = e^(−q·T)·φ(d1) / (S·σ·√T)
- *   vega   = S·e^(−q·T)·φ(d1)·√T            (annualised, then ÷100 → per-1%-vol)
- *   Θ_call = −S·e^(−q·T)·φ(d1)·σ/(2·√T)             (÷ thetaDayCount → /day)
- *            − r·K·e^(−r·T)·Φ(d2) + q·S·e^(−q·T)·Φ(d1)
- *   Θ_put  = −S·e^(−q·T)·φ(d1)·σ/(2·√T)
- *            + r·K·e^(−r·T)·Φ(−d2) − q·S·e^(−q·T)·Φ(−d1)
- *   ρ_call =  K·T·e^(−r·T)·Φ(d2)             (annualised, then ÷100 → per-1%-rate)
- *   ρ_put  = −K·T·e^(−r·T)·Φ(−d2)
- * </pre>
- */
 @Component
 public class GreeksCalculator {
 
@@ -33,7 +12,6 @@ public class GreeksCalculator {
     this.config = config;
   }
 
-  /** Compute all five Greeks for {@code contract}. */
   public Greeks compute(OptionContract contract) {
     DiscountedTerms terms = DiscountedTerms.from(contract);
     double s = contract.spot();

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/GreeksResponse.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/GreeksResponse.java
@@ -1,6 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/** Response body for {@code POST /api/options/greeks}. */
 public record GreeksResponse(String symbol, OptionType type, Greeks greeks) {
 
   static GreeksResponse of(OptionPricingRequest request, Greeks greeks) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityCalculator.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityCalculator.java
@@ -2,18 +2,6 @@ package com.mariaalpha.strategyengine.options;
 
 import org.springframework.stereotype.Component;
 
-/**
- * Solves for the implied volatility that makes {@link BlackScholesPricer} reproduce an observed
- * market premium.
- *
- * <p>Strategy: Newton-Raphson seeded at {@code σ₀ = 0.20} using the analytic vega as the
- * derivative, with bisection on {@code [impliedVolLowerBound, impliedVolUpperBound]} as the
- * fallback. Newton is fast (quadratic) but unstable at low vega — the bisection guard ensures we
- * always return a value when one exists in the configured bracket.
- *
- * <p>Returned object carries the converged sigma plus the number of iterations and the method that
- * produced it, so the REST response can show "12 Newton steps, residual 4e-9" for transparency.
- */
 @Component
 public class ImpliedVolatilityCalculator {
 
@@ -27,17 +15,6 @@ public class ImpliedVolatilityCalculator {
     this.config = config;
   }
 
-  /**
-   * Solve {@code BlackScholes(σ; spot, strike, T, r, q, type) == marketPrice}.
-   *
-   * @param spot underlying spot price (S, &gt; 0)
-   * @param strike strike (K, &gt; 0)
-   * @param timeToExpiryYears years to expiry (T, &gt; 0)
-   * @param riskFreeRate continuously-compounded risk-free rate (r)
-   * @param dividendYield continuous dividend yield (q, &ge; 0)
-   * @param type CALL or PUT
-   * @param marketPrice observed premium to invert; must be strictly inside the no-arbitrage band
-   */
   public Result solve(
       double spot,
       double strike,
@@ -84,7 +61,6 @@ public class ImpliedVolatilityCalculator {
       if (Math.abs(residual) <= config.impliedVolTolerance()) {
         return new Result(sigma, iteration, Method.NEWTON, residual);
       }
-      // analytic vega (annualised, raw — not the per-1%-scaled form GreeksCalculator returns)
       BlackScholesPricer.DiscountedTerms terms = BlackScholesPricer.DiscountedTerms.from(trial);
       double vega = terms.discountedSpot() * NormalDistribution.pdf(terms.d1()) * terms.sqrtT();
       if (vega < 1.0e-8) {
@@ -159,10 +135,8 @@ public class ImpliedVolatilityCalculator {
             spot, strike, timeToExpiryYears, sigma, riskFreeRate, dividendYield, type));
   }
 
-  /** Implied-vol solver outcome. */
   public record Result(double impliedVolatility, int iterations, Method method, double residual) {}
 
-  /** Which solver produced the implied vol. */
   public enum Method {
     NEWTON,
     BISECTION

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityRequest.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityRequest.java
@@ -1,10 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/**
- * Request body for {@code POST /api/options/implied-volatility}. Same shape as {@link
- * OptionPricingRequest} but replaces {@code volatility} with {@code marketPrice} — the observed
- * premium we want to invert.
- */
 public record ImpliedVolatilityRequest(
     String symbol,
     double spot,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityResponse.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityResponse.java
@@ -1,6 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/** Response body for {@code POST /api/options/implied-volatility}. */
 public record ImpliedVolatilityResponse(
     String symbol,
     OptionType type,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/NormalDistribution.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/NormalDistribution.java
@@ -1,16 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/**
- * Standard normal CDF (Φ) and PDF (φ).
- *
- * <p>The CDF uses Abramowitz &amp; Stegun 26.2.17 — a five-term rational approximation accurate to
- * about 7.5×10⁻⁸ across the entire real line, which is more than enough for option pricing
- * (Black-Scholes prices are stable to ~10⁻⁵ at typical inputs and our integration tests target
- * 4-decimal agreement with textbook values).
- *
- * <p>Pulled into its own class so {@link BlackScholesPricer} and {@link GreeksCalculator} share
- * exactly one implementation, and so unit tests can exercise it in isolation.
- */
 final class NormalDistribution {
 
   private static final double INV_SQRT_TWO_PI = 1.0 / Math.sqrt(2.0 * Math.PI);
@@ -22,19 +11,12 @@ final class NormalDistribution {
   private static final double A5 = 1.330274429;
   private static final double GAMMA = 0.2316419;
 
-  private NormalDistribution() {
-    // utility
-  }
+  private NormalDistribution() {}
 
-  /** Standard normal probability density φ(x) = (1/√(2π)) · exp(-x²/2). */
   static double pdf(double x) {
     return INV_SQRT_TWO_PI * Math.exp(-0.5 * x * x);
   }
 
-  /**
-   * Standard normal cumulative distribution Φ(x). Uses the A&amp;S 26.2.17 rational approximation
-   * for x ≥ 0 and the reflection Φ(-x) = 1 − Φ(x) for x &lt; 0.
-   */
   static double cdf(double x) {
     if (Double.isNaN(x)) {
       return Double.NaN;

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionContract.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionContract.java
@@ -1,26 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/**
- * Inputs to the Black-Scholes-Merton model for a European option on a single underlying with a
- * continuous dividend yield.
- *
- * <ul>
- *   <li>{@code spot} — current price of the underlying (S), &gt; 0.
- *   <li>{@code strike} — exercise price (K), &gt; 0.
- *   <li>{@code timeToExpiryYears} — calendar-time to expiry in years (T), &gt; 0. e.g. 0.25 for a
- *       three-month option.
- *   <li>{@code volatility} — annualised volatility of log-returns (σ), &gt; 0. 0.25 means 25%/yr.
- *   <li>{@code riskFreeRate} — annualised continuously-compounded risk-free rate (r). Allowed to be
- *       negative; e.g. 0.05 for 5%.
- *   <li>{@code dividendYield} — annualised continuous dividend yield (q), &ge; 0. Use 0 for
- *       non-dividend-paying equities.
- *   <li>{@code type} — {@link OptionType#CALL} or {@link OptionType#PUT}.
- * </ul>
- *
- * <p>The compact constructor rejects non-positive values for {@code spot}, {@code strike}, {@code
- * timeToExpiryYears}, and {@code volatility}, and a negative {@code dividendYield} — the rest of
- * the pipeline can therefore trust the contract.
- */
 public record OptionContract(
     double spot,
     double strike,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionPricingRequest.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionPricingRequest.java
@@ -1,11 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/**
- * Request body for {@code POST /api/options/price} and {@code POST /api/options/greeks}. Mirrors
- * {@link OptionContract} one-for-one — kept as a separate record so the controller can stay free of
- * the constructor-time validation thrown by {@link OptionContract}, and so future request fields
- * (e.g. {@code symbol}, {@code contractSize}) can be added without disturbing the math.
- */
 public record OptionPricingRequest(
     String symbol,
     double spot,
@@ -16,7 +10,6 @@ public record OptionPricingRequest(
     double dividendYield,
     OptionType type) {
 
-  /** Convert to the math-layer {@link OptionContract}. */
   public OptionContract toContract() {
     return new OptionContract(
         spot, strike, timeToExpiryYears, volatility, riskFreeRate, dividendYield, type);

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionPricingResponse.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionPricingResponse.java
@@ -1,10 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/**
- * Response body for {@code POST /api/options/price} — the theoretical premium plus the full Greek
- * bundle. The echoed {@code symbol} / {@code type} keep the response self-describing so the UI can
- * render a row of contracts side-by-side without holding onto the request.
- */
 public record OptionPricingResponse(String symbol, OptionType type, double price, Greeks greeks) {
 
   static OptionPricingResponse of(OptionPricingRequest request, double price, Greeks greeks) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionPricingService.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionPricingService.java
@@ -4,11 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Façade that bundles {@link BlackScholesPricer} + {@link GreeksCalculator} into a single call so
- * the REST controller, future option strategies, and risk checks can ask for "everything I need
- * about this contract" in one shot.
- */
 @Component
 public class OptionPricingService {
 
@@ -25,7 +20,6 @@ public class OptionPricingService {
     this.metrics = metrics;
   }
 
-  /** Theoretical fair value of {@code contract}. */
   public double price(OptionContract contract) {
     long start = System.nanoTime();
     double premium = pricer.price(contract);
@@ -33,12 +27,10 @@ public class OptionPricingService {
     return premium;
   }
 
-  /** Five-Greek sensitivity bundle for {@code contract}. */
   public Greeks greeks(OptionContract contract) {
     return greeksCalculator.compute(contract);
   }
 
-  /** Combined price + Greeks in one pass. */
   public Priced priceWithGreeks(OptionContract contract) {
     long start = System.nanoTime();
     double premium = pricer.price(contract);
@@ -57,6 +49,5 @@ public class OptionPricingService {
     return new Priced(premium, greeks);
   }
 
-  /** Result of {@link #priceWithGreeks(OptionContract)}. */
   public record Priced(double price, Greeks greeks) {}
 }

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionType.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionType.java
@@ -1,6 +1,5 @@
 package com.mariaalpha.strategyengine.options;
 
-/** European option payoff direction. */
 public enum OptionType {
   CALL,
   PUT

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionsController.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionsController.java
@@ -8,20 +8,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-/**
- * Options pricing endpoints (roadmap 3.2.1 / 3.2.2).
- *
- * <ul>
- *   <li>{@code POST /api/options/price} — Black-Scholes-Merton premium + the full Greek bundle.
- *   <li>{@code POST /api/options/greeks} — Greeks only (slightly cheaper if the caller already
- *       priced the contract).
- *   <li>{@code POST /api/options/implied-volatility} — invert an observed market premium to a
- *       volatility using {@link ImpliedVolatilityCalculator}.
- * </ul>
- *
- * <p>Validation lives in {@link OptionContract}'s compact constructor — bad inputs surface as
- * {@code 400 Bad Request} via the {@link IllegalArgumentException} translator below.
- */
 @RestController
 @RequestMapping("/api/options")
 public class OptionsController {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionsMetrics.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionsMetrics.java
@@ -7,7 +7,6 @@ import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.TimeUnit;
 import org.springframework.stereotype.Component;
 
-/** Per-component instrumentation for the options pricing module (roadmap 3.2.1 / 3.2.2). */
 @Component
 public class OptionsMetrics {
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionsPricingConfig.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/options/OptionsPricingConfig.java
@@ -2,24 +2,6 @@ package com.mariaalpha.strategyengine.options;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Knobs for the options pricing module (3.2.1 / 3.2.2).
- *
- * <ul>
- *   <li>{@link #thetaDayCount()} — denominator used to convert annualised Theta into a per-day
- *       number. Two conventions in industry use: {@code 365} (calendar) and {@code 252} (trading).
- *       Defaults to 365 so the UI matches Bloomberg's OVME.
- *   <li>{@link #impliedVolMaxIterations()} — Newton-Raphson cap before the implied-vol solver gives
- *       up and falls back to bisection. Defaults to 100, which leaves plenty of headroom past the
- *       quadratic convergence point.
- *   <li>{@link #impliedVolTolerance()} — absolute tolerance on the price residual for the
- *       implied-vol solver. Defaults to {@code 1e-6} dollars; below that, floating-point noise in
- *       {@code NormalDistribution.cdf} dominates the residual.
- *   <li>{@link #impliedVolLowerBound()} / {@link #impliedVolUpperBound()} — bracket for the
- *       bisection fallback. {@code [0.0001, 5.0]} spans &lt;1%/yr to 500%/yr — outside that range
- *       an option is either pinned to intrinsic value or the inputs are wrong.
- * </ul>
- */
 @ConfigurationProperties(prefix = "strategy-engine.options")
 public record OptionsPricingConfig(
     double thetaDayCount,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/publisher/SignalPublisher.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/publisher/SignalPublisher.java
@@ -45,9 +45,6 @@ public class SignalPublisher {
           signal.symbol(),
           signal.quantity(),
           signal.limitPrice());
-      // Roadmap 3.4.5 — fan out a SIGNAL_EMITTED event for any active algo order tracking
-      // this symbol so WebSocket subscribers see live progress. Done best-effort; signal
-      // publication is the source of truth, the algo-progress topic is a UI convenience.
       algoOrderRegistry
           .activeForSymbol(signal.symbol())
           .forEach(algo -> algoProgressPublisher.publishSignalEmitted(algo, signal));

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/MarketStateCache.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/MarketStateCache.java
@@ -9,15 +9,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
-/**
- * Per-symbol cache of the latest bid/ask/last + a bounded ring of mid-prices used by {@link
- * VolatilityTracker} for realised-volatility estimation. Populated from the same Kafka tick stream
- * the strategy engine already consumes.
- *
- * <p>The cache is intentionally service-local. Reads on the RFQ hot path are sub-microsecond and
- * the data is reconstructable from the next tick — perfect for an in-process map. A future
- * Redis-backed roll-out would replace this with the shared order-book cache.
- */
 @Component
 public class MarketStateCache {
 
@@ -41,7 +32,6 @@ public class MarketStateCache {
     return state == null ? Optional.empty() : Optional.of(state.snapshot(symbol));
   }
 
-  /** Returns an unmodifiable, point-in-time copy of the rolling mid-price history. */
   public Optional<double[]> midHistory(String symbol) {
     var state = stateBySymbol.get(symbol);
     return state == null ? Optional.empty() : Optional.of(state.midHistory());

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/PositionLookup.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/PositionLookup.java
@@ -14,21 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/**
- * Looks up the desk's current net position in a single symbol from the Order Manager REST API. Used
- * by {@link RfqPricingEngine} to skew the mid for inventory.
- *
- * <p>Falls back to a flat position (zero net quantity) when:
- *
- * <ul>
- *   <li>the Order Manager returns 404 (symbol never traded yet);
- *   <li>the HTTP call times out or errors (so RFQ pricing degrades to symmetric quoting around mid
- *       rather than blocking on a downstream stall).
- * </ul>
- *
- * <p>The 500ms default timeout is small on purpose — RFQ pricing is a foreground UI call and the
- * trader sees the resulting quote within a few seconds.
- */
 @Component
 public class PositionLookup {
 
@@ -85,7 +70,6 @@ public class PositionLookup {
     }
   }
 
-  /** What the RFQ pricing engine needs to know about a symbol's current position. */
   public record PositionView(
       String symbol, BigDecimal netQuantity, BigDecimal lastMarkPrice, boolean available) {
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqAcceptRequest.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqAcceptRequest.java
@@ -4,5 +4,4 @@ import com.mariaalpha.strategyengine.model.Side;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-/** Request body for {@code POST /api/rfq/accept}. */
 public record RfqAcceptRequest(UUID quoteId, Side side, BigDecimal price) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqController.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqController.java
@@ -17,18 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-/**
- * RFQ pricing endpoints (FR-40 / TDD §2.6.2).
- *
- * <ul>
- *   <li>{@code POST /api/rfq/quote} — returns a two-way quote built by {@link RfqPricingEngine}.
- *   <li>{@code POST /api/rfq/accept} — accepts a previously issued quote (by id), validates
- *       freshness and the requested side+price, and publishes an {@link OrderSignal} for the
- *       Execution Engine to pick up via the regular signals topic.
- *   <li>{@code GET /api/rfq/quotes/{id}} — debug endpoint, returns whatever the store remembers
- *       about a quote (active or expired).
- * </ul>
- */
 @RestController
 @RequestMapping("/api/rfq")
 public class RfqController {
@@ -55,7 +43,6 @@ public class RfqController {
     this.config = config;
   }
 
-  /** Compute an inventory- and vol-aware RFQ quote. */
   @PostMapping("/quote")
   public ResponseEntity<RfqQuoteResponse> quote(@RequestBody RfqQuoteRequest request) {
     if (request == null) {
@@ -72,7 +59,6 @@ public class RfqController {
     }
   }
 
-  /** Accept a previously issued RFQ quote and publish an order signal. */
   @PostMapping("/accept")
   public ResponseEntity<RfqAcceptResponse> accept(@RequestBody RfqAcceptRequest request) {
     if (request == null
@@ -124,7 +110,6 @@ public class RfqController {
         new RfqAcceptResponse(quote.quoteId(), quote.symbol(), signal, "ACCEPTED"));
   }
 
-  /** Look up a previously issued RFQ quote (debug). */
   @GetMapping("/quotes/{quoteId}")
   public ResponseEntity<RfqQuoteResponse> getQuote(@PathVariable java.util.UUID quoteId) {
     return quoteStore

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqMetrics.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqMetrics.java
@@ -5,7 +5,6 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
-/** Per-component instrumentation for the RFQ pricing engine (issues 2.4.1 + 2.4.2). */
 @Component
 public class RfqMetrics {
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqPricingConfig.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqPricingConfig.java
@@ -2,28 +2,6 @@ package com.mariaalpha.strategyengine.rfq;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Knobs for the RFQ pricing engine.
- *
- * <ul>
- *   <li>{@link #baseSpreadBps()} — symmetric spread applied around the (inventory-skewed) mid;
- *       splits 50/50 into bid and ask half-spreads.
- *   <li>{@link #inventoryLambda()} — half-skew applied to the mid per unit of inventory notional,
- *       expressed as a fraction. e.g. 0.0001 with $1M of long inventory and a $1M neutral-notional
- *       shifts the mid down by 0.0001 × ($1M / $1M) = 1 bp. Positive shift down when long; up when
- *       short.
- *   <li>{@link #inventoryNeutralNotional()} — denominator for the inventory skew; the desk's "soft
- *       limit" in USD.
- *   <li>{@link #inventoryMaxSkewBps()} — cap on the inventory mid-shift so a runaway position can't
- *       push the quote arbitrarily far from market mid.
- *   <li>{@link #volScalar()} — multiplier on realised volatility (bps per look-back window) added
- *       to the half-spread on each side.
- *   <li>{@link #advScalar()} — multiplier on size/ADV (expressed in bps) added to the half-spread.
- *   <li>{@link #quoteValidityMs()} — TTL on emitted quotes; UI uses this as the count-down.
- *   <li>{@link #orderManagerBaseUrl()} — base URL used by the position lookup.
- *   <li>{@link #positionLookupTimeoutMs()} — caps the HTTP wait for an order-manager position read.
- * </ul>
- */
 @ConfigurationProperties(prefix = "strategy-engine.rfq")
 public record RfqPricingConfig(
     double baseSpreadBps,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqPricingEngine.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqPricingEngine.java
@@ -10,23 +10,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/**
- * Two-way RFQ quote generator combining inventory skew and volatility + size/ADV widening.
- *
- * <p>Pricing pipeline per quote request:
- *
- * <ol>
- *   <li>Fetch market mid from {@link MarketStateCache}; reject if no book yet.
- *   <li>Fetch current desk position from {@link PositionLookup}; treat missing as flat.
- *   <li>Compute inventory skew on the <em>mid</em> — long inventory pushes mid down (offload),
- *       short pushes it up (cover). Capped at {@code inventoryMaxSkewBps} so a runaway position
- *       can't shove the quote arbitrarily far.
- *   <li>Compute realised volatility (bps) over the rolling window via {@link VolatilityTracker}.
- *   <li>Compute size-as-percent-of-ADV.
- *   <li>Assemble half-spread = base/2 + volScalar × vol + advScalar × (size/ADV in bps).
- *   <li>Bid = adjusted_mid × (1 − half-spread); Ask = adjusted_mid × (1 + half-spread).
- * </ol>
- */
 @Component
 public class RfqPricingEngine {
 
@@ -90,7 +73,6 @@ public class RfqPricingEngine {
     var snapshot = snapshotOpt.get();
     BigDecimal marketMid = snapshot.mid();
 
-    // --- Inventory skew -------------------------------------------------------
     var position = positionLookup.fetch(symbol);
     double netQty = position.netQuantity().doubleValue();
     double inventoryNotional = netQty * marketMid.doubleValue();
@@ -101,16 +83,13 @@ public class RfqPricingEngine {
         clamp(rawSkewBps, -config.inventoryMaxSkewBps(), config.inventoryMaxSkewBps());
     BigDecimal adjustedMid = marketMid.multiply(BigDecimal.valueOf(1.0 - cappedSkewBps / 10_000.0));
 
-    // --- Volatility widening --------------------------------------------------
     double realizedVolBps = volatilityTracker.realizedVolBps(symbol);
     double volWideningBps = config.volScalar() * realizedVolBps;
 
-    // --- ADV widening ---------------------------------------------------------
     long adv = refData.advOf(symbol);
     double advFraction = adv <= 0 ? 0.0 : (double) quantity / (double) adv;
     double advWideningBps = config.advScalar() * advFraction * 10_000.0;
 
-    // --- Assemble spread ------------------------------------------------------
     double baseHalfSpreadBps = config.baseSpreadBps() / 2.0;
     double totalHalfSpreadBps = baseHalfSpreadBps + volWideningBps + advWideningBps;
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuote.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuote.java
@@ -4,11 +4,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * A two-way RFQ quote, including the per-component breakdown used to assemble it. The breakdown is
- * what makes inventory / volatility / ADV widening auditable — the UI surfaces it next to the
- * quote, and TCA replays it for the accepted-price reconstruction.
- */
 public record RfqQuote(
     UUID quoteId,
     String symbol,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuoteRequest.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuoteRequest.java
@@ -1,4 +1,3 @@
 package com.mariaalpha.strategyengine.rfq;
 
-/** Request body for {@code POST /api/rfq/quote}. */
 public record RfqQuoteRequest(String symbol, int quantity) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuoteResponse.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuoteResponse.java
@@ -4,11 +4,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Response body for {@code POST /api/rfq/quote}. The breakdown fields are stable for UI consumption
- * — the React RFQ panel reads them to show inventory / vol / ADV contributions next to the bid +
- * ask, so traders can sanity-check why a particular quote came out where it did.
- */
 public record RfqQuoteResponse(
     UUID quoteId,
     String symbol,

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuoteStore.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqQuoteStore.java
@@ -8,11 +8,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/**
- * Short-lived in-memory store of issued RFQ quotes so that the accept endpoint can validate quoteId
- * + freshness. Quotes are evicted on a best-effort basis when looked up after expiry — a dedicated
- * reaper is over-engineered for the volume this endpoint sees.
- */
 @Component
 public class RfqQuoteStore {
 
@@ -32,7 +27,6 @@ public class RfqQuoteStore {
     quotes.put(quote.quoteId(), quote);
   }
 
-  /** Returns the quote if present and not yet expired; evicts expired entries on the way out. */
   public Optional<RfqQuote> lookupActive(UUID quoteId) {
     var q = quotes.get(quoteId);
     if (q == null) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqSymbolReferenceConfig.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqSymbolReferenceConfig.java
@@ -3,16 +3,6 @@ package com.mariaalpha.strategyengine.rfq;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Per-symbol reference data for RFQ pricing: ADV used in the size/ADV spread widening term. Sectors
- * and betas are tracked alongside for forward-compatibility with later RFQ pricing extensions (e.g.
- * issuer-level beta tiering), but the pricing engine today only reads {@code adv}.
- *
- * <p>Mirrors the execution-engine's {@code SymbolReferenceConfig} layout intentionally — both
- * services own their own reference data per the §5.4 ownership rule. {@code defaults} provides a
- * conservative fall-back ADV for any unmapped symbol so the spread widening still kicks in for new
- * tickers.
- */
 @ConfigurationProperties(prefix = "strategy-engine.rfq.reference-data")
 public record RfqSymbolReferenceConfig(List<SymbolRef> symbols, SymbolRef defaults) {
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqSymbolReferenceData.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/RfqSymbolReferenceData.java
@@ -8,11 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Symbol-keyed ADV / sector / beta lookup used by the RFQ pricing engine. Implementation parallels
- * the execution-engine's {@code SymbolReferenceData} — kept service-local because each service owns
- * its own config per the TDD §5.4 ownership rule.
- */
 @Component
 public class RfqSymbolReferenceData {
 

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/VolatilityTracker.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/rfq/VolatilityTracker.java
@@ -23,7 +23,6 @@ public class VolatilityTracker {
     this.cache = cache;
   }
 
-  /** Sample stdev of log returns, expressed in basis points (1 bp = 1e-4). */
   public double realizedVolBps(String symbol) {
     var history = cache.midHistory(symbol).orElse(new double[0]);
     if (history.length < 2) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/routing/RegimeBasedStrategySelector.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/routing/RegimeBasedStrategySelector.java
@@ -11,23 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * FR-17 implementation: maps the current ML regime classification for a symbol to a strategy. The
- * selector is consulted by {@code StrategyEvaluationService} before falling back to the manually
- * bound strategy in {@link SymbolStrategyRouter}, and only returns a strategy when:
- *
- * <ol>
- *   <li>auto-select is enabled in config,
- *   <li>the ML service returns a regime (i.e. the gRPC call succeeded and the circuit breaker is
- *       closed),
- *   <li>the regime confidence meets the configured threshold,
- *   <li>the regime has a configured mapping (HIGH_VOLATILITY and UNKNOWN are unmapped by default),
- *   <li>and that mapped strategy is registered in the {@link StrategyRegistry}.
- * </ol>
- *
- * Any other case returns {@link Optional#empty()} so the caller falls through to the user's manual
- * binding.
- */
 @Component
 public class RegimeBasedStrategySelector {
 
@@ -51,7 +34,6 @@ public class RegimeBasedStrategySelector {
         regimeMap);
   }
 
-  /** Returns the strategy the regime model recommends for {@code symbol}, or empty. */
   public Optional<TradingStrategy> selectFor(String symbol) {
     if (!config.enabled()) {
       return Optional.empty();

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/routing/SymbolStrategyRouter.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/routing/SymbolStrategyRouter.java
@@ -21,10 +21,6 @@ public class SymbolStrategyRouter {
     this.registry = registry;
   }
 
-  /**
-   * Binds {@code symbol} to {@code strategyName}. Returns {@code true} if the strategy is
-   * registered, {@code false} if the name is unknown (mapping is not changed in that case).
-   */
   public boolean setActiveStrategy(String symbol, String strategyName) {
     if (registry.get(strategyName).isEmpty()) {
       LOG.warn("Cannot route {} → {}: strategy not found", symbol, strategyName);
@@ -35,28 +31,18 @@ public class SymbolStrategyRouter {
     return true;
   }
 
-  /** Returns the strategy name currently bound to {@code symbol}, or empty if none. */
   public Optional<String> getActiveStrategyName(String symbol) {
     return Optional.ofNullable(symbolToStrategy.get(symbol));
   }
 
-  /** Returns the live {@link TradingStrategy} bound to {@code symbol}, or empty if none. */
   public Optional<TradingStrategy> getActiveStrategy(String symbol) {
     return getActiveStrategyName(symbol).flatMap(registry::get);
   }
 
-  /** Returns an immutable snapshot of all currently routed symbols. */
   public Set<String> routedSymbols() {
     return Set.copyOf(symbolToStrategy.keySet());
   }
 
-  /**
-   * Removes any active strategy binding for {@code symbol}, so subsequent ticks for that symbol no
-   * longer reach a strategy. Returns {@code true} if a binding existed and was removed. Used by e2e
-   * tests to detach a stateful strategy (e.g. MOMENTUM on GOOGL) once their assertion has been met,
-   * preventing the strategy from continuing to oscillate in the background and contending with
-   * later tests for the simulated venue queue.
-   */
   public boolean clearActiveStrategy(String symbol) {
     var previous = symbolToStrategy.remove(symbol);
     if (previous != null) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/service/StrategyEvaluationService.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/service/StrategyEvaluationService.java
@@ -44,16 +44,11 @@ public class StrategyEvaluationService {
   }
 
   public void evaluate(MarketTick tick) {
-    // Roadmap 3.1.3 — drop ticks for markets that are closed at the tick's timestamp so
     // indicator-driven strategies (Momentum's EMAs / RSI) don't drift on out-of-hours quotes.
-    // The gate is a soft no-op when disabled in config, preserving pre-3.1.3 behaviour.
     if (!tradingHoursService.isMarketOpen(tick.symbol(), tick.timestamp())) {
       metrics.recordTickSuppressed(tick.symbol(), "market_closed");
       return;
     }
-    // FR-17: when regime auto-select is enabled and the ML service produces a high-confidence
-    // regime, route to the strategy the regime prescribes. Otherwise fall back to the manual
-    // SymbolStrategyRouter binding.
     var strategyOptional = regimeSelector.selectFor(tick.symbol());
     if (strategyOptional.isEmpty()) {
       strategyOptional = router.getActiveStrategy(tick.symbol());

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/sessions/TradingHoursConfig.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/sessions/TradingHoursConfig.java
@@ -11,21 +11,6 @@ import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
-/**
- * Per-market trading-session schedule (roadmap 3.1.3 — multi-market trading hours).
- *
- * <p>A {@link MarketSchedule} carries a timezone (so each session's open / close are in local
- * time), a list of {@link SessionWindow}s (TSE has two — the morning Zenba and afternoon Goba, US
- * markets have one continuous session, LSE has one), a set of trading days, and an optional holiday
- * list.
- *
- * <p>Symbols pick their market via {@link #symbolOverrides()}; symbols not listed fall back to
- * {@link #defaultMarket()}. The {@link #enabled()} flag is a soft feature gate — when {@code false}
- * the service treats every market as 24/7 open, matching the pre-3.1.3 behaviour.
- *
- * <p>FX conversion is unrelated and lives separately (see {@code order-manager.currency} + {@code
- * CurrencyExposureService}).
- */
 @ConfigurationProperties(prefix = "strategy-engine.trading-hours")
 public record TradingHoursConfig(
     boolean enabled,
@@ -40,7 +25,6 @@ public record TradingHoursConfig(
     symbolOverrides = normaliseOverrides(symbolOverrides);
   }
 
-  /** Resolves the market name a symbol belongs to (override first, then default). */
   public String marketFor(String symbol) {
     if (symbol == null) {
       return defaultMarket;
@@ -62,7 +46,6 @@ public record TradingHoursConfig(
     return Map.copyOf(copy);
   }
 
-  /** A single market's session calendar. */
   public record MarketSchedule(
       ZoneId timezone,
       List<SessionWindow> sessions,
@@ -87,11 +70,6 @@ public record TradingHoursConfig(
     }
   }
 
-  /**
-   * One contiguous open-to-close window in the market's local time. TSE has two (Zenba / Goba),
-   * NYSE / NASDAQ / LSE have one; some venues (after-hours / extended trading) would have a third.
-   * Inclusive open, exclusive close — matches the convention every exchange API uses.
-   */
   public record SessionWindow(LocalTime open, LocalTime close) {
     public SessionWindow {
       if (open == null || close == null) {

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/sessions/TradingHoursService.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/sessions/TradingHoursService.java
@@ -11,18 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-/**
- * Resolves whether a symbol's market is currently trading at a given timestamp (roadmap 3.1.3).
- *
- * <p>Used by {@code StrategyEvaluationService} as an early-exit gate: ticks that arrive outside the
- * resolved market's session windows are dropped before the strategy sees them. Keeping after-hours
- * ticks out of strategy state matters most for indicator-driven strategies (Momentum's EMAs / RSI
- * would otherwise drift on stale quotes).
- *
- * <p>When {@code enabled=false} the service short-circuits to "always open" so the pre-3.1.3
- * behaviour is preserved with zero config change. Single-market deployments only need to ensure
- * {@code default-market}'s schedule is configured.
- */
 @Service
 public class TradingHoursService {
 
@@ -40,11 +28,6 @@ public class TradingHoursService {
     }
   }
 
-  /**
-   * Returns whether {@code symbol}'s market is open at {@code timestamp}. Always returns {@code
-   * true} when the gate is disabled. Falls back to {@code true} when the resolved market is not
-   * configured — refusing to gate beats silently dropping every tick due to a missing entry.
-   */
   public boolean isMarketOpen(String symbol, Instant timestamp) {
     if (!config.enabled()) {
       return true;
@@ -61,16 +44,10 @@ public class TradingHoursService {
             });
   }
 
-  /** Returns the market name a symbol resolves to. */
   public String marketFor(String symbol) {
     return config.marketFor(symbol);
   }
 
-  /**
-   * Looks up the {@link MarketSchedule} for a symbol. Useful for diagnostics endpoints and the
-   * forthcoming `/api/strategies/state` integration that surfaces market status alongside strategy
-   * status.
-   */
   public Optional<MarketSchedule> scheduleFor(String symbol) {
     var name = config.marketFor(symbol);
     return Optional.ofNullable(config.markets().get(name));

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/close/CloseSlice.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/close/CloseSlice.java
@@ -2,13 +2,4 @@ package com.mariaalpha.strategyengine.strategy.close;
 
 import java.time.LocalTime;
 
-/**
- * One equal-duration time interval of a Close strategy's <em>pre-close</em> working window,
- * half-open {@code [startTime, endTime)} in the market time zone.
- *
- * <p>Identical in shape to TWAP's slice — the pre-close window {@code [windowStart, mocCutoff)} is
- * divided into evenly spaced intervals. What differs is that only a configurable {@code
- * preCloseFraction} of the parent quantity is distributed across these slices; the remainder is
- * reserved for the Market-on-Close (MOC) child that fires once at {@code mocCutoff}.
- */
 public record CloseSlice(LocalTime startTime, LocalTime endTime) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/close/CloseStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/close/CloseStrategy.java
@@ -18,33 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Close (Market-on-Close benchmark) execution strategy.
- *
- * <p>The Close algorithm targets the official closing-auction price as its benchmark — the routine
- * choice for index funds, ETF rebalances, and any flow tagged "MOC". The MariaAlpha implementation
- * is a <em>working-into-the-close</em> variant: a configurable {@code preCloseFraction} of the
- * parent is worked as TWAP-style LIMIT slices through a pre-close window {@code [windowStart,
- * mocCutoff)}, and the remainder is sent as a single MARKET (MOC-equivalent) child at {@code
- * mocCutoff = closeTime − mocOffsetMinutes}. The pre-close working dampens impact on the close
- * auction itself; the MOC clip captures the closing print.
- *
- * <ul>
- *   <li>{@code preCloseFraction = 0} → pure MOC: one MARKET order at the cutoff for the whole
- *       parent (the canonical Market-on-Close behaviour).
- *   <li>{@code preCloseFraction = 1} → working-only: TWAP-into-the-close with no closing-auction
- *       clip; the MOC fires for zero shares.
- *   <li>{@code numPreCloseSlices = 0} or {@code windowStart ≥ mocCutoff} → degenerate pre-close
- *       schedule, all quantity flows through the MOC.
- * </ul>
- *
- * <p>If the strategy is bound after {@code mocCutoff} but before {@code closeTime}, the first tick
- * fires the MOC for whatever has not yet been emitted. If it is bound after {@code closeTime}, a
- * defensive MARKET sweep emits the leftover so a late-arriving parent still leaves the strategy.
- * The market clock is driven by tick timestamps (in {@code America/New_York}), not the wall clock —
- * so unit tests and historical replays behave identically to live trading. See {@code
- * docs/close-strategy-explainer.md}.
- */
 @Component
 public class CloseStrategy implements TradingStrategy {
 
@@ -55,7 +28,6 @@ public class CloseStrategy implements TradingStrategy {
   private static final double DEFAULT_PRE_CLOSE_FRACTION = 0.30;
   private static final int DEFAULT_MOC_OFFSET_MINUTES = 5;
 
-  // Configuration parameters
   private volatile int targetQuantity;
   private Side side = Side.BUY;
   private LocalTime windowStart = LocalTime.of(15, 30);
@@ -64,12 +36,10 @@ public class CloseStrategy implements TradingStrategy {
   private volatile double preCloseFraction = DEFAULT_PRE_CLOSE_FRACTION;
   private volatile int numPreCloseSlices = DEFAULT_NUM_PRE_CLOSE_SLICES;
 
-  // Derived pre-close schedule + allocations
   private final List<CloseSlice> preCloseSlices = new ArrayList<>();
   private final List<Integer> sliceAllocations = new ArrayList<>();
   private volatile int mocAllocation;
 
-  // Execution state
   private final ConcurrentHashMap<Integer, Boolean> sliceExecuted = new ConcurrentHashMap<>();
   private volatile boolean mocFired;
   private volatile MarketTick latestTick;
@@ -105,18 +75,15 @@ public class CloseStrategy implements TradingStrategy {
       return Optional.empty();
     }
 
-    // Past close — defensive sweep in case the MOC was missed (e.g. late binding).
     if (!marketTime.isBefore(closeTime)) {
       return emitSweep(symbol);
     }
 
-    // MOC cutoff reached: fire the MOC clip (catches any skipped pre-close slices).
     var mocCutoff = mocCutoff();
     if (!marketTime.isBefore(mocCutoff)) {
       return emitMoc(symbol);
     }
 
-    // Pre-close working window: emit the slice's LIMIT clip, at-most-once per slice.
     int sliceIndex = findSliceIndex(marketTime);
     if (sliceIndex < 0 || sliceIndex >= sliceAllocations.size()) {
       return Optional.empty();
@@ -187,19 +154,11 @@ public class CloseStrategy implements TradingStrategy {
     resetExecutionState();
   }
 
-  /** Returns the MOC cutoff time (closeTime minus mocOffsetMinutes), clamped at windowStart. */
   private LocalTime mocCutoff() {
     var cutoff = closeTime.minusMinutes(Math.max(0, mocOffsetMinutes));
-    // If the offset overshoots windowStart, MOC opens at windowStart (no pre-close window).
     return cutoff.isBefore(windowStart) ? windowStart : cutoff;
   }
 
-  /**
-   * Rebuilds the equal-duration pre-close slice schedule spanning {@code [windowStart, mocCutoff)}.
-   * Boundaries are computed in whole seconds from the window start so the final boundary lands
-   * exactly on {@code mocCutoff}. Produces no slices when the window is empty/inverted or {@code
-   * numPreCloseSlices <= 0}; in that case all quantity flows through the MOC.
-   */
   private void rebuildSchedule() {
     preCloseSlices.clear();
     var cutoff = mocCutoff();
@@ -216,12 +175,6 @@ public class CloseStrategy implements TradingStrategy {
     }
   }
 
-  /**
-   * Splits {@code targetQuantity} into per-pre-close-slice LIMIT allocations and a single MOC
-   * allocation. The last pre-close slice absorbs the rounding remainder so {@code
-   * sum(sliceAllocations) + mocAllocation == targetQuantity}. A {@code preCloseFraction} outside
-   * {@code [0, 1]} is clamped.
-   */
   private void computeAllocations() {
     sliceAllocations.clear();
     mocAllocation = 0;
@@ -245,7 +198,6 @@ public class CloseStrategy implements TradingStrategy {
     mocAllocation = targetQuantity - preCloseTotal;
   }
 
-  /** Resets execution state for a fresh run. */
   private void resetExecutionState() {
     sliceExecuted.clear();
     mocFired = false;
@@ -253,7 +205,6 @@ public class CloseStrategy implements TradingStrategy {
     completed = false;
   }
 
-  /** Resolves the limit price from the latest tick based on side. */
   private BigDecimal resolveLimitPrice() {
     if (side == Side.BUY) {
       var ask = latestTick.askPrice();
@@ -263,7 +214,6 @@ public class CloseStrategy implements TradingStrategy {
     return bid != null && bid.compareTo(BigDecimal.ZERO) > 0 ? bid : latestTick.price();
   }
 
-  /** Finds the pre-close slice index for the given market time. Returns -1 if not in any slice. */
   private int findSliceIndex(LocalTime marketTime) {
     for (var i = 0; i < preCloseSlices.size(); i++) {
       var slice = preCloseSlices.get(i);
@@ -274,7 +224,6 @@ public class CloseStrategy implements TradingStrategy {
     return -1;
   }
 
-  /** Sums the per-slice allocations of pre-close slices that have already fired. */
   private int sumExecutedFromPreCloseSlices() {
     int executed = 0;
     for (var entry : sliceExecuted.entrySet()) {
@@ -286,10 +235,6 @@ public class CloseStrategy implements TradingStrategy {
     return executed;
   }
 
-  /**
-   * Emits the MOC MARKET order at {@code mocCutoff}. Sweeps everything not yet emitted (planned MOC
-   * clip plus any skipped pre-close slices), so the parent leaves the strategy by the close.
-   */
   private Optional<OrderSignal> emitMoc(String symbol) {
     if (mocFired) {
       return Optional.empty();
@@ -305,10 +250,6 @@ public class CloseStrategy implements TradingStrategy {
             symbol, side, remaining, OrderType.MARKET, null, NAME, latestTick.timestamp()));
   }
 
-  /**
-   * Defensive post-close sweep. If the MOC has not fired (e.g. the strategy was bound after the
-   * close), emit a single MARKET order for whatever is outstanding so the parent does not strand.
-   */
   private Optional<OrderSignal> emitSweep(String symbol) {
     if (completed) {
       return Optional.empty();

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/momentum/MomentumStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/momentum/MomentumStrategy.java
@@ -16,36 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Momentum / trend-following execution strategy.
- *
- * <p>Unlike {@link com.mariaalpha.strategyengine.strategy.vwap.VwapStrategy} and {@link
- * com.mariaalpha.strategyengine.strategy.twap.TwapStrategy} — which slice a fixed parent order
- * across a time window — Momentum is a <em>signal-generating</em> strategy. It watches the price
- * tape, maintains a fast and a slow Exponential Moving Average (EMA) plus a Relative Strength Index
- * (RSI) and an average-volume baseline, and opens a fixed-size position when a trend confirms,
- * flattening it when the trend reverses, momentum exhausts, or a stop-loss trips.
- *
- * <p>For the long case ({@code side = BUY}):
- *
- * <ul>
- *   <li><b>Entry</b> — the fast EMA crosses <em>above</em> the slow EMA, RSI is not overbought, and
- *       the triggering trade's volume exceeds {@code volumeMultiplier ×} the recent average. Emits
- *       a {@code LIMIT} BUY of {@code tradeQuantity} shares at the best ask.
- *   <li><b>Exit</b> — the fast EMA crosses <em>below</em> the slow EMA, OR RSI reaches overbought,
- *       OR price falls {@code stopLossPct}% below the entry price. Emits a {@code MARKET} SELL of
- *       {@code tradeQuantity} shares to flatten.
- * </ul>
- *
- * <p>The short case ({@code side = SELL}) is the mirror image: enter short on a bearish crossover
- * with RSI not oversold, exit on a bullish crossover, RSI oversold, or stop-loss.
- *
- * <p>Indicators are driven by {@link EventType#TRADE} ticks (the canonical "last price" tape);
- * {@link EventType#QUOTE} ticks only refresh the best bid/ask used to price child orders and the
- * mark used for the stop-loss. Like VWAP/TWAP the strategy's clock is the tick stream, never the
- * wall clock, so it is fully deterministic and replayable. See {@code
- * docs/momentum-strategy-explainer.md}.
- */
 @Component
 public class MomentumStrategy implements TradingStrategy {
 
@@ -65,7 +35,6 @@ public class MomentumStrategy implements TradingStrategy {
     SHORT
   }
 
-  // Configuration parameters
   private int fastPeriod = 20;
   private int slowPeriod = 50;
   private int rsiPeriod = 14;
@@ -77,10 +46,8 @@ public class MomentumStrategy implements TradingStrategy {
   private Side side = Side.BUY;
   private double stopLossPct = 2.0;
 
-  // 0 means "auto" — warm up for {@code slowPeriod} trades before acting on a crossover.
   private int warmupTrades = 0;
 
-  // Rolling indicator state
   private final Deque<Long> volumeWindow = new ArrayDeque<>();
   private boolean emaSeeded;
   private double fastEma;
@@ -97,7 +64,6 @@ public class MomentumStrategy implements TradingStrategy {
   private long tradesObserved;
   private boolean lastTradeVolumeConfirmed;
 
-  // Execution state
   private Cross pendingCross = Cross.NONE;
   private Position position = Position.FLAT;
   private double entryPrice;
@@ -118,7 +84,6 @@ public class MomentumStrategy implements TradingStrategy {
     }
   }
 
-  /** Folds one trade into the EMA / RSI / volume state and records any EMA crossover. */
   private void ingestTrade(MarketTick tick) {
     tradesObserved++;
     double price = tick.price().doubleValue();
@@ -127,7 +92,6 @@ public class MomentumStrategy implements TradingStrategy {
       updateRsi(price - prevPrice);
     }
 
-    // Volume confirmation compares this trade against the average of the *preceding* trades.
     lastTradeVolumeConfirmed = volumeConfirmed(tick.size());
     pushVolume(tick.size());
 
@@ -149,7 +113,6 @@ public class MomentumStrategy implements TradingStrategy {
       return Optional.empty();
     }
 
-    // A crossover is a one-shot event: consume it whether or not it produces a signal.
     Cross cross = pendingCross;
     pendingCross = Cross.NONE;
 
@@ -160,7 +123,6 @@ public class MomentumStrategy implements TradingStrategy {
     };
   }
 
-  /** Opens a position when the configured entry side's confirmation conditions all hold. */
   private Optional<OrderSignal> tryEnter(String symbol, Cross cross) {
     if (side == Side.BUY
         && cross == Cross.BULLISH
@@ -199,7 +161,6 @@ public class MomentumStrategy implements TradingStrategy {
     return Optional.empty();
   }
 
-  /** Flattens a long position on a reverse crossover, overbought RSI, or stop-loss. */
   private Optional<OrderSignal> tryExitLong(String symbol, Cross cross) {
     String reason = longExitReason(cross);
     if (reason == null) {
@@ -211,7 +172,6 @@ public class MomentumStrategy implements TradingStrategy {
     return Optional.of(buildSignal(symbol, Side.SELL, OrderType.MARKET, null));
   }
 
-  /** Covers a short position on a reverse crossover, oversold RSI, or stop-loss. */
   private Optional<OrderSignal> tryExitShort(String symbol, Cross cross) {
     String reason = shortExitReason(cross);
     if (reason == null) {
@@ -249,10 +209,6 @@ public class MomentumStrategy implements TradingStrategy {
     return null;
   }
 
-  /**
-   * Returns whether price has moved {@code stopLossPct}% against an open position. A non-positive
-   * {@code stopLossPct} disables the stop. The mark is the latest trade price or quote mid.
-   */
   private boolean stopLossTripped(boolean isLong) {
     if (stopLossPct <= 0.0 || entryPrice <= 0.0 || lastPrice <= 0.0) {
       return false;
@@ -320,12 +276,10 @@ public class MomentumStrategy implements TradingStrategy {
     resetState();
   }
 
-  /** Number of trades to observe before acting on a crossover (auto = {@code slowPeriod}). */
   private int effectiveWarmup() {
     return warmupTrades > 0 ? warmupTrades : Math.max(slowPeriod, 1);
   }
 
-  /** Wilder's RSI, identical in behaviour to the ML service's {@code indicators.rsi}. */
   private void updateRsi(double delta) {
     if (rsiPeriod <= 0) {
       rsi = NEUTRAL_RSI;
@@ -342,7 +296,7 @@ public class MomentumStrategy implements TradingStrategy {
         avgLoss = seedLossSum / rsiPeriod;
         rsi = computeRsi();
       } else {
-        rsi = NEUTRAL_RSI; // not enough data yet
+        rsi = NEUTRAL_RSI;
       }
       return;
     }
@@ -358,7 +312,6 @@ public class MomentumStrategy implements TradingStrategy {
     return 100.0 - 100.0 / (1.0 + avgGain / avgLoss);
   }
 
-  /** EMA with {@code alpha = 2 / (period + 1)}, seeded with the first observed price. */
   private void updateEmas(double price) {
     if (!emaSeeded) {
       fastEma = price;
@@ -372,15 +325,12 @@ public class MomentumStrategy implements TradingStrategy {
     slowEma = slowAlpha * price + (1.0 - slowAlpha) * slowEma;
   }
 
-  /**
-   * True when this trade's size confirms the move (> {@code volumeMultiplier ×} recent average).
-   */
   private boolean volumeConfirmed(long size) {
     if (volumeMultiplier <= 0.0) {
-      return true; // gate disabled
+      return true;
     }
     if (volumeWindow.isEmpty()) {
-      return false; // no baseline yet
+      return false;
     }
     double avg = volumeWindow.stream().mapToLong(Long::longValue).average().orElse(0.0);
     return size > volumeMultiplier * avg;
@@ -393,7 +343,6 @@ public class MomentumStrategy implements TradingStrategy {
     }
   }
 
-  /** Tracks the latest price: trade price for trades, quote mid (or last) for quotes. */
   private void updateLastPrice(MarketTick tick) {
     if (tick.eventType() == EventType.TRADE && tick.price().signum() > 0) {
       lastPrice = tick.price().doubleValue();
@@ -408,7 +357,6 @@ public class MomentumStrategy implements TradingStrategy {
     }
   }
 
-  /** Buy at the ask, sell at the bid, falling back to the last trade price. */
   private BigDecimal resolveLimitPrice(Side orderSide) {
     if (orderSide == Side.BUY) {
       var ask = latestTick.askPrice();
@@ -428,7 +376,6 @@ public class MomentumStrategy implements TradingStrategy {
     return BigDecimal.valueOf(value).setScale(4, RoundingMode.HALF_UP).doubleValue();
   }
 
-  /** Clears all rolling indicator and execution state for a fresh run. */
   private void resetState() {
     volumeWindow.clear();
     emaSeeded = false;

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/pov/PovStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/pov/PovStrategy.java
@@ -15,30 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Percentage-of-Volume (POV) execution strategy.
- *
- * <p>POV participates as a configurable fraction of the real-time traded volume on the tape: as the
- * market trades more shares the strategy emits child orders proportionally, so its participation
- * rate stays close to {@code participationRate} cumulatively across the window.
- *
- * <p>Bookkeeping is purely cumulative — no fixed time slicing. The strategy tracks the running
- * market volume seen since {@code startTime} (summing {@code size} from {@link EventType#TRADE}
- * ticks only; quotes carry no executed volume) and, on each tick, computes the desired
- * already-traded total as {@code targetExecuted = floor(participationRate × cumulativeVolume)},
- * capped by the parent {@code targetQuantity}. The delta vs. shares already emitted is the next
- * child clip. Clips smaller than {@code minClipSize} are deferred until volume builds; clips larger
- * than {@code maxClipSize} are capped so a single block print can't drag a parent off course.
- *
- * <p>Child orders are LIMIT at the best ask (BUY) / best bid (SELL) for price protection, mirroring
- * the other slicing strategies. Any quantity still outstanding when the window closes is swept with
- * a single MARKET order at {@code endTime}.
- *
- * <p>POV is the reactive counterpart to TWAP/VWAP/IS: those algorithms commit to a schedule up
- * front; POV adapts to whatever the tape actually does. Trade-off: lower information leakage and
- * better impact on slow days, but no completion guarantee within the window if liquidity dries up —
- * the end-of-window MARKET sweep is the safety valve.
- */
 @Component
 public class PovStrategy implements TradingStrategy {
 
@@ -49,7 +25,6 @@ public class PovStrategy implements TradingStrategy {
   private static final int DEFAULT_MIN_CLIP_SIZE = 1;
   private static final int DEFAULT_MAX_CLIP_SIZE = Integer.MAX_VALUE;
 
-  // Configuration parameters
   private volatile int targetQuantity;
   private volatile Side side = Side.BUY;
   private volatile LocalTime startTime = LocalTime.of(9, 30);
@@ -58,7 +33,6 @@ public class PovStrategy implements TradingStrategy {
   private volatile int minClipSize = DEFAULT_MIN_CLIP_SIZE;
   private volatile int maxClipSize = DEFAULT_MAX_CLIP_SIZE;
 
-  // Execution state — guarded by the strategy's intrinsic lock for atomic onTick/evaluate updates
   private long cumulativeMarketVolume;
   private long emittedQuantity;
   private volatile MarketTick latestTick;
@@ -98,7 +72,6 @@ public class PovStrategy implements TradingStrategy {
       return Optional.empty();
     }
 
-    // Past end time: sweep remaining quantity
     if (!marketTime.isBefore(endTime)) {
       return emitSweep(symbol);
     }
@@ -176,7 +149,6 @@ public class PovStrategy implements TradingStrategy {
     resetExecutionState();
   }
 
-  /** Resets execution state for a fresh run. */
   private void resetExecutionState() {
     cumulativeMarketVolume = 0L;
     emittedQuantity = 0L;
@@ -184,7 +156,6 @@ public class PovStrategy implements TradingStrategy {
     completed = false;
   }
 
-  /** Resolves the limit price from the latest tick based on side. */
   private BigDecimal resolveLimitPrice() {
     if (side == Side.BUY) {
       var ask = latestTick.askPrice();
@@ -194,7 +165,6 @@ public class PovStrategy implements TradingStrategy {
     return bid != null && bid.compareTo(BigDecimal.ZERO) > 0 ? bid : latestTick.price();
   }
 
-  /** Emits a MARKET sweep for any remaining unexecuted quantity. */
   private Optional<OrderSignal> emitSweep(String symbol) {
     if (completed) {
       return Optional.empty();

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/shortfall/ImplementationShortfallStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/shortfall/ImplementationShortfallStrategy.java
@@ -19,33 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Implementation Shortfall (IS) execution strategy.
- *
- * <p>Like {@link com.mariaalpha.strategyengine.strategy.twap.TwapStrategy}, IS divides the trading
- * window {@code [startTime, endTime)} into {@code numSlices} equal-duration intervals and emits one
- * LIMIT child order as the market clock (driven by tick timestamps, never the wall clock) crosses
- * into each slice, sweeping any leftover with a MARKET order at the deadline. The <em>only</em>
- * difference is how the parent quantity is spread across those slices: TWAP allocates it
- * <b>uniformly</b>, whereas IS <b>front-loads</b> it.
- *
- * <p>Front-loading minimises <em>implementation shortfall</em> — the gap between the decision
- * (arrival) price and the realised average fill price. By trading more aggressively early, IS
- * shrinks the window over which the price can drift away from the arrival mark (timing risk), at
- * the cost of higher temporary market impact. The trade-off is governed by a single dimensionless
- * {@code urgency} knob (κ):
- *
- * <ul>
- *   <li>{@code urgency = 0} → uniform slicing, i.e. exactly TWAP (graceful degradation).
- *   <li>{@code urgency > 0} → strictly decreasing per-slice allocations; the larger κ, the more of
- *       the order is packed into the first few slices.
- * </ul>
- *
- * <p>The allocation curve is the discrete Almgren–Chriss optimal-execution trajectory: the fraction
- * still outstanding after slice {@code i} is {@code h(i) = sinh(κ(N−i)) / sinh(κN)}, so slice
- * {@code i} trades {@code h(i) − h(i+1)}. As κ → 0 every slice tends to {@code 1/N}. See {@code
- * docs/implementation-shortfall-strategy-explainer.md}.
- */
 @Component
 public class ImplementationShortfallStrategy implements TradingStrategy {
 
@@ -55,7 +28,6 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
   private static final int DEFAULT_NUM_SLICES = 12;
   private static final double DEFAULT_URGENCY = 0.5;
 
-  // Configuration parameters
   private volatile int targetQuantity;
   private Side side = Side.BUY;
   private LocalTime startTime = LocalTime.of(9, 30);
@@ -63,13 +35,10 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
   private volatile int numSlices = DEFAULT_NUM_SLICES;
   private volatile double urgency = DEFAULT_URGENCY;
 
-  // Derived schedule: equal-duration slices spanning [startTime, endTime)
   private final List<ShortfallSlice> slices = new ArrayList<>();
 
-  // Computed front-loaded allocations: sliceIndex -> share count
   private final List<Integer> sliceAllocations = new ArrayList<>();
 
-  // Execution state: tracks which slices have emitted signals (at-most-once)
   private final ConcurrentHashMap<Integer, Boolean> sliceExecuted = new ConcurrentHashMap<>();
   private volatile MarketTick latestTick;
   private volatile boolean completed;
@@ -104,18 +73,15 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
       return Optional.empty();
     }
 
-    // Past end time: sweep remaining quantity
     if (!marketTime.isBefore(endTime)) {
       return emitSweep(symbol);
     }
 
-    // Find current slice
     int sliceIndex = findSliceIndex(marketTime);
     if (sliceIndex < 0) {
       return Optional.empty();
     }
 
-    // Check if current slice already executed (at-most-once)
     if (sliceExecuted.putIfAbsent(sliceIndex, Boolean.TRUE) != null) {
       return Optional.empty();
     }
@@ -180,13 +146,6 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
     resetExecutionState();
   }
 
-  /**
-   * Rebuilds the equal-duration slice schedule from {@code startTime}, {@code endTime}, and {@code
-   * numSlices}. Boundaries are computed in whole seconds from the window start so they never drift
-   * past {@code endTime}; the final boundary lands exactly on {@code endTime}. Produces no slices
-   * when the window is empty/inverted or {@code numSlices <= 0}. Identical to TWAP's schedule — IS
-   * differs only in allocation, not in interval layout.
-   */
   private void rebuildSchedule() {
     slices.clear();
     long totalSeconds = Duration.between(startTime, endTime).getSeconds();
@@ -202,11 +161,6 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
     }
   }
 
-  /**
-   * Computes per-slice share allocations by front-loading the target quantity along the
-   * Almgren–Chriss trajectory (see {@link #frontLoadWeights}). The last slice absorbs any rounding
-   * remainder so the allocations always sum exactly to {@code targetQuantity}.
-   */
   private void computeAllocations() {
     sliceAllocations.clear();
     int n = slices.size();
@@ -223,17 +177,6 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
     sliceAllocations.add(targetQuantity - allocated);
   }
 
-  /**
-   * Fraction of the parent to trade in each of {@code n} equal time slices, front-loaded by the
-   * Almgren–Chriss optimal trajectory. The outstanding-holdings curve is {@code h(m) = sinh(κm) /
-   * sinh(κn)}, so slice {@code i} (holdings going from {@code h(n−i)} down to {@code h(n−i−1)})
-   * trades {@code h(n−i) − h(n−i−1)}. The weights are strictly decreasing for κ &gt; 0 and sum to
-   * 1.
-   *
-   * <p>A non-positive urgency degrades to uniform {@code 1/n} weights (i.e. TWAP). The hyperbolic
-   * sines are evaluated in the numerically stable exponential form (dividing through by {@code
-   * e^{κn}/2}) so the computation never overflows even for large {@code κ·n}.
-   */
   private static double[] frontLoadWeights(int n, double urgency) {
     double[] weights = new double[n];
     if (urgency <= 0.0) {
@@ -241,12 +184,9 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
       return weights;
     }
     double k = urgency;
-    // denom = sinh(κn) normalised by e^{κn}/2 = 1 − e^{−2κn}
     double denom = 1.0 - Math.exp(-2.0 * k * n);
-    double prevHoldings = 1.0; // h(n) = 100% outstanding before slice 0
+    double prevHoldings = 1.0;
     for (var i = 0; i < n; i++) {
-      // holdings after slice i = h(n−i−1) = sinh(κ(n−i−1))/sinh(κn), exp-stable form:
-      //   (e^{−κ(i+1)} − e^{−κ(2n−i−1)}) / denom
       double holdings = (Math.exp(-k * (i + 1)) - Math.exp(-k * (2.0 * n - i - 1))) / denom;
       weights[i] = prevHoldings - holdings;
       prevHoldings = holdings;
@@ -254,26 +194,21 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
     return weights;
   }
 
-  /** Resets execution state for a fresh run. */
   private void resetExecutionState() {
     sliceExecuted.clear();
     latestTick = null;
     completed = false;
   }
 
-  /** Resolves the limit price from the latest tick based on side. */
   private BigDecimal resolveLimitPrice() {
     if (side == Side.BUY) {
-      // buy at the ask
       var ask = latestTick.askPrice();
       return ask.compareTo(BigDecimal.ZERO) > 0 ? ask : latestTick.price();
     }
-    // sell at the bid
     var bid = latestTick.bidPrice();
     return bid.compareTo(BigDecimal.ZERO) > 0 ? bid : latestTick.price();
   }
 
-  /** Computes the total remaining (unexecuted) quantity. */
   private int remainingQuantity() {
     int executed = 0;
     for (var entry : sliceExecuted.entrySet()) {
@@ -285,7 +220,6 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
     return targetQuantity - executed;
   }
 
-  /** Finds the slice index for the given market time. Returns -1 if not in any slice. */
   private int findSliceIndex(LocalTime marketTime) {
     for (var i = 0; i < slices.size(); i++) {
       var slice = slices.get(i);
@@ -296,7 +230,6 @@ public class ImplementationShortfallStrategy implements TradingStrategy {
     return -1;
   }
 
-  /** Emits a MARKET sweep for any remaining unexecuted quantity. */
   private Optional<OrderSignal> emitSweep(String symbol) {
     if (completed) {
       return Optional.empty();

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/shortfall/ShortfallSlice.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/shortfall/ShortfallSlice.java
@@ -2,14 +2,4 @@ package com.mariaalpha.strategyengine.strategy.shortfall;
 
 import java.time.LocalTime;
 
-/**
- * One equal-duration time interval of an Implementation Shortfall schedule, half-open {@code
- * [startTime, endTime)} in the market time zone.
- *
- * <p>Identical in shape to TWAP's {@code TwapSlice} — the intervals are evenly spaced. What differs
- * is the per-slice <em>allocation</em>: TWAP splits the parent equally across slices, whereas
- * Implementation Shortfall front-loads it via an Almgren–Chriss optimal trajectory (see {@link
- * ImplementationShortfallStrategy}). The slice itself carries no weight; the strategy holds the
- * computed share allocations alongside this schedule.
- */
 public record ShortfallSlice(LocalTime startTime, LocalTime endTime) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapSlice.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapSlice.java
@@ -2,9 +2,4 @@ package com.mariaalpha.strategyengine.strategy.twap;
 
 import java.time.LocalTime;
 
-/**
- * One equal-duration time interval of a TWAP schedule, half-open {@code [startTime, endTime)} in
- * the market time zone. Unlike VWAP's {@code TimeBin}, a TWAP slice carries no volume fraction —
- * the parent quantity is divided equally across the configured number of slices.
- */
 public record TwapSlice(LocalTime startTime, LocalTime endTime) {}

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategy.java
@@ -18,18 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/**
- * Time-Weighted Average Price execution strategy.
- *
- * <p>Splits the trading window {@code [startTime, endTime)} into {@code numSlices} equal-duration
- * intervals and distributes the parent quantity evenly across them. As the market clock (driven by
- * tick timestamps, not the wall clock) crosses into each slice, a single LIMIT child order is
- * emitted at the current best ask (buys) or best bid (sells). Any quantity still unexecuted when
- * the window closes is swept with a final MARKET order.
- *
- * <p>This mirrors {@link com.mariaalpha.strategyengine.strategy.vwap.VwapStrategy} but replaces the
- * historical volume profile with equal time slicing — see {@code docs/twap-strategy-explainer.md}.
- */
 @Component
 public class TwapStrategy implements TradingStrategy {
 
@@ -38,20 +26,16 @@ public class TwapStrategy implements TradingStrategy {
   static final ZoneId MARKET_ZONE = ZoneId.of("America/New_York");
   private static final int DEFAULT_NUM_SLICES = 12;
 
-  // Configuration parameters
   private volatile int targetQuantity;
   private Side side = Side.BUY;
   private LocalTime startTime = LocalTime.of(9, 30);
   private LocalTime endTime = LocalTime.of(16, 0);
   private volatile int numSlices = DEFAULT_NUM_SLICES;
 
-  // Derived schedule: equal-duration slices spanning [startTime, endTime)
   private final List<TwapSlice> slices = new ArrayList<>();
 
-  // Computed allocations: sliceIndex -> share count
   private final List<Integer> sliceAllocations = new ArrayList<>();
 
-  // Execution state: tracks which slices have emitted signals (at-most-once)
   private final ConcurrentHashMap<Integer, Boolean> sliceExecuted = new ConcurrentHashMap<>();
   private volatile MarketTick latestTick;
   private volatile boolean completed;
@@ -86,18 +70,15 @@ public class TwapStrategy implements TradingStrategy {
       return Optional.empty();
     }
 
-    // Past end time: sweep remaining quantity
     if (!marketTime.isBefore(endTime)) {
       return emitSweep(symbol);
     }
 
-    // Find current slice
     int sliceIndex = findSliceIndex(marketTime);
     if (sliceIndex < 0) {
       return Optional.empty();
     }
 
-    // Check if current slice already executed (at-most-once)
     if (sliceExecuted.putIfAbsent(sliceIndex, Boolean.TRUE) != null) {
       return Optional.empty();
     }
@@ -151,12 +132,6 @@ public class TwapStrategy implements TradingStrategy {
     resetExecutionState();
   }
 
-  /**
-   * Rebuilds the equal-duration slice schedule from {@code startTime}, {@code endTime}, and {@code
-   * numSlices}. Boundaries are computed in whole seconds from the window start so they never drift
-   * past {@code endTime}; the final boundary lands exactly on {@code endTime}. Produces no slices
-   * when the window is empty/inverted or {@code numSlices <= 0}.
-   */
   private void rebuildSchedule() {
     slices.clear();
     long totalSeconds = Duration.between(startTime, endTime).getSeconds();
@@ -172,10 +147,6 @@ public class TwapStrategy implements TradingStrategy {
     }
   }
 
-  /**
-   * Computes per-slice share allocations by dividing the target quantity equally. The last slice
-   * absorbs any rounding remainder so the allocations always sum to {@code targetQuantity}.
-   */
   private void computeAllocations() {
     sliceAllocations.clear();
     if (slices.isEmpty() || targetQuantity <= 0) {
@@ -190,26 +161,21 @@ public class TwapStrategy implements TradingStrategy {
     sliceAllocations.add(targetQuantity - allocated);
   }
 
-  /** Resets execution state for a fresh run. */
   private void resetExecutionState() {
     sliceExecuted.clear();
     latestTick = null;
     completed = false;
   }
 
-  /** Resolves the limit price from the latest tick based on side. */
   private BigDecimal resolveLimitPrice() {
     if (side == Side.BUY) {
-      // buy at the ask
       var ask = latestTick.askPrice();
       return ask.compareTo(BigDecimal.ZERO) > 0 ? ask : latestTick.price();
     }
-    // sell at the bid
     var bid = latestTick.bidPrice();
     return bid.compareTo(BigDecimal.ZERO) > 0 ? bid : latestTick.price();
   }
 
-  /** Computes the total remaining (unexecuted) quantity. */
   private int remainingQuantity() {
     int executed = 0;
     for (var entry : sliceExecuted.entrySet()) {
@@ -221,7 +187,6 @@ public class TwapStrategy implements TradingStrategy {
     return targetQuantity - executed;
   }
 
-  /** Finds the slice index for the given market time. Returns -1 if not in any slice. */
   private int findSliceIndex(LocalTime marketTime) {
     for (var i = 0; i < slices.size(); i++) {
       var slice = slices.get(i);
@@ -232,7 +197,6 @@ public class TwapStrategy implements TradingStrategy {
     return -1;
   }
 
-  /** Emits a MARKET sweep for any remaining unexecuted quantity. */
   private Optional<OrderSignal> emitSweep(String symbol) {
     if (completed) {
       return Optional.empty();

--- a/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/vwap/VwapStrategy.java
+++ b/strategy-engine/src/main/java/com/mariaalpha/strategyengine/strategy/vwap/VwapStrategy.java
@@ -24,17 +24,14 @@ public class VwapStrategy implements TradingStrategy {
   private static final String NAME = "VWAP";
   static final ZoneId MARKET_ZONE = ZoneId.of("America/New_York");
 
-  // Configuration parameters
   private volatile int targetQuantity;
   private Side side = Side.BUY;
   private LocalTime startTime = LocalTime.of(9, 30);
   private LocalTime endTime = LocalTime.of(16, 0);
   private List<TimeBin> volumeProfile = List.of();
 
-  // Computed allocations: binIndex -> share count
   private final List<Integer> binAllocations = new ArrayList<>();
 
-  // Execution state: tracks which bins have emitted signals
   private final ConcurrentHashMap<Integer, Boolean> binExecuted = new ConcurrentHashMap<>();
   private volatile MarketTick latestTick;
   private volatile boolean completed;
@@ -65,18 +62,15 @@ public class VwapStrategy implements TradingStrategy {
       return Optional.empty();
     }
 
-    // Past end time: sweep remaining quantity
     if (!marketTime.isBefore(endTime)) {
       return emitSweep(symbol);
     }
 
-    // Find current bin
     int binIndex = findBinIndex(marketTime);
     if (binIndex < 0) {
       return Optional.empty();
     }
 
-    // Check if current bin already executed (at-most-once)
     if (binExecuted.putIfAbsent(binIndex, Boolean.TRUE) != null) {
       return Optional.empty();
     }
@@ -145,10 +139,6 @@ public class VwapStrategy implements TradingStrategy {
     resetExecutionState();
   }
 
-  /**
-   * Computes per-bin share allocations from the volume profile. Last bin absorbs rounding
-   * remainder.
-   */
   private void computeAllocations() {
     binAllocations.clear();
     if (volumeProfile.isEmpty() || targetQuantity <= 0) {
@@ -163,26 +153,21 @@ public class VwapStrategy implements TradingStrategy {
     binAllocations.add(targetQuantity - allocated);
   }
 
-  /** Resets execution state for a fresh run. */
   private void resetExecutionState() {
     binExecuted.clear();
     latestTick = null;
     completed = false;
   }
 
-  /** Resolves the limit price from the latest tick based on side. */
   private BigDecimal resolveLimitPrice() {
     if (side == Side.BUY) {
-      // buy at the ask
       var ask = latestTick.askPrice();
       return ask.compareTo(BigDecimal.ZERO) > 0 ? ask : latestTick.price();
     }
-    // sell at the bid
     var bid = latestTick.bidPrice();
     return bid.compareTo(BigDecimal.ZERO) > 0 ? bid : latestTick.price();
   }
 
-  /** Computes the total remaining (unexecuted) quantity. */
   private int remainingQuantity() {
     int executed = 0;
     for (var entry : binExecuted.entrySet()) {
@@ -194,7 +179,6 @@ public class VwapStrategy implements TradingStrategy {
     return targetQuantity - executed;
   }
 
-  /** Finds the bin index for the given market time. Returns -1 if not in any bin. */
   private int findBinIndex(LocalTime marketTime) {
     for (var i = 0; i < volumeProfile.size(); i++) {
       var bin = volumeProfile.get(i);
@@ -205,7 +189,6 @@ public class VwapStrategy implements TradingStrategy {
     return -1;
   }
 
-  /** Emits a MARKET sweep for any remaining unexecuted quantity. */
   private Optional<OrderSignal> emitSweep(String symbol) {
     if (completed) {
       return Optional.empty();

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/algo/AlgoOrderServiceTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/algo/AlgoOrderServiceTest.java
@@ -49,8 +49,6 @@ class AlgoOrderServiceTest {
     assertThat(algo.status()).isEqualTo(AlgoOrder.Status.ACTIVE);
     assertThat(algo.symbol()).isEqualTo("AAPL");
     assertThat(algo.targetQuantity()).isEqualTo(100);
-    // Caller params are forwarded, enriched with the order's side (and targetQuantity when the
-    // caller didn't supply one) so the strategy can't run with a stale side from a prior order.
     verify(strategy).updateParameters(Map.of("targetQuantity", 100, "side", "BUY"));
     verify(router).setActiveStrategy("AAPL", "VWAP");
     verify(progressPublisher).publishLifecycle(algo, AlgoProgressEvent.EventType.CREATED);
@@ -102,7 +100,6 @@ class AlgoOrderServiceTest {
     when(strategyRegistry.get("VWAP")).thenReturn(Optional.of(strategy));
     var algo = service.submit(new AlgoOrderRequest("AAPL", Side.BUY, 100, "VWAP", Map.of()));
     service.cancel(algo.algoOrderId());
-    // Second cancel returns the already-terminal record but does not re-publish or re-unbind.
     var again = service.cancel(algo.algoOrderId());
     assertThat(again).isPresent();
     assertThat(again.get().status()).isEqualTo(AlgoOrder.Status.CANCELLED);

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/consumer/TickConsumerIntegrationTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/consumer/TickConsumerIntegrationTest.java
@@ -69,7 +69,6 @@ public class TickConsumerIntegrationTest {
     when(mlSignalClient.getSignal(anyString())).thenReturn(Optional.empty());
     when(mlSignalClient.getCircuitBreakerState()).thenReturn(CircuitBreaker.State.CLOSED);
 
-    // Configure VWAP: 500 shares, single full-day bin, so any trading-hours tick fires a signal
     var vwapStrategy = strategyRegistry.get("VWAP").orElseThrow();
     var volumeProfile = List.of(new TimeBin(LocalTime.of(9, 30), LocalTime.of(16, 0), 1.0));
     vwapStrategy.updateParameters(
@@ -84,7 +83,6 @@ public class TickConsumerIntegrationTest {
 
   @Test
   void tickPublishedToKafkaTriggersSignalOnStrategySignalsTopic() throws Exception {
-    // Build a tick at 10:00 America/New_York — inside the single VWAP bin
     var ts =
         ZonedDateTime.of(
                 LocalDate.of(2026, 3, 24), LocalTime.of(10, 0), ZoneId.of("America/New_York"))
@@ -104,7 +102,6 @@ public class TickConsumerIntegrationTest {
             DataSource.ALPACA,
             false);
 
-    // Create a raw Kafka consumer pointed at strategy.signals
     var props = new HashMap<String, Object>();
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
     props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-" + Instant.now().toEpochMilli());
@@ -117,12 +114,8 @@ public class TickConsumerIntegrationTest {
     try (var consumer = new KafkaConsumer<String, String>(props)) {
       consumer.subscribe(List.of("strategy.signals"));
 
-      // Publish the tick to market-data.ticks
       kafkaTemplate.send("market-data.ticks", "AAPL", objectMapper.writeValueAsString(tick)).get();
 
-      // Wait for the AAPL signal to appear on strategy.signals. Filter by symbol: this topic is
-      // shared across all the test methods in this class and read from earliest, so other methods'
-      // signals (MSFT/GOOGL/AMZN) may already sit ahead of ours regardless of execution order.
       Awaitility.await()
           .atMost(Duration.ofSeconds(15))
           .pollInterval(Duration.ofMillis(500))
@@ -148,7 +141,6 @@ public class TickConsumerIntegrationTest {
 
   @Test
   void twapTickPublishedToKafkaTriggersSignalOnStrategySignalsTopic() throws Exception {
-    // Configure TWAP: 300 shares, single full-day slice, so any trading-hours tick fires it.
     var twapStrategy = strategyRegistry.get("TWAP").orElseThrow();
     twapStrategy.updateParameters(
         Map.of(
@@ -218,9 +210,6 @@ public class TickConsumerIntegrationTest {
 
   @Test
   void implementationShortfallTickPublishedToKafkaTriggersFrontLoadedSignal() throws Exception {
-    // Configure IS: 1000 shares over two equal half-day slices with urgency 0.5. A tick inside
-    // the first slice fires its front-loaded allocation — 557 shares (> the 500 a uniform split
-    // would give), demonstrating the front-loading end-to-end.
     var isStrategy = strategyRegistry.get("IS").orElseThrow();
     isStrategy.updateParameters(
         Map.of(
@@ -297,8 +286,6 @@ public class TickConsumerIntegrationTest {
 
   @Test
   void povTickPublishedToKafkaTriggersParticipationClip() throws Exception {
-    // Configure POV: parent 1000 shares, 10% participation. A single TRADE tick of size 5000
-    // means cumulativeMarketVolume=5000 → targetExecuted = 0.10 × 5000 = 500 → emit 500-share clip.
     var povStrategy = strategyRegistry.get("POV").orElseThrow();
     povStrategy.updateParameters(
         Map.of(
@@ -377,9 +364,6 @@ public class TickConsumerIntegrationTest {
 
   @Test
   void closePreCloseSliceLimitOrderEmittedDuringWorkingWindow() throws Exception {
-    // Configure CLOSE: parent 1000 shares, 50% pre-close fraction, 5 slices. A tick inside the
-    // first pre-close slice (15:05) emits the slice's 100-share LIMIT clip — exercising the
-    // working-into-the-close phase end-to-end.
     var closeStrategy = strategyRegistry.get("CLOSE").orElseThrow();
     closeStrategy.updateParameters(
         Map.of(
@@ -459,8 +443,6 @@ public class TickConsumerIntegrationTest {
 
   @Test
   void momentumUptrendPublishedToKafkaTriggersEntrySignal() throws Exception {
-    // Configure MOMENTUM with tiny EMA periods so a two-trade uptrend produces a bullish
-    // crossover, and a 2-trade warmup so it acts immediately.
     var momentumStrategy = strategyRegistry.get("MOMENTUM").orElseThrow();
     momentumStrategy.updateParameters(
         Map.of(
@@ -488,7 +470,6 @@ public class TickConsumerIntegrationTest {
     try (var consumer = new KafkaConsumer<String, String>(props)) {
       consumer.subscribe(List.of("strategy.signals"));
 
-      // Ordered publish on the same key (symbol) → same partition → in-order processing.
       kafkaTemplate.send("market-data.ticks", "GOOGL", objectMapper.writeValueAsString(seed)).get();
       kafkaTemplate
           .send("market-data.ticks", "GOOGL", objectMapper.writeValueAsString(breakout))

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/controller/StrategyControllerTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/controller/StrategyControllerTest.java
@@ -150,7 +150,6 @@ class StrategyControllerTest {
     mockMvc
         .perform(get("/api/strategies/state"))
         .andExpect(status().isOk())
-        // routedSymbols are sorted for stable UI ordering
         .andExpect(jsonPath("$[0].symbol").value("AAPL"))
         .andExpect(jsonPath("$[1].symbol").value("MSFT"));
   }
@@ -164,7 +163,6 @@ class StrategyControllerTest {
         .perform(get("/api/strategies/state").param("symbol", "AAPL"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].activeStrategy").value("VWAP"))
-        // nullable fields omitted when empty (no JSON include)
         .andExpect(jsonPath("$[0].mlSignal").doesNotExist())
         .andExpect(jsonPath("$[0].mlRegime").doesNotExist());
   }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/ml/MlSignalClientTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/ml/MlSignalClientTest.java
@@ -98,7 +98,6 @@ class MlSignalClientTest {
     fakeSignalService.nextError(Status.UNAVAILABLE.asRuntimeException());
     for (int i = 0; i < 5; i++) {
       client.getSignal("AAPL");
-      // refresh the error each call (FakeSignalService clears after use)
       fakeSignalService.nextError(Status.UNAVAILABLE.asRuntimeException());
     }
     assertThat(client.getCircuitBreakerState()).isEqualTo(CircuitBreaker.State.OPEN);

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/ml/MlSignalGateTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/ml/MlSignalGateTest.java
@@ -48,7 +48,6 @@ class MlSignalGateTest {
   void exactThresholdTreatedAsLowConfidence() {
     var ml = Optional.of(new MlSignalResult(Direction.SHORT, 0.7, 0.0));
     var decision = new MlSignalGate(strict()).decide(BUY, ml);
-    // confidence > threshold is the spec; equality should not be enough to suppress
     assertThat(decision.outcome()).isEqualTo(MlGateDecision.Outcome.LOW_CONFIDENCE);
   }
 

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/BlackScholesPricerTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/BlackScholesPricerTest.java
@@ -9,11 +9,6 @@ class BlackScholesPricerTest {
 
   private final BlackScholesPricer pricer = new BlackScholesPricer();
 
-  /**
-   * Hull, <em>Options, Futures and Other Derivatives</em>, Ch.15 worked example. {@code S=42},
-   * {@code K=40}, {@code T=0.5}, {@code σ=0.20}, {@code r=0.10}, {@code q=0}. Hull's published
-   * answers are call=4.76 and put=0.81 — match to 0.01 with our 6-decimal Φ approximation.
-   */
   @Test
   void hullTextbookCallPutValues() {
     var call = new OptionContract(42.0, 40.0, 0.5, 0.20, 0.10, 0.0, OptionType.CALL);
@@ -22,10 +17,6 @@ class BlackScholesPricerTest {
     assertThat(pricer.price(put)).isCloseTo(0.81, within(0.01));
   }
 
-  /**
-   * Generalised put-call parity for a stock paying a continuous dividend yield: {@code C − P =
-   * S·e^(−qT) − K·e^(−rT)}. Must hold to machine precision for any well-defined input.
-   */
   @Test
   void putCallParityHoldsWithDividendYield() {
     double spot = 100;
@@ -42,7 +33,6 @@ class BlackScholesPricerTest {
 
   @Test
   void deepInTheMoneyCallApproachesIntrinsicValue() {
-    // Spot far above strike, short maturity, low vol → call ≈ S·e^(−qT) − K·e^(−rT)
     var contract = new OptionContract(200, 100, 0.05, 0.10, 0.03, 0.0, OptionType.CALL);
     double intrinsicForward =
         contract.spot() * Math.exp(-contract.dividendYield() * contract.timeToExpiryYears())
@@ -67,7 +57,6 @@ class BlackScholesPricerTest {
 
   @Test
   void atTheMoneyCallEqualsAtTheMoneyPutAtZeroCarry() {
-    // r = q → forward price equals spot, so ATM call and put have equal value.
     var call = new OptionContract(100, 100, 1.0, 0.25, 0.02, 0.02, OptionType.CALL);
     var put = new OptionContract(100, 100, 1.0, 0.25, 0.02, 0.02, OptionType.PUT);
     assertThat(pricer.price(call)).isCloseTo(pricer.price(put), within(1e-8));
@@ -82,7 +71,6 @@ class BlackScholesPricerTest {
 
   @Test
   void longerTimeIncreasesAtmCallPremium() {
-    // For a non-dividend-paying ATM call with r > 0, longer T monotonically increases premium.
     var nearTerm = new OptionContract(100, 100, 0.1, 0.20, 0.05, 0.0, OptionType.CALL);
     var farTerm = new OptionContract(100, 100, 2.0, 0.20, 0.05, 0.0, OptionType.CALL);
     assertThat(pricer.price(farTerm)).isGreaterThan(pricer.price(nearTerm));

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/GreeksCalculatorTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/GreeksCalculatorTest.java
@@ -15,12 +15,6 @@ class GreeksCalculatorTest {
 
   @Test
   void hullTextbookCallGreeks() {
-    // Hull Ch.19 worked example, same inputs as the pricer test. Published reference values:
-    //   delta = 0.7791 (= N(d1))
-    //   gamma = 0.0498
-    //   vega (annualised) = 8.79 → 0.0879 per 1% vol
-    //   theta_call (annualised) ≈ −4.5532 → ÷365 ≈ −0.01247 per day
-    //   rho_call (annualised) ≈ 13.98 → 0.1398 per 1% rate
     var contract = new OptionContract(42.0, 40.0, 0.5, 0.20, 0.10, 0.0, OptionType.CALL);
     var greeks = calculator.compute(contract);
     assertThat(greeks.delta()).isCloseTo(0.7791, within(0.001));
@@ -32,13 +26,6 @@ class GreeksCalculatorTest {
 
   @Test
   void hullTextbookPutGreeksMatchParity() {
-    // Same inputs as the call test → put Greeks via parity relations:
-    //   delta_put = delta_call − e^(−qT) = 0.7791 − 1.0 = −0.2209  (q = 0)
-    //   gamma_put = gamma_call = 0.0498
-    //   vega_put = vega_call = 0.0879
-    //   theta_put (annualised) = theta_call + r·K·e^(−rT) = −4.5532 + 0.10·40·0.9512 = −0.7484
-    //              → ÷365 ≈ −0.00205 per day
-    //   rho_put (annualised) = rho_call − K·T·e^(−rT) = 13.98 − 19.024 = −5.044 → −0.05044 per 1%
     var contract = new OptionContract(42.0, 40.0, 0.5, 0.20, 0.10, 0.0, OptionType.PUT);
     var greeks = calculator.compute(contract);
     assertThat(greeks.delta()).isCloseTo(-0.2209, within(0.001));
@@ -51,7 +38,6 @@ class GreeksCalculatorTest {
   @Test
   void atTheMoneyCallDeltaIsNearHalf() {
     var contract = new OptionContract(100, 100, 0.5, 0.25, 0.01, 0.0, OptionType.CALL);
-    // ATM-forward delta is slightly > 0.5 because the carry pushes d1 above zero.
     assertThat(calculator.compute(contract).delta()).isCloseTo(0.55, within(0.05));
   }
 
@@ -111,7 +97,6 @@ class GreeksCalculatorTest {
 
   @Test
   void deltaMatchesNumericalBumpForCall() {
-    // Numerical bump check: delta ≈ (price(S+h) - price(S-h)) / (2h)
     var base = new OptionContract(100, 100, 0.5, 0.25, 0.03, 0.0, OptionType.CALL);
     double h = 0.01;
     var up = new OptionContract(100 + h, 100, 0.5, 0.25, 0.03, 0.0, OptionType.CALL);
@@ -138,7 +123,6 @@ class GreeksCalculatorTest {
     var up = new OptionContract(100, 100, 0.5, 0.25 + h, 0.03, 0.0, OptionType.CALL);
     var down = new OptionContract(100, 100, 0.5, 0.25 - h, 0.03, 0.0, OptionType.CALL);
     double numericVegaAnnual = (pricer.price(up) - pricer.price(down)) / (2 * h);
-    // Our reported vega is per-1%-vol; rescale numerical vega to compare.
     assertThat(calculator.compute(base).vega() * 100.0).isCloseTo(numericVegaAnnual, within(1e-3));
   }
 
@@ -149,7 +133,6 @@ class GreeksCalculatorTest {
     var trading = new GreeksCalculator(new OptionsPricingConfig(252.0, 100, 1e-6, 1e-4, 5.0));
     double calendarTheta = calendar.compute(contract).theta();
     double tradingTheta = trading.compute(contract).theta();
-    // Same annualised theta → trading-day theta is more negative by factor 365/252 (1.448×).
     assertThat(tradingTheta).isCloseTo(calendarTheta * (365.0 / 252.0), within(1e-6));
   }
 }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityCalculatorTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/ImpliedVolatilityCalculatorTest.java
@@ -17,7 +17,6 @@ class ImpliedVolatilityCalculatorTest {
 
   @Test
   void roundTripsForwardPriceCallVolatility() {
-    // Price a contract, then invert that price back to volatility — should recover σ to tolerance.
     double trueVol = 0.27;
     var contract = new OptionContract(100, 100, 0.5, trueVol, 0.03, 0.0, OptionType.CALL);
     double marketPrice = pricer.price(contract);
@@ -42,13 +41,11 @@ class ImpliedVolatilityCalculatorTest {
     double marketPrice = pricer.price(contract);
     var result = solver.solve(100, 100, 0.5, 0.03, 0.0, OptionType.CALL, marketPrice);
     assertThat(result.method()).isEqualTo(ImpliedVolatilityCalculator.Method.NEWTON);
-    // Newton is quadratic — well under 10 iterations from σ₀=0.2 to σ=0.3.
     assertThat(result.iterations()).isLessThan(10);
   }
 
   @Test
   void rejectsPriceBelowIntrinsic() {
-    // Deep-ITM call: lower no-arb bound ≈ S − K·e^(−rT)
     assertThatThrownBy(() -> solver.solve(150, 100, 1.0, 0.05, 0.0, OptionType.CALL, 30.0))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("no-arbitrage band");
@@ -56,7 +53,6 @@ class ImpliedVolatilityCalculatorTest {
 
   @Test
   void rejectsPriceAboveForwardSpot() {
-    // Upper no-arb bound for a call is S·e^(−qT). Asking for a premium > S is impossible.
     assertThatThrownBy(() -> solver.solve(100, 100, 1.0, 0.05, 0.0, OptionType.CALL, 105.0))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("no-arbitrage band");

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/NormalDistributionTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/NormalDistributionTest.java
@@ -14,7 +14,6 @@ class NormalDistributionTest {
 
   @Test
   void cdfTextbookValues() {
-    // A&S 26.2 reference values, accurate to the A&S 26.2.17 approximation budget (~7.5e-8)
     assertThat(NormalDistribution.cdf(1.0)).isCloseTo(0.8413447, within(1e-6));
     assertThat(NormalDistribution.cdf(-1.0)).isCloseTo(0.1586553, within(1e-6));
     assertThat(NormalDistribution.cdf(1.96)).isCloseTo(0.9750021, within(1e-6));

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/OptionContractTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/OptionContractTest.java
@@ -51,7 +51,6 @@ class OptionContractTest {
 
   @Test
   void acceptsNegativeRiskFreeRate() {
-    // Negative rates are real (e.g. EUR/CHF in the 2010s) — must not be rejected.
     new OptionContract(100, 100, 0.5, 0.2, -0.005, 0.0, OptionType.CALL);
   }
 }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/OptionsControllerTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/OptionsControllerTest.java
@@ -73,12 +73,10 @@ class OptionsControllerTest {
 
   @Test
   void impliedVolEndpointRejectsImpossiblePremiumAs422() {
-    // Premium above the no-arbitrage upper bound (forward spot) → 422 Unprocessable Entity, since
-    // the input is well-formed but the solver cannot satisfy it.
     var request =
         new ImpliedVolatilityRequest("AAPL", 100, 100, 1.0, 0.05, 0.0, OptionType.CALL, 105.0);
     assertThatThrownBy(() -> controller.impliedVolatility(request))
         .isInstanceOf(ResponseStatusException.class)
-        .hasMessageContaining("400"); // Falls into IllegalArgumentException → 400
+        .hasMessageContaining("400");
   }
 }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/OptionsEndToEndIntegrationTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/options/OptionsEndToEndIntegrationTest.java
@@ -136,7 +136,6 @@ public class OptionsEndToEndIntegrationTest {
 
   @Test
   void impliedVolEndpointRoundTripsThroughHttp() throws Exception {
-    // Step 1: price a known contract through the price endpoint.
     var pricingReq =
         new OptionPricingRequest("AAPL", 100.0, 100.0, 0.5, 0.35, 0.04, 0.0, OptionType.CALL);
     var pricingResp =
@@ -149,7 +148,6 @@ public class OptionsEndToEndIntegrationTest {
     var pricing =
         json.readValue(pricingResp.getResponse().getContentAsString(), OptionPricingResponse.class);
 
-    // Step 2: invert that premium back through the implied-vol endpoint — must recover σ.
     var ivReq =
         new ImpliedVolatilityRequest(
             "AAPL", 100.0, 100.0, 0.5, 0.04, 0.0, OptionType.CALL, pricing.price());

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/MarketStateCacheTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/MarketStateCacheTest.java
@@ -39,7 +39,6 @@ class MarketStateCacheTest {
       cache.onTick(quote("AAPL", String.valueOf(100 + i), String.valueOf(100.2 + i)));
     }
     var history = cache.midHistory("AAPL").orElseThrow();
-    // window size 5 → last 5 entries
     assertThat(history).hasSize(5);
     assertThat(history[0]).isCloseTo(105.1, within(0.001));
     assertThat(history[4]).isCloseTo(109.1, within(0.001));

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/RfqEndToEndIntegrationTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/RfqEndToEndIntegrationTest.java
@@ -38,15 +38,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 
-/**
- * Wires the RFQ controller, pricing engine, market-state cache, position lookup (mocked) and Kafka
- * publisher into a Spring context. Drives the {@code /api/rfq/quote} + {@code /api/rfq/accept}
- * happy path, verifies the resulting OrderSignal lands on the {@code strategy.signals} topic.
- *
- * <p>The OM HTTP call is short-circuited by overriding the position-lookup base URL to a
- * non-routable address, so the engine falls back to "unavailable" — meaning flat position — which
- * is exactly what the test expects.
- */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @Testcontainers
@@ -59,7 +50,6 @@ public class RfqEndToEndIntegrationTest {
   @DynamicPropertySource
   static void kafkaProperties(DynamicPropertyRegistry registry) {
     registry.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
-    // route OM lookups to a black-hole address so the engine sees a fall-back flat position
     registry.add("strategy-engine.rfq.order-manager-base-url", () -> "http://127.0.0.1:1");
     registry.add("strategy-engine.rfq.position-lookup-timeout-ms", () -> "100");
   }
@@ -71,7 +61,6 @@ public class RfqEndToEndIntegrationTest {
 
   @Test
   void quoteThenAcceptPublishesOrderSignalToStrategySignalsTopic() throws Exception {
-    // 1. prime book
     cache.onTick(
         new MarketTick(
             "AAPL",
@@ -87,7 +76,6 @@ public class RfqEndToEndIntegrationTest {
             DataSource.SIMULATED,
             false));
 
-    // 2. request quote
     var quoteResp =
         mvc.perform(
                 post("/api/rfq/quote")
@@ -99,7 +87,6 @@ public class RfqEndToEndIntegrationTest {
     var body = json.readValue(quoteResp.getResponse().getContentAsString(), RfqQuoteResponse.class);
     assertThat(body.bid().doubleValue()).isLessThan(body.ask().doubleValue());
 
-    // 3. accept BUY side at ask
     var props = new HashMap<String, Object>();
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
     props.put(ConsumerConfig.GROUP_ID_CONFIG, "rfq-test-" + UUID.randomUUID());

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/RfqPricingEngineTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/RfqPricingEngineTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 class RfqPricingEngineTest {
 
-  // base 4 bps, λ=1.0, neutral $1M, max-skew 30 bps, vol scalar 0.5, adv scalar 0.3
   private static final RfqPricingConfig CONFIG =
       new RfqPricingConfig(4.0, 1.0, 1_000_000.0, 30.0, 0.5, 0.3, 10_000L, "http://x", 500L, 30);
 
@@ -66,40 +65,34 @@ class RfqPricingEngineTest {
 
   @Test
   void flatPositionYieldsSymmetricSpreadAroundMid() {
-    primeBook("AAPL", "100.00", "100.20"); // mid 100.10
+    primeBook("AAPL", "100.00", "100.20");
     when(positionLookup.fetch("AAPL")).thenReturn(PositionView.flat("AAPL"));
 
-    var q = engine.quote("AAPL", 100); // size/ADV = 100/60M ≈ 1.67e-6 → ~5e-4 bps widening
+    var q = engine.quote("AAPL", 100);
     assertThat(q.inventorySkewBps()).isEqualTo(0.0);
     assertThat(q.marketMid()).isEqualByComparingTo("100.10");
     assertThat(q.adjustedMid()).isEqualByComparingTo("100.10");
-    // base 4 / 2 = 2 bps half-spread → bid = 100.10 * (1-0.0002) = 100.0800,
-    //   ask = 100.10 * (1+0.0002) = 100.1200
     assertThat(q.bid().doubleValue()).isCloseTo(100.0800, within(0.001));
     assertThat(q.ask().doubleValue()).isCloseTo(100.1200, within(0.001));
   }
 
   @Test
   void longInventoryShiftsMidDown() {
-    primeBook("AAPL", "100.00", "100.20"); // mid 100.10
-    // +10_000 shares × $100.10 mid = $1.001M notional → λ=1 → 1.0 × (1.001M / 1M) = 1.001
-    // expressed in fraction → 1.001 → in bps 10_010. Capped to inventoryMaxSkewBps=30 → 30 bps.
+    primeBook("AAPL", "100.00", "100.20");
     when(positionLookup.fetch("AAPL"))
         .thenReturn(
             new PositionView("AAPL", new BigDecimal("10000"), new BigDecimal("100.10"), true));
 
     var q = engine.quote("AAPL", 100);
-    // skew capped at +30 bps → adjMid = 100.10 * (1 - 0.0030) = 99.7997
     assertThat(q.inventorySkewBps()).isCloseTo(30.0, within(0.01));
     assertThat(q.adjustedMid().doubleValue()).isCloseTo(99.7997, within(0.01));
-    // bid/ask straddle the lower adjMid → both shift down vs the flat case
     assertThat(q.bid().doubleValue()).isLessThan(100.0800);
     assertThat(q.ask().doubleValue()).isLessThan(100.1200);
   }
 
   @Test
   void shortInventoryShiftsMidUp() {
-    primeBook("AAPL", "100.00", "100.20"); // mid 100.10
+    primeBook("AAPL", "100.00", "100.20");
     when(positionLookup.fetch("AAPL"))
         .thenReturn(
             new PositionView("AAPL", new BigDecimal("-10000"), new BigDecimal("100.10"), true));
@@ -113,9 +106,7 @@ class RfqPricingEngineTest {
 
   @Test
   void inventorySkewProportionalBelowCap() {
-    primeBook("AAPL", "100.00", "100.20"); // mid 100.10
-    // 1000 shares × $100.10 ≈ $100,100 notional, /1M neutral × λ=1 → 0.1001 frac → 1001 bps,
-    // but capped at 30 bps. So we use a smaller λ to stay below cap:
+    primeBook("AAPL", "100.00", "100.20");
     var lowLambdaConfig =
         new RfqPricingConfig(
             4.0, 0.0001, 1_000_000.0, 30.0, 0.0, 0.0, 10_000L, "http://x", 500L, 30);
@@ -127,20 +118,17 @@ class RfqPricingEngineTest {
             new PositionView("AAPL", new BigDecimal("1000"), new BigDecimal("100.10"), true));
 
     var q = lowEngine.quote("AAPL", 100);
-    // notional ≈ 100100, λ=1e-4 → fraction = 1e-4 × 100100/1e6 = 1.001e-5 → 0.1001 bps
     assertThat(q.inventorySkewBps()).isCloseTo(0.1001, within(0.005));
   }
 
   @Test
   void higherVolatilityWidensSpread() {
     when(positionLookup.fetch("AAPL")).thenReturn(PositionView.flat("AAPL"));
-    // calm series
     primeBook("AAPL", "100.00", "100.20");
     primeBook("AAPL", "100.01", "100.21");
     primeBook("AAPL", "100.00", "100.20");
     var calm = engine.quote("AAPL", 100);
 
-    // now inject big moves to drive realised vol up
     primeBook("AAPL", "102.00", "102.20");
     primeBook("AAPL", "98.00", "98.20");
     primeBook("AAPL", "103.00", "103.20");
@@ -158,8 +146,8 @@ class RfqPricingEngineTest {
     when(positionLookup.fetch("AAPL")).thenReturn(PositionView.flat("AAPL"));
     primeBook("AAPL", "100.00", "100.20");
 
-    var small = engine.quote("AAPL", 100); // tiny vs ADV=60M
-    var big = engine.quote("AAPL", 600_000); // 1% of ADV
+    var small = engine.quote("AAPL", 100);
+    var big = engine.quote("AAPL", 600_000);
 
     assertThat(big.advParticipationFraction()).isGreaterThan(small.advParticipationFraction());
     assertThat(big.advWideningBps()).isGreaterThan(small.advWideningBps());
@@ -171,7 +159,6 @@ class RfqPricingEngineTest {
     primeBook("XYZ", "50.00", "50.10");
     when(positionLookup.fetch("XYZ")).thenReturn(PositionView.flat("XYZ"));
     var q = engine.quote("XYZ", 100);
-    // ADV=0 → advFraction=0 → no widening
     assertThat(q.advParticipationFraction()).isEqualTo(0.0);
     assertThat(q.advWideningBps()).isEqualTo(0.0);
   }
@@ -181,7 +168,7 @@ class RfqPricingEngineTest {
     primeBook("AAPL", "100.00", "100.20");
     when(positionLookup.fetch("AAPL")).thenReturn(PositionView.unavailable("AAPL"));
     var q = engine.quote("AAPL", 100);
-    assertThat(q.inventorySkewBps()).isEqualTo(0.0); // treated as flat
+    assertThat(q.inventorySkewBps()).isEqualTo(0.0);
     assertThat(q.bid()).isNotNull();
     assertThat(q.ask()).isNotNull();
   }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/VolatilityTrackerTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/rfq/VolatilityTrackerTest.java
@@ -21,7 +21,7 @@ class VolatilityTrackerTest {
     var tracker = new VolatilityTracker(cache);
     assertThat(tracker.realizedVolBps("AAPL")).isZero();
     cache.onTick(quote("AAPL", "100.00", "100.10"));
-    assertThat(tracker.realizedVolBps("AAPL")).isZero(); // 1 sample → 0 returns
+    assertThat(tracker.realizedVolBps("AAPL")).isZero();
   }
 
   @Test
@@ -39,12 +39,11 @@ class VolatilityTrackerTest {
     var cache = new MarketStateCache(CONFIG);
     var tracker = new VolatilityTracker(cache);
 
-    cache.onTick(quote("AAPL", "100.00", "100.20")); // mid 100.10
-    cache.onTick(quote("AAPL", "100.50", "100.70")); // mid 100.60 → log(100.60/100.10)≈0.00498
-    cache.onTick(quote("AAPL", "100.00", "100.20")); // mid 100.10 → log(100.10/100.60)≈-0.00498
+    cache.onTick(quote("AAPL", "100.00", "100.20"));
+    cache.onTick(quote("AAPL", "100.50", "100.70"));
+    cache.onTick(quote("AAPL", "100.00", "100.20"));
 
     double vol = tracker.realizedVolBps("AAPL");
-    // sample stdev of {+0.00498, -0.00498} ≈ 0.00704 → 70.4 bps
     assertThat(vol).isCloseTo(70.4, within(0.5));
   }
 

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/routing/RegimeBasedStrategySelectorTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/routing/RegimeBasedStrategySelectorTest.java
@@ -33,7 +33,6 @@ public class RegimeBasedStrategySelectorTest {
             new RegimeAutoSelectConfig(false, 0.6, Map.of()), mlClient, registry);
 
     assertThat(selector.selectFor("AAPL")).isEmpty();
-    // No need to call out to the ML service when the feature is off.
     verify(mlClient, never()).getRegime("AAPL");
   }
 
@@ -74,7 +73,6 @@ public class RegimeBasedStrategySelectorTest {
 
   @Test
   void returnsEmptyOnUnmappedRegimeSoCallerFallsBackToManualBinding() {
-    // HIGH_VOLATILITY intentionally has no default mapping — let the user choose explicitly.
     when(mlClient.getRegime("TSLA"))
         .thenReturn(Optional.of(new MlRegimeResult(MarketRegime.HIGH_VOLATILITY, 0.95)));
     var selector =
@@ -96,8 +94,7 @@ public class RegimeBasedStrategySelectorTest {
 
   @Test
   void honorsConfigOverridesOverDefaults() {
-    // Override the default MEAN_REVERTING → VWAP mapping to TWAP via config.
-    var twap = vwap; // reuse the mock — its identity is what matters
+    var twap = vwap;
     when(mlClient.getRegime("GOOGL"))
         .thenReturn(Optional.of(new MlRegimeResult(MarketRegime.MEAN_REVERTING, 0.8)));
     when(registry.get("TWAP")).thenReturn(Optional.of(twap));

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/service/StrategyEvaluationServiceTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/service/StrategyEvaluationServiceTest.java
@@ -66,10 +66,8 @@ public class StrategyEvaluationServiceTest {
     underTest =
         new StrategyEvaluationService(
             router, regimeSelector, mlClient, gate, signalPublisher, metrics, tradingHoursService);
-    // Lenient because the regime-selector test overrides this and skips the router path.
     lenient().when(regimeSelector.selectFor(SYMBOL)).thenReturn(Optional.empty());
     lenient().when(router.getActiveStrategy(SYMBOL)).thenReturn(Optional.of(strategy));
-    // Most tests assume the market is open — the trading-hours-gate test overrides this.
     lenient().when(tradingHoursService.isMarketOpen(any(), any())).thenReturn(true);
   }
 
@@ -169,7 +167,6 @@ public class StrategyEvaluationServiceTest {
 
     when(strategy.name()).thenReturn("VWAP");
     when(strategy.evaluate(SYMBOL)).thenReturn(Optional.of(BUY_SIGNAL));
-    // recommendedSize=0.30 → scale = 0.30 / 0.20 = 1.5x → 100 * 1.5 = 150
     when(mlClient.getSignal(SYMBOL))
         .thenReturn(Optional.of(new MlSignalResult(Direction.LONG, 0.85, 0.30)));
 
@@ -183,7 +180,6 @@ public class StrategyEvaluationServiceTest {
 
   @Test
   void evaluateUsesRegimeSelectorWhenItReturnsAStrategy() {
-    // Regime-driven selection overrides whatever the manual router would say (FR-17).
     when(regimeSelector.selectFor(SYMBOL)).thenReturn(Optional.of(strategy));
     when(strategy.name()).thenReturn("MOMENTUM");
     when(strategy.evaluate(SYMBOL)).thenReturn(Optional.of(BUY_SIGNAL));
@@ -193,7 +189,6 @@ public class StrategyEvaluationServiceTest {
 
     verify(signalPublisher).publish(BUY_SIGNAL);
     verify(metrics).recordSignal("MOMENTUM", Side.BUY);
-    // Manual router should not be consulted when the regime selector returns a strategy.
     verify(router, never()).getActiveStrategy(SYMBOL);
   }
 

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/sessions/TradingHoursServiceTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/sessions/TradingHoursServiceTest.java
@@ -53,41 +53,35 @@ class TradingHoursServiceTest {
   void disabledServiceTreatsEveryTimestampAsOpen() {
     var disabled =
         new TradingHoursService(new TradingHoursConfig(false, "NYSE", Map.of(), Map.of()));
-    // Saturday 3am — well outside any reasonable session.
     assertThat(disabled.isMarketOpen("AAPL", Instant.parse("2026-06-13T03:00:00Z"))).isTrue();
   }
 
   @Test
   void nyseOpenAt10AmEt() {
-    // 14:30Z = 10:30 ET — inside the regular session on a Monday.
     assertThat(enabledService().isMarketOpen("AAPL", Instant.parse("2026-06-08T14:30:00Z")))
         .isTrue();
   }
 
   @Test
   void nyseClosedBefore930Et() {
-    // 13:00Z = 09:00 ET — half an hour before the open.
     assertThat(enabledService().isMarketOpen("AAPL", Instant.parse("2026-06-08T13:00:00Z")))
         .isFalse();
   }
 
   @Test
   void nyseClosedAfter4PmEt() {
-    // 20:30Z = 16:30 ET — half an hour after the close.
     assertThat(enabledService().isMarketOpen("AAPL", Instant.parse("2026-06-08T20:30:00Z")))
         .isFalse();
   }
 
   @Test
   void nyseClosedOnWeekends() {
-    // 2026-06-13 is a Saturday.
     assertThat(enabledService().isMarketOpen("AAPL", Instant.parse("2026-06-13T14:30:00Z")))
         .isFalse();
   }
 
   @Test
   void nyseClosedOnConfiguredHoliday() {
-    // 2026-07-03 is the observed Independence Day holiday on the NYSE config above.
     assertThat(enabledService().isMarketOpen("AAPL", Instant.parse("2026-07-03T14:30:00Z")))
         .isFalse();
   }
@@ -95,11 +89,8 @@ class TradingHoursServiceTest {
   @Test
   void tseHandlesZenbaAndGobaWithLunchBreakClosed() {
     var service = enabledService();
-    // 09:30 JST Monday — inside Zenba.
     assertThat(service.isMarketOpen("7203", Instant.parse("2026-06-08T00:30:00Z"))).isTrue();
-    // 12:00 JST Monday — inside the one-hour lunch break.
     assertThat(service.isMarketOpen("7203", Instant.parse("2026-06-08T03:00:00Z"))).isFalse();
-    // 13:00 JST Monday — inside Goba.
     assertThat(service.isMarketOpen("7203", Instant.parse("2026-06-08T04:00:00Z"))).isTrue();
   }
 
@@ -110,11 +101,7 @@ class TradingHoursServiceTest {
 
   @Test
   void unknownMarketAllowsTickThroughForSafety() {
-    // Symbol mapped to a market that is NOT in the schedules → service should not silently block
-    // every tick; safer to let it through than to assume the desk meant to halt trading.
-    var config =
-        new TradingHoursConfig(
-            true, "MYSTERY", Map.of("NYSE", NYSE), Map.of()); // default→MYSTERY not in schedules
+    var config = new TradingHoursConfig(true, "MYSTERY", Map.of("NYSE", NYSE), Map.of());
     var svc = new TradingHoursService(config);
     assertThat(svc.isMarketOpen("AAPL", Instant.parse("2026-06-08T03:00:00Z"))).isTrue();
   }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/close/CloseStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/close/CloseStrategyTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 class CloseStrategyTest {
 
   private static final String AAPL = "AAPL";
-  // Standard test window: 15:00-16:00 with MOC offset 10 min → mocCutoff = 15:50, pre-close
-  // window = 15:00-15:50 (50 minutes), 5 ten-minute slices.
   private static final LocalTime WINDOW_START = LocalTime.of(15, 0);
   private static final LocalTime CLOSE_TIME = LocalTime.of(16, 0);
   private static final int MOC_OFFSET_MIN = 10;
@@ -58,7 +56,6 @@ class CloseStrategyTest {
 
   @Test
   void evaluateReturnsEmptyBeforeConfiguration() {
-    // Before target is set, evaluate is empty regardless of incoming ticks.
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
 
@@ -71,7 +68,6 @@ class CloseStrategyTest {
 
   @Test
   void preCloseSliceEmitsLimitOrderAtBidAsk() {
-    // 1000 shares, 50% preCloseFraction → 500 in pre-close (5 slices × 100), 500 in MOC.
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
 
@@ -90,7 +86,7 @@ class CloseStrategyTest {
   void evaluateDoesNotReemitForSameSlice() {
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
-    strategy.evaluate(AAPL); // fires slice 0
+    strategy.evaluate(AAPL);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 9), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
@@ -104,7 +100,6 @@ class CloseStrategyTest {
     quantities.add(emitSliceAt(15, 25));
     quantities.add(emitSliceAt(15, 35));
     quantities.add(emitSliceAt(15, 45));
-    // All five 10-min slices fire 100 shares each → 500 in pre-close (the 50% half).
     assertThat(quantities).containsExactly(100, 100, 100, 100, 100);
   }
 
@@ -112,12 +107,9 @@ class CloseStrategyTest {
   void mocFiresAtCutoffSweepingResidualAndPlannedMoc() {
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
 
-    // Execute first two pre-close slices (100 + 100 = 200).
     emitSliceAt(15, 5);
     emitSliceAt(15, 15);
 
-    // Jump to MOC cutoff (15:50). Remaining = 1000 - 200 = 800 — the 500 planned MOC + the 300
-    // skipped slice quantity, swept in a single MARKET order.
     strategy.onTick(quoteTick(AAPL, etInstant(15, 50), "180.00", "180.04"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -132,7 +124,7 @@ class CloseStrategyTest {
   void mocFiresOnlyOnce() {
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 55), "180.00", "180.04"));
-    assertThat(strategy.evaluate(AAPL)).isPresent(); // MOC fires
+    assertThat(strategy.evaluate(AAPL)).isPresent();
     strategy.onTick(quoteTick(AAPL, etInstant(15, 58), "180.00", "180.04"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
     assertThat(strategy.getParameters().get("mocFired")).isEqualTo(true);
@@ -140,7 +132,6 @@ class CloseStrategyTest {
 
   @Test
   void pureMocWhenPreCloseFractionIsZero() {
-    // 0% pre-close → all 1000 shares go in the MOC, pre-close slices fire 0 shares.
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, 0.0, FIVE_SLICES);
     var params = strategy.getParameters();
     assertThat(params.get("mocAllocation")).isEqualTo(1000);
@@ -149,11 +140,9 @@ class CloseStrategyTest {
     var allocations = (List<Integer>) params.get("sliceAllocations");
     assertThat(allocations).containsExactly(0, 0, 0, 0, 0);
 
-    // Pre-close ticks emit no LIMIT signals.
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
 
-    // At MOC cutoff, the full 1000 fires as MARKET.
     strategy.onTick(quoteTick(AAPL, etInstant(15, 50), "180.00", "180.04"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -163,7 +152,6 @@ class CloseStrategyTest {
 
   @Test
   void pureWorkingWhenPreCloseFractionIsOne() {
-    // 100% pre-close → all 1000 shares spread across the 5 slices, MOC fires for 0 shares.
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, 1.0, FIVE_SLICES);
 
     var quantities = new ArrayList<Integer>();
@@ -172,11 +160,9 @@ class CloseStrategyTest {
     quantities.add(emitSliceAt(15, 25));
     quantities.add(emitSliceAt(15, 35));
     quantities.add(emitSliceAt(15, 45));
-    // 1000 / 5 = 200 per slice; last absorbs remainder = 1000 - 4*200 = 200.
     assertThat(quantities).containsExactly(200, 200, 200, 200, 200);
     assertThat(quantities.stream().mapToInt(Integer::intValue).sum()).isEqualTo(1000);
 
-    // At MOC cutoff, remaining = 0 → no MARKET emit, but mocFired flips to true.
     strategy.onTick(quoteTick(AAPL, etInstant(15, 55), "180.00", "180.04"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
     assertThat(strategy.getParameters().get("mocFired")).isEqualTo(true);
@@ -184,8 +170,6 @@ class CloseStrategyTest {
 
   @Test
   void allocationsSumExactlyToTarget() {
-    // 1001 shares, 50%, 5 slices → preCloseTotal = 501. perSlice = round(501/5) = 100, last
-    // absorbs remainder = 501 - 4×100 = 101. mocAllocation = 1001 - 501 = 500.
     configure(1001, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     var params = strategy.getParameters();
 
@@ -235,7 +219,6 @@ class CloseStrategyTest {
 
   @Test
   void lateBindingAfterCutoffStillFiresMoc() {
-    // Strategy bound at 15:58, between mocCutoff (15:50) and closeTime (16:00).
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 58), "180.00", "180.04"));
     var signal = strategy.evaluate(AAPL);
@@ -246,7 +229,6 @@ class CloseStrategyTest {
 
   @Test
   void postCloseSweepEmitsResidualAsMarket() {
-    // Strategy bound *after* closeTime — no MOC opportunity, sweep instead.
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(16, 5), "180.00", "180.04"));
     var signal = strategy.evaluate(AAPL);
@@ -254,7 +236,6 @@ class CloseStrategyTest {
     assertThat(signal.get().quantity()).isEqualTo(1000);
     assertThat(signal.get().orderType()).isEqualTo(OrderType.MARKET);
 
-    // Subsequent post-close ticks are quiet — completed flag prevents re-fire.
     strategy.onTick(quoteTick(AAPL, etInstant(16, 10), "180.00", "180.04"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
@@ -269,8 +250,6 @@ class CloseStrategyTest {
 
   @Test
   void degenerateScheduleWhenMocOffsetOvershootsWindow() {
-    // mocOffset (90 min) is bigger than the 60-min window → mocCutoff clamped to windowStart,
-    // pre-close window is empty, everything flows through the MOC.
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, 90, HALF, FIVE_SLICES);
     var params = strategy.getParameters();
     assertThat(params.get("totalPreCloseSlices")).isEqualTo(0);
@@ -285,7 +264,7 @@ class CloseStrategyTest {
     assertThat(params.get("mocAllocation")).isEqualTo(1000);
 
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
-    assertThat(strategy.evaluate(AAPL)).isEmpty(); // pre-close inactive
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
 
     strategy.onTick(quoteTick(AAPL, etInstant(15, 50), "180.00", "180.04"));
     var signal = strategy.evaluate(AAPL);
@@ -316,36 +295,31 @@ class CloseStrategyTest {
   void partialParameterUpdatePreservesOtherFields() {
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.updateParameters(Map.of("preCloseFraction", 0.0));
-    // Window/side/target/slice count must remain — only the split changes.
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
-    // preCloseFraction=0 → each pre-close slice allocates 0 shares.
     assertThat(strategy.evaluate(AAPL)).isEmpty();
 
     strategy.onTick(quoteTick(AAPL, etInstant(15, 50), "180.00", "180.04"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
-    assertThat(signal.get().quantity()).isEqualTo(1000); // full size in MOC
+    assertThat(signal.get().quantity()).isEqualTo(1000);
   }
 
   @Test
   void updateParametersResetsExecutionState() {
     configure(1000, Side.BUY, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
-    assertThat(strategy.evaluate(AAPL)).isPresent(); // slice 0 fires
+    assertThat(strategy.evaluate(AAPL)).isPresent();
 
-    // Reconfigure with new target — slice 0 should be re-eligible.
     configure(2000, Side.SELL, WINDOW_START, CLOSE_TIME, MOC_OFFSET_MIN, HALF, FIVE_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(15, 5), "178.50", "178.54"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
-    assertThat(signal.get().quantity()).isEqualTo(200); // 50% of 2000 / 5 slices
+    assertThat(signal.get().quantity()).isEqualTo(200);
     assertThat(signal.get().side()).isEqualTo(Side.SELL);
   }
 
   @Test
   void fullSessionSimulationCompletesByTheClose() {
-    // 10,000-share parent, default window 15:30-16:00 with MOC offset 5 → mocCutoff 15:55,
-    // 6 pre-close slices of ~4 min 10 s each, 30% pre-close fraction.
     var params = new HashMap<String, Object>();
     params.put("targetQuantity", 10000);
     params.put("side", "BUY");
@@ -358,7 +332,6 @@ class CloseStrategyTest {
       strategy.onTick(quoteTick(AAPL, ts, "178.50", "178.54"));
       strategy.evaluate(AAPL).ifPresent(signals::add);
     }
-    // EOD: tick at 16:00 confirms completion (no further emits expected).
     var closeTs = ZonedDateTime.of(baseDate, LocalTime.of(16, 0), MARKET_ZONE).toInstant();
     strategy.onTick(quoteTick(AAPL, closeTs, "178.50", "178.54"));
     strategy.evaluate(AAPL).ifPresent(signals::add);
@@ -368,14 +341,11 @@ class CloseStrategyTest {
 
     var marketSignals = signals.stream().filter(s -> s.orderType() == OrderType.MARKET).toList();
     var limitSignals = signals.stream().filter(s -> s.orderType() == OrderType.LIMIT).toList();
-    assertThat(marketSignals).hasSize(1); // exactly one MOC
-    assertThat(marketSignals.getFirst().quantity()).isEqualTo(7000); // 70% in MOC
+    assertThat(marketSignals).hasSize(1);
+    assertThat(marketSignals.getFirst().quantity()).isEqualTo(7000);
     assertThat(limitSignals.stream().mapToInt(OrderSignal::quantity).sum()).isEqualTo(3000);
   }
 
-  /**
-   * Feeds a quote tick at {@code hour}:{@code minute} ET and returns the emitted slice quantity.
-   */
   private int emitSliceAt(int hour, int minute) {
     strategy.onTick(quoteTick(AAPL, etInstant(hour, minute), "178.50", "178.54"));
     return strategy.evaluate(AAPL).orElseThrow().quantity();

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/momentum/MomentumStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/momentum/MomentumStrategyTest.java
@@ -59,7 +59,7 @@ class MomentumStrategyTest {
   void bullishCrossoverWithConfirmationEntersLong() {
     configure(Map.of());
 
-    assertThat(step(trade(AAPL, "100.00", 100, "99.98", "100.02"))).isEmpty(); // seed
+    assertThat(step(trade(AAPL, "100.00", 100, "99.98", "100.02"))).isEmpty();
     var signal = step(trade(AAPL, "101.00", 300, "100.98", "101.02"));
 
     assertThat(signal).isPresent();
@@ -84,7 +84,6 @@ class MomentumStrategyTest {
   @Test
   void entrySuppressedWhenVolumeNotConfirmed() {
     configure(Map.of("volumeMultiplier", 1.5));
-    // Large baseline, tiny breakout volume — crossover fires but volume fails to confirm.
     assertThat(step(trade(AAPL, "100.00", 1000, "99.98", "100.02"))).isEmpty();
     assertThat(step(trade(AAPL, "101.00", 100, "100.98", "101.02"))).isEmpty();
     assertThat(strategy.getParameters().get("position")).isEqualTo("FLAT");
@@ -92,12 +91,11 @@ class MomentumStrategyTest {
 
   @Test
   void entrySuppressedWhenRsiOverbought() {
-    // rsiPeriod 2 makes RSI react fast; a sharp rally lifts RSI above 70 at the crossover.
     configure(Map.of("rsiPeriod", 2, "volumeMultiplier", 0.0));
-    step(trade(AAPL, "100.00", 100, "99.98", "100.02")); // seed, above=false
-    step(trade(AAPL, "99.00", 100, "98.98", "99.02")); // down
-    step(trade(AAPL, "98.00", 100, "97.98", "98.02")); // down → RSI 0
-    var signal = step(trade(AAPL, "102.00", 300, "101.98", "102.02")); // rally → bullish + RSI 80
+    step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
+    step(trade(AAPL, "99.00", 100, "98.98", "99.02"));
+    step(trade(AAPL, "98.00", 100, "97.98", "98.02"));
+    var signal = step(trade(AAPL, "102.00", 300, "101.98", "102.02"));
 
     assertThat(signal).as("bullish crossover but RSI overbought → no entry").isEmpty();
     assertThat(strategy.getParameters().get("position")).isEqualTo("FLAT");
@@ -108,8 +106,7 @@ class MomentumStrategyTest {
   void noReentryWhileAlreadyLong() {
     configure(Map.of());
     step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
-    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent(); // enter long
-    // Further up-trending trades keep us long but emit nothing new.
+    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent();
     assertThat(step(trade(AAPL, "102.00", 300, "101.98", "102.02"))).isEmpty();
     assertThat(step(trade(AAPL, "103.00", 300, "102.98", "103.02"))).isEmpty();
     assertThat(strategy.getParameters().get("position")).isEqualTo("LONG");
@@ -119,9 +116,9 @@ class MomentumStrategyTest {
   void bearishCrossoverExitsLong() {
     configure(Map.of());
     step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
-    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent(); // enter long
+    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent();
 
-    var exit = step(trade(AAPL, "100.00", 300, "99.98", "100.02")); // fast dips below slow
+    var exit = step(trade(AAPL, "100.00", 300, "99.98", "100.02"));
     assertThat(exit).isPresent();
     var order = exit.get();
     assertThat(order.side()).isEqualTo(Side.SELL);
@@ -134,9 +131,9 @@ class MomentumStrategyTest {
   @Test
   void rsiOverboughtExitsLong() {
     configure(Map.of("rsiPeriod", 2, "rsiOverbought", 70.0, "volumeMultiplier", 0.0));
-    step(trade(AAPL, "100.00", 100, "99.98", "100.02")); // seed
-    assertThat(step(trade(AAPL, "101.00", 100, "100.98", "101.02"))).isPresent(); // enter, RSI ~50
-    var exit = step(trade(AAPL, "102.00", 100, "101.98", "102.02")); // RSI → 100, still long-trend
+    step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
+    assertThat(step(trade(AAPL, "101.00", 100, "100.98", "101.02"))).isPresent();
+    var exit = step(trade(AAPL, "102.00", 100, "101.98", "102.02"));
     assertThat(exit).isPresent();
     assertThat(exit.get().side()).isEqualTo(Side.SELL);
     assertThat(exit.get().orderType()).isEqualTo(OrderType.MARKET);
@@ -147,9 +144,8 @@ class MomentumStrategyTest {
   void stopLossExitsLongOnAdverseQuote() {
     configure(Map.of("stopLossPct", 1.0));
     step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
-    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent(); // long @ 101.02
+    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent();
 
-    // A quote dropping ~2% below entry trips the stop without moving the EMAs.
     var exit = step(quote(AAPL, "99.00", "99.04"));
     assertThat(exit).isPresent();
     assertThat(exit.get().side()).isEqualTo(Side.SELL);
@@ -160,15 +156,15 @@ class MomentumStrategyTest {
   @Test
   void shortSideEntersOnBearishCrossover() {
     configure(Map.of("side", "SELL"));
-    step(trade(AAPL, "100.00", 100, "99.98", "100.02")); // seed
-    step(trade(AAPL, "101.00", 100, "100.98", "101.02")); // bullish (ignored on short side)
-    var signal = step(trade(AAPL, "99.00", 300, "98.96", "99.04")); // bearish crossover
+    step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
+    step(trade(AAPL, "101.00", 100, "100.98", "101.02"));
+    var signal = step(trade(AAPL, "99.00", 300, "98.96", "99.04"));
 
     assertThat(signal).isPresent();
     var order = signal.get();
     assertThat(order.side()).isEqualTo(Side.SELL);
     assertThat(order.orderType()).isEqualTo(OrderType.LIMIT);
-    assertThat(order.limitPrice()).isEqualByComparingTo(new BigDecimal("98.96")); // sells at bid
+    assertThat(order.limitPrice()).isEqualByComparingTo(new BigDecimal("98.96"));
     assertThat(strategy.getParameters().get("position")).isEqualTo("SHORT");
   }
 
@@ -177,9 +173,9 @@ class MomentumStrategyTest {
     configure(Map.of("side", "SELL"));
     step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
     step(trade(AAPL, "101.00", 100, "100.98", "101.02"));
-    assertThat(step(trade(AAPL, "99.00", 300, "98.96", "99.04"))).isPresent(); // enter short
+    assertThat(step(trade(AAPL, "99.00", 300, "98.96", "99.04"))).isPresent();
 
-    var exit = step(trade(AAPL, "101.00", 100, "100.98", "101.02")); // bullish crossover
+    var exit = step(trade(AAPL, "101.00", 100, "100.98", "101.02"));
     assertThat(exit).isPresent();
     assertThat(exit.get().side()).isEqualTo(Side.BUY);
     assertThat(exit.get().orderType()).isEqualTo(OrderType.MARKET);
@@ -216,14 +212,13 @@ class MomentumStrategyTest {
   void updateParametersResetsState() {
     configure(Map.of());
     step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
-    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent(); // long
+    assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isPresent();
     assertThat(strategy.getParameters().get("position")).isEqualTo("LONG");
 
     configure(Map.of("tradeQuantity", 50));
     assertThat(strategy.getParameters().get("position")).isEqualTo("FLAT");
     assertThat(strategy.getParameters().get("tradesObserved")).isEqualTo(0L);
 
-    // Fresh run honours the new quantity.
     step(trade(AAPL, "100.00", 100, "99.98", "100.02"));
     var signal = step(trade(AAPL, "101.00", 300, "100.98", "101.02"));
     assertThat(signal).isPresent();
@@ -237,7 +232,7 @@ class MomentumStrategyTest {
     var params = strategy.getParameters();
     assertThat(params.get("tradeQuantity")).isEqualTo(250);
     assertThat(params.get("side")).isEqualTo("BUY");
-    assertThat(params.get("fastPeriod")).isEqualTo(2); // retained from configure()
+    assertThat(params.get("fastPeriod")).isEqualTo(2);
     assertThat(params.get("slowPeriod")).isEqualTo(3);
   }
 
@@ -258,8 +253,6 @@ class MomentumStrategyTest {
     assertThat(step(trade(AAPL, "101.00", 300, "100.98", "101.02"))).isEmpty();
   }
 
-  // --- helpers ---------------------------------------------------------------
-
   private Optional<OrderSignal> step(MarketTick tick) {
     strategy.onTick(tick);
     return strategy.evaluate(tick.symbol());
@@ -277,7 +270,7 @@ class MomentumStrategyTest {
     params.put("volumeLookback", 20);
     params.put("tradeQuantity", 100);
     params.put("side", "BUY");
-    params.put("stopLossPct", 50.0); // effectively off unless overridden
+    params.put("stopLossPct", 50.0);
     params.putAll(overrides);
     strategy.updateParameters(params);
   }

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/pov/PovStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/pov/PovStrategyTest.java
@@ -67,19 +67,15 @@ class PovStrategyTest {
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
     // Pre-open prints don't count toward cumulative volume
     strategy.onTick(tradeTick(AAPL, etInstant(9, 0), "178.50", 50_000L));
-    // First in-window tick has small size so participation target is 0
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.55", 5L));
     var signal = strategy.evaluate(AAPL);
-    // 10% × 5 shares = 0.5, floors to 0, no emission
     assertThat(signal).isEmpty();
     assertThat(strategy.getParameters().get("cumulativeMarketVolume")).isEqualTo(5L);
   }
 
   @Test
   void firstQualifyingTickEmitsParticipationClip() {
-    // 1000-share parent at 10% participation
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
-    // 5000 shares trade on the tape → strategy should emit 500
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 5_000L));
 
     var signal = strategy.evaluate(AAPL);
@@ -96,15 +92,12 @@ class PovStrategyTest {
   @Test
   void cumulativeParticipationTracksMarketVolume() {
     configurePov(10_000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
-    // Tick 1: 1000 shares → 100 share clip
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 1_000L));
     assertThat(strategy.evaluate(AAPL).orElseThrow().quantity()).isEqualTo(100);
 
-    // Tick 2: another 1000 shares → 100 more shares (cumulative 200, emitted 200)
     strategy.onTick(tradeTick(AAPL, etInstant(10, 1), "178.55", 1_000L));
     assertThat(strategy.evaluate(AAPL).orElseThrow().quantity()).isEqualTo(100);
 
-    // Tick 3: 5000 more → 500 more shares (cumulative 700)
     strategy.onTick(tradeTick(AAPL, etInstant(10, 2), "178.56", 5_000L));
     assertThat(strategy.evaluate(AAPL).orElseThrow().quantity()).isEqualTo(500);
 
@@ -114,11 +107,9 @@ class PovStrategyTest {
   @Test
   void smallVolumeBelowMinClipDeferred() {
     configurePov(1000, Side.BUY, TEN_PCT, 100, Integer.MAX_VALUE);
-    // 500 shares × 10% = 50 < minClipSize=100 → no emission
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 500L));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
 
-    // Another 500 shares → cumulative 1000 × 10% = 100 ≥ minClipSize → emit 100
     strategy.onTick(tradeTick(AAPL, etInstant(10, 1), "178.55", 500L));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -127,7 +118,6 @@ class PovStrategyTest {
 
   @Test
   void maxClipSizeCapsLargeBlockPrints() {
-    // 1M share block print would normally trigger a 100k clip; cap at 1000 instead.
     configurePov(200_000, Side.BUY, TEN_PCT, 1, 1_000);
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 1_000_000L));
 
@@ -135,7 +125,6 @@ class PovStrategyTest {
     assertThat(signal).isPresent();
     assertThat(signal.get().quantity()).isEqualTo(1_000);
 
-    // Next tick with same cumulative volume should drain the remainder progressively
     strategy.onTick(tradeTick(AAPL, etInstant(10, 1), "178.55", 0L));
     var followUp = strategy.evaluate(AAPL);
     assertThat(followUp).isPresent();
@@ -144,7 +133,6 @@ class PovStrategyTest {
 
   @Test
   void cumulativeEmissionCappedByTargetQuantity() {
-    // 1000-share parent. Tape trades 50k → 10% would suggest 5000, but parent caps it at 1000.
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 50_000L));
 
@@ -152,7 +140,6 @@ class PovStrategyTest {
     assertThat(signal).isPresent();
     assertThat(signal.get().quantity()).isEqualTo(1000);
 
-    // No further emissions; parent fully placed
     strategy.onTick(tradeTick(AAPL, etInstant(10, 1), "178.55", 10_000L));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
@@ -160,7 +147,6 @@ class PovStrategyTest {
   @Test
   void quoteTicksDoNotIncrementVolume() {
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
-    // A quote tick has bidSize/askSize but those are not executed volume
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
     assertThat(strategy.getParameters().get("cumulativeMarketVolume")).isEqualTo(0L);
@@ -196,12 +182,10 @@ class PovStrategyTest {
   @Test
   void emitsMarketSweepAtEndTimeWhenIncomplete() {
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
-    // Execute 500 shares early
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 5_000L));
     var first = strategy.evaluate(AAPL);
     assertThat(first.orElseThrow().quantity()).isEqualTo(500);
 
-    // Jump past end-time tick with little volume
     strategy.onTick(tradeTick(AAPL, etInstant(16, 5), "180.00", 100L));
     var sweep = strategy.evaluate(AAPL);
     assertThat(sweep).isPresent();
@@ -222,7 +206,6 @@ class PovStrategyTest {
   @Test
   void noSweepWhenFullyExecuted() {
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
-    // Drive cumulative volume above 10k so 10% × 10k = 1000 = parent
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 10_000L));
     assertThat(strategy.evaluate(AAPL).orElseThrow().quantity()).isEqualTo(1000);
 
@@ -233,7 +216,6 @@ class PovStrategyTest {
   @Test
   void postWindowTradeVolumeIgnored() {
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
-    // Trades after endTime should NOT bump cumulativeMarketVolume
     strategy.onTick(tradeTick(AAPL, etInstant(16, 30), "180.00", 100_000L));
     assertThat(strategy.getParameters().get("cumulativeMarketVolume")).isEqualTo(0L);
   }
@@ -269,9 +251,8 @@ class PovStrategyTest {
   void updateParametersResetsState() {
     configurePov(1000, Side.BUY, TEN_PCT, 1, Integer.MAX_VALUE);
     strategy.onTick(tradeTick(AAPL, etInstant(10, 0), "178.54", 5_000L));
-    strategy.evaluate(AAPL); // emits 500
+    strategy.evaluate(AAPL);
 
-    // Reconfigure → state resets
     configurePov(2000, Side.SELL, 0.20, 1, Integer.MAX_VALUE);
     var params = strategy.getParameters();
     assertThat(params.get("emittedQuantity")).isEqualTo(0L);
@@ -293,8 +274,6 @@ class PovStrategyTest {
 
   @Test
   void fullSessionSimulationApproximatesTargetParticipation() {
-    // Simulate a session: 100 trades of 10k shares each → 1M cumulative volume.
-    // At 10% participation, the strategy should emit ~10% × 1M = 100k shares (capped at parent).
     configurePov(120_000, Side.BUY, TEN_PCT, 100, Integer.MAX_VALUE);
 
     var baseDate = LocalDate.of(2026, 3, 24);
@@ -323,7 +302,6 @@ class PovStrategyTest {
         signalCount++;
       }
     }
-    // Cumulative emitted ≈ 100k (10% of 1M traded), well within the 120k parent.
     assertThat(totalEmitted).isEqualTo(100_000L);
     assertThat(signalCount).isGreaterThan(0);
     assertThat((long) strategy.getParameters().get("emittedQuantity")).isEqualTo(totalEmitted);
@@ -356,7 +334,7 @@ class PovStrategyTest {
         symbol,
         ts,
         EventType.TRADE,
-        new BigDecimal(ask), // last-trade price ~= ask for a buy print
+        new BigDecimal(ask),
         size,
         new BigDecimal(bid),
         new BigDecimal(ask),

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/shortfall/ImplementationShortfallStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/shortfall/ImplementationShortfallStrategyTest.java
@@ -25,8 +25,6 @@ class ImplementationShortfallStrategyTest {
 
   private static final String AAPL = "AAPL";
 
-  // Standard test window: 09:30-13:30, four equal one-hour slices.
-  //   slice 0: 09:30-10:30, slice 1: 10:30-11:30, slice 2: 11:30-12:30, slice 3: 12:30-13:30
   private static final LocalTime WINDOW_START = LocalTime.of(9, 30);
   private static final LocalTime WINDOW_END = LocalTime.of(13, 30);
   private static final int FOUR_SLICES = 4;
@@ -46,7 +44,6 @@ class ImplementationShortfallStrategyTest {
 
   @Test
   void defaultScheduleSpansTwelveSlicesWithDefaultUrgency() {
-    // Constructor builds the default 09:30-16:00 schedule with 12 slices and urgency 0.5.
     var params = strategy.getParameters();
     assertThat(params.get("totalSlices")).isEqualTo(12);
     assertThat(params.get("numSlices")).isEqualTo(12);
@@ -55,7 +52,6 @@ class ImplementationShortfallStrategyTest {
 
   @Test
   void evaluateReturnsEmptyBeforeConfiguration() {
-    // Fresh strategy: schedule exists but targetQuantity is 0.
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
 
@@ -68,7 +64,6 @@ class ImplementationShortfallStrategyTest {
 
   @Test
   void firstSliceIsFrontLoaded() {
-    // 1000 shares, 4 one-hour slices, urgency 0.5 → front-loaded [413, 263, 180, 144].
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
 
@@ -88,19 +83,18 @@ class ImplementationShortfallStrategyTest {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
 
     var quantities = new ArrayList<Integer>();
-    quantities.add(emitSlice(10)); // slice 0
-    quantities.add(emitSlice(11)); // slice 1
-    quantities.add(emitSlice(12)); // slice 2 (12:00 is inside slice 2: 11:30-12:30)
-    quantities.add(emitSlice(13)); // slice 3 (13:00 is inside slice 3: 12:30-13:30)
+    quantities.add(emitSlice(10));
+    quantities.add(emitSlice(11));
+    quantities.add(emitSlice(12));
+    quantities.add(emitSlice(13));
 
     assertThat(quantities).containsExactly(413, 263, 180, 144);
-    assertThat(quantities).isSortedAccordingTo((a, b) -> Integer.compare(b, a)); // strictly desc
+    assertThat(quantities).isSortedAccordingTo((a, b) -> Integer.compare(b, a));
     assertThat(quantities.stream().mapToInt(Integer::intValue).sum()).isEqualTo(1000);
   }
 
   @Test
   void urgencyZeroDegradesToTwapEqualSlicing() {
-    // urgency 0 → uniform 1/N allocation, identical to TWAP.
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, 0.0);
 
     var quantities = new ArrayList<Integer>();
@@ -127,7 +121,7 @@ class ImplementationShortfallStrategyTest {
     int aggressive = emitSlice(10);
 
     assertThat(aggressive).isGreaterThan(gentle);
-    assertThat(aggressive).isEqualTo(865); // [865, 117, 16, 2]
+    assertThat(aggressive).isEqualTo(865);
     assertThat(gentle).isEqualTo(413);
   }
 
@@ -135,7 +129,7 @@ class ImplementationShortfallStrategyTest {
   void evaluateDoesNotReemitForSameSlice() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
-    strategy.evaluate(AAPL); // first call emits
+    strategy.evaluate(AAPL);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 15), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
@@ -144,11 +138,9 @@ class ImplementationShortfallStrategyTest {
   void evaluateEmitsForNextSliceWhenTimeAdvances() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
 
-    // Slice 0
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).get().extracting(OrderSignal::quantity).isEqualTo(413);
 
-    // Slice 1 (10:30-11:30) — smaller, front-loaded allocation
     strategy.onTick(quoteTick(AAPL, etInstant(11, 0), "179.00", "179.04"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -161,17 +153,15 @@ class ImplementationShortfallStrategyTest {
   void evaluateEmitsMarketSweepAtEndTime() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
 
-    // Execute only slice 0 (413 shares)
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     strategy.evaluate(AAPL);
 
-    // Jump past end time
     strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
 
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
     var orderSignal = signal.get();
-    assertThat(orderSignal.quantity()).isEqualTo(587); // 1000 - 413
+    assertThat(orderSignal.quantity()).isEqualTo(587);
     assertThat(orderSignal.orderType()).isEqualTo(OrderType.MARKET);
     assertThat(orderSignal.limitPrice()).isNull();
   }
@@ -180,14 +170,13 @@ class ImplementationShortfallStrategyTest {
   void sweepEmitsOnlyOnce() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
     strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
-    assertThat(strategy.evaluate(AAPL)).isPresent(); // sweep
+    assertThat(strategy.evaluate(AAPL)).isPresent();
     strategy.onTick(quoteTick(AAPL, etInstant(13, 40), "180.00", "180.04"));
-    assertThat(strategy.evaluate(AAPL)).isEmpty(); // completed
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
 
   @Test
   void noSweepWhenFullyExecuted() {
-    // Single slice covering the whole window: it fully executes, so end-of-window has nothing left.
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, 1, URGENCY);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).get().extracting(OrderSignal::quantity).isEqualTo(1000);
@@ -225,7 +214,6 @@ class ImplementationShortfallStrategyTest {
 
   @Test
   void allocationRemainderGoesToLastSlice() {
-    // 1001 shares over 3 one-hour slices (09:30-12:30), urgency 0.5 → 449, 308, 244 (sum 1001).
     configureStrategy(1001, Side.BUY, WINDOW_START, LocalTime.of(12, 30), 3, URGENCY);
 
     int total = 0;
@@ -238,7 +226,6 @@ class ImplementationShortfallStrategyTest {
 
   @Test
   void fullTradingDaySimulation() {
-    // 10,000 shares, default 09:30-16:00 window, 12 thirty-two-and-a-half-minute slices.
     configureStrategy(10000, Side.BUY, LocalTime.of(9, 30), LocalTime.of(16, 0), 12, URGENCY);
     var signals = new ArrayList<OrderSignal>();
 
@@ -252,7 +239,6 @@ class ImplementationShortfallStrategyTest {
       }
     }
 
-    // EOD: tick at 16:00 triggers sweep if needed
     var closeTs = ZonedDateTime.of(baseDate, LocalTime.of(16, 0), MARKET_ZONE).toInstant();
     strategy.onTick(quoteTick(AAPL, closeTs, "178.50", "178.54"));
     strategy.evaluate(AAPL).ifPresent(signals::add);
@@ -260,13 +246,11 @@ class ImplementationShortfallStrategyTest {
     int totalQty = signals.stream().mapToInt(OrderSignal::quantity).sum();
     assertThat(totalQty).isEqualTo(10000);
 
-    // All 12 slices fire as LIMIT orders; nothing left for the sweep.
     var limitSignals = signals.stream().filter(s -> s.orderType() == OrderType.LIMIT).toList();
     assertThat(limitSignals).hasSize(12);
     assertThat(signals).allMatch(s -> s.symbol().equals(AAPL));
     assertThat(signals).allMatch(s -> s.side() == Side.BUY);
 
-    // Front-loading: the first slice's clip dwarfs the last.
     assertThat(limitSignals.getFirst().quantity()).isGreaterThan(limitSignals.getLast().quantity());
   }
 
@@ -304,31 +288,27 @@ class ImplementationShortfallStrategyTest {
   void updateParametersResetsState() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
 
-    // Execute slice 0
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isPresent();
 
-    // Reconfigure with a new target and side
     configureStrategy(2000, Side.SELL, WINDOW_START, WINDOW_END, FOUR_SLICES, 0.0);
 
-    // Slice 0 should fire again (state was reset) with the new (now uniform) allocation
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
     var orderSignal = signal.get();
-    assertThat(orderSignal.quantity()).isEqualTo(500); // 2000 / 4 at urgency 0
+    assertThat(orderSignal.quantity()).isEqualTo(500);
     assertThat(orderSignal.side()).isEqualTo(Side.SELL);
   }
 
   @Test
   void partialUrgencyUpdatePreservesOtherFields() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES, URGENCY);
-    // Update only urgency to 0 (uniform); window, side, target, slice count must be retained.
     strategy.updateParameters(Map.of("urgency", 0.0));
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
-    assertThat(signal.get().quantity()).isEqualTo(250); // 1000 / 4 slices, now uniform
+    assertThat(signal.get().quantity()).isEqualTo(250);
     assertThat(signal.get().side()).isEqualTo(Side.BUY);
   }
 
@@ -349,7 +329,6 @@ class ImplementationShortfallStrategyTest {
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
 
-  /** Feeds a quote tick at {@code hour}:00 ET and returns the emitted slice quantity. */
   private int emitSlice(int hour) {
     strategy.onTick(quoteTick(AAPL, etInstant(hour, 0), "178.50", "178.54"));
     return strategy.evaluate(AAPL).orElseThrow().quantity();

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/twap/TwapStrategyTest.java
@@ -25,8 +25,6 @@ class TwapStrategyTest {
 
   private static final String AAPL = "AAPL";
 
-  // Standard test window: 09:30-13:30, four equal one-hour slices.
-  //   slice 0: 09:30-10:30, slice 1: 10:30-11:30, slice 2: 11:30-12:30, slice 3: 12:30-13:30
   private static final LocalTime WINDOW_START = LocalTime.of(9, 30);
   private static final LocalTime WINDOW_END = LocalTime.of(13, 30);
   private static final int FOUR_SLICES = 4;
@@ -45,7 +43,6 @@ class TwapStrategyTest {
 
   @Test
   void defaultScheduleSpansTwelveSlices() {
-    // Constructor builds the default 09:30-16:00 schedule with 12 slices.
     var params = strategy.getParameters();
     assertThat(params.get("totalSlices")).isEqualTo(12);
     assertThat(params.get("numSlices")).isEqualTo(12);
@@ -53,7 +50,6 @@ class TwapStrategyTest {
 
   @Test
   void evaluateReturnsEmptyBeforeConfiguration() {
-    // Fresh strategy: schedule exists but targetQuantity is 0.
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
 
@@ -84,7 +80,7 @@ class TwapStrategyTest {
   void evaluateDoesNotReemitForSameSlice() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
-    strategy.evaluate(AAPL); // first call emits
+    strategy.evaluate(AAPL);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 15), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
@@ -93,11 +89,9 @@ class TwapStrategyTest {
   void evaluateEmitsForNextSliceWhenTimeAdvances() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
 
-    // Slice 0
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     strategy.evaluate(AAPL);
 
-    // Slice 1 (10:30-11:30)
     strategy.onTick(quoteTick(AAPL, etInstant(11, 0), "179.00", "179.04"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -110,11 +104,9 @@ class TwapStrategyTest {
   void evaluateEmitsMarketSweepAtEndTime() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
 
-    // Execute only slice 0 (250 shares)
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     strategy.evaluate(AAPL);
 
-    // Jump past end time
     strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
 
     var signal = strategy.evaluate(AAPL);
@@ -129,14 +121,13 @@ class TwapStrategyTest {
   void sweepEmitsOnlyOnce() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
     strategy.onTick(quoteTick(AAPL, etInstant(13, 35), "180.00", "180.04"));
-    assertThat(strategy.evaluate(AAPL)).isPresent(); // sweep
+    assertThat(strategy.evaluate(AAPL)).isPresent();
     strategy.onTick(quoteTick(AAPL, etInstant(13, 40), "180.00", "180.04"));
-    assertThat(strategy.evaluate(AAPL)).isEmpty(); // completed
+    assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
 
   @Test
   void noSweepWhenFullyExecuted() {
-    // Single slice covering the whole window: it fully executes, so end-of-window has nothing left.
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, 1);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).get().extracting(OrderSignal::quantity).isEqualTo(1000);
@@ -174,7 +165,6 @@ class TwapStrategyTest {
 
   @Test
   void allocationRemainderGoesToLastSlice() {
-    // 1001 shares over 3 one-hour slices (09:30-12:30): 334, 334, 333.
     configureStrategy(1001, Side.BUY, WINDOW_START, LocalTime.of(12, 30), 3);
 
     int total = 0;
@@ -190,7 +180,6 @@ class TwapStrategyTest {
 
   @Test
   void fullTradingDaySimulation() {
-    // 10,000 shares, default 09:30-16:00 window, 13 thirty-minute slices.
     configureStrategy(10000, Side.BUY, LocalTime.of(9, 30), LocalTime.of(16, 0), 13);
     var signals = new ArrayList<OrderSignal>();
 
@@ -204,7 +193,6 @@ class TwapStrategyTest {
       }
     }
 
-    // EOD: tick at 16:00 triggers sweep if needed
     var closeTs = ZonedDateTime.of(baseDate, LocalTime.of(16, 0), MARKET_ZONE).toInstant();
     strategy.onTick(quoteTick(AAPL, closeTs, "178.50", "178.54"));
     strategy.evaluate(AAPL).ifPresent(signals::add);
@@ -212,7 +200,6 @@ class TwapStrategyTest {
     int totalQty = signals.stream().mapToInt(OrderSignal::quantity).sum();
     assertThat(totalQty).isEqualTo(10000);
 
-    // All 13 slices fire as LIMIT orders; nothing left for the sweep.
     var limitSignals = signals.stream().filter(s -> s.orderType() == OrderType.LIMIT).toList();
     assertThat(limitSignals).hasSize(13);
     assertThat(signals).allMatch(s -> s.symbol().equals(AAPL));
@@ -248,14 +235,11 @@ class TwapStrategyTest {
   void updateParametersResetsState() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
 
-    // Execute slice 0
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isPresent();
 
-    // Reconfigure with a new target and side
     configureStrategy(2000, Side.SELL, WINDOW_START, WINDOW_END, FOUR_SLICES);
 
-    // Slice 0 should fire again (state was reset) with the new allocation
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -267,12 +251,11 @@ class TwapStrategyTest {
   @Test
   void partialParameterUpdatePreservesOtherFields() {
     configureStrategy(1000, Side.BUY, WINDOW_START, WINDOW_END, FOUR_SLICES);
-    // Update only the target quantity; window and slice count must be retained.
     strategy.updateParameters(Map.of("targetQuantity", 800));
     strategy.onTick(quoteTick(AAPL, etInstant(10, 0), "178.50", "178.54"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
-    assertThat(signal.get().quantity()).isEqualTo(200); // 800 / 4 slices
+    assertThat(signal.get().quantity()).isEqualTo(200);
   }
 
   @Test

--- a/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/vwap/VwapStrategyTest.java
+++ b/strategy-engine/src/test/java/com/mariaalpha/strategyengine/strategy/vwap/VwapStrategyTest.java
@@ -25,8 +25,6 @@ class VwapStrategyTest {
   public static final String AAPL = "AAPL";
   private VwapStrategy strategy;
 
-  // Standard 3-bin profile for most tests:
-  //   09:30-10:30 (40%), 10:30-11:30 (35%), 11:30-12:30 (25%)
   private static final List<TimeBin> THREE_BIN_PROFILE =
       List.of(
           new TimeBin(LocalTime.of(9, 30), LocalTime.of(10, 30), 0.40),
@@ -45,7 +43,6 @@ class VwapStrategyTest {
     configureStrategy(targetQty, Side.BUY, volumeProfile);
     var signals = new ArrayList<OrderSignal>();
 
-    // Simulate ticks every 15 minutes from 09:30 to 16:00
     var baseDate = LocalDate.of(2026, 3, 24);
     for (int hour = 9; hour <= 15; hour++) {
       int startMin = (hour == 9) ? 30 : 0;
@@ -56,20 +53,16 @@ class VwapStrategyTest {
       }
     }
 
-    // EOD: tick at 16:00 triggers sweep if needed
     var closeTs = ZonedDateTime.of(baseDate, LocalTime.of(16, 0), MARKET_ZONE).toInstant();
     strategy.onTick(quoteTick(AAPL, closeTs, "178.50", "178.54"));
     strategy.evaluate(AAPL).ifPresent(signals::add);
 
-    // Verify all bins emitted exactly once (13 bin signals + possibly 1 sweep)
     int totalQty = signals.stream().mapToInt(OrderSignal::quantity).sum();
     assertThat(totalQty).isEqualTo(targetQty);
 
-    // All non-sweep signals should be LIMIT orders
     var limitSignals = signals.stream().filter(s -> s.orderType() == OrderType.LIMIT).toList();
     assertThat(limitSignals).hasSize(13);
 
-    // Every signal should be for APPL
     assertThat(signals).allMatch(s -> s.symbol().equals(AAPL));
     assertThat(signals).allMatch(s -> s.side() == Side.BUY);
   }
@@ -83,7 +76,6 @@ class VwapStrategyTest {
             new TimeBin(LocalTime.of(11, 30), LocalTime.of(12, 30), 0.334));
     configureStrategy(1001, Side.BUY, profile);
 
-    // Execute all bins and collect quantities
     int total = 0;
     strategy.onTick(quoteTick(AAPL, etInstant(9, 45), "178.50", "178.54"));
     total += strategy.evaluate(AAPL).get().quantity();
@@ -131,7 +123,7 @@ class VwapStrategyTest {
   void evaluateDoesNotReemitForSameBin() {
     configureStrategy(1000, Side.BUY, THREE_BIN_PROFILE);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 45), "178.50", "178.54"));
-    strategy.evaluate(AAPL); // first call emits
+    strategy.evaluate(AAPL);
     strategy.onTick(quoteTick(AAPL, etInstant(10, 45), "178.50", "178.54"));
     assertThat(strategy.evaluate(AAPL)).isEmpty();
   }
@@ -140,11 +132,9 @@ class VwapStrategyTest {
   void evaluateEmitsForNextBinWhenTimeAdvances() {
     configureStrategy(1000, Side.BUY, THREE_BIN_PROFILE);
 
-    // Bin 0
     strategy.onTick(quoteTick(AAPL, etInstant(9, 45), "178.50", "178.54"));
     strategy.evaluate(AAPL);
 
-    // Bin 1
     strategy.onTick(quoteTick(AAPL, etInstant(10, 45), "179.00", "179.04"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -157,11 +147,9 @@ class VwapStrategyTest {
   void evaluateEmitsMarketSweepAtEndTime() {
     configureStrategy(1000, Side.BUY, THREE_BIN_PROFILE);
 
-    // Execute only bin 0 (400 shares)
     strategy.onTick(quoteTick(AAPL, etInstant(9, 45), "178.50", "178.54"));
     strategy.evaluate(AAPL);
 
-    // Jump past end time
     strategy.onTick(quoteTick(AAPL, etInstant(12, 35), "180.00", "180.04"));
 
     var signal = strategy.evaluate(AAPL);
@@ -203,14 +191,11 @@ class VwapStrategyTest {
   void updateParametersResetsState() {
     configureStrategy(1000, Side.BUY, THREE_BIN_PROFILE);
 
-    // Execute bin 0
     strategy.onTick(quoteTick("AAPL", etInstant(9, 45), "178.50", "178.54"));
     assertThat(strategy.evaluate("AAPL")).isPresent();
 
-    // Reconfigure with new target
     configureStrategy(2000, Side.SELL, THREE_BIN_PROFILE);
 
-    // Bin 0 should fire again (state was reset)
     strategy.onTick(quoteTick("AAPL", etInstant(9, 45), "178.50", "178.54"));
     var signal = strategy.evaluate(AAPL);
     assertThat(signal).isPresent();
@@ -269,8 +254,6 @@ class VwapStrategyTest {
   }
 
   private static List<TimeBin> buildFullDayProfile() {
-    // 13 bins, 30 min each, from 09:30 to 16:00
-    // U-shaped volume distribution
     double[] fractions = {
       0.12, 0.09, 0.07, 0.06, 0.05, 0.05, 0.05, 0.05, 0.06, 0.07, 0.09, 0.11, 0.13
     };

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,14 +17,6 @@ import { usePositionStore } from "@/stores/positionStore";
 import { useOrderStore } from "@/stores/orderStore";
 import type { OrderEvent, PositionUpdate, RiskAlert } from "@/types/api";
 
-/**
- * App-wide WebSocket consumers.
- *
- * The Dashboard and OrderEntry pages historically each opened their own `/ws/positions` and
- * `/ws/orders` connections, so navigating between pages tore down + recreated them. Mounting all
- * three streams here means the gateway holds one persistent connection per topic for the entire
- * session — and every page renders from a single, shared store.
- */
 function AppWideStreams() {
   const applyPosition = usePositionStore((s) => s.applyUpdate);
   const applyOrder = useOrderStore((s) => s.applyEvent);

--- a/ui/src/components/AlertsBanner.tsx
+++ b/ui/src/components/AlertsBanner.tsx
@@ -16,10 +16,6 @@ const severityClass = (s: string): string => {
   }
 };
 
-/**
- * Floating alert stack rendered above all pages. Subscribed to the app-wide alert store
- * populated by the `/ws/alerts` WebSocket consumer in `App.tsx`.
- */
 export default function AlertsBanner() {
   const activeAlerts = useAlertStore(
     useShallow((s) => s.alerts.filter((a) => !a.dismissed).slice(0, 5)),

--- a/ui/src/components/DailyPnlChart.tsx
+++ b/ui/src/components/DailyPnlChart.tsx
@@ -15,7 +15,7 @@ interface Sample {
   pnl: number;
 }
 const SAMPLE_INTERVAL_MS = 1_000;
-const MAX_SAMPLES = 600; // 10 minutes at 1Hz
+const MAX_SAMPLES = 600;
 
 export default function DailyPnlChart() {
   const samplesRef = useRef<Sample[]>([]);

--- a/ui/src/components/FillHistoryTable.tsx
+++ b/ui/src/components/FillHistoryTable.tsx
@@ -5,8 +5,6 @@ import type { Fill, Order } from "@/types/api";
 import { fmtMoney, fmtQty } from "@/lib/format";
 
 export default function FillHistoryTable() {
-  // Return a stable primitive key so useSyncExternalStore doesn't trigger an infinite re-render
-  // loop when Array.from always produces a new reference.
   const orderIdsKey = useOrderStore((s) => Array.from(s.orders.keys()).sort().join(","));
   const orderIds = orderIdsKey.length > 0 ? orderIdsKey.split(",") : [];
   const [fills, setFills] = useState<Fill[]>([]);

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -3,9 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWebSocket } from "./useWebSocket";
 import { useConnectionStore } from "@/stores/connectionStore";
 
-// ---------------------------------------------------------------------------
-// Fake WebSocket
-// ---------------------------------------------------------------------------
 
 interface FakeSocket {
   url: string;
@@ -58,15 +55,11 @@ class FakeWebSocket implements FakeSocket {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 beforeEach(() => {
   allSockets.length = 0;
   lastSocket = null;
   vi.stubGlobal("WebSocket", FakeWebSocket);
-  // Set env vars needed by buildWsUrl
   vi.stubGlobal("location", { protocol: "http:", host: "localhost:5173" });
   Object.assign(import.meta.env, {
     VITE_MARIAALPHA_API_KEY: "local-dev-key",

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWebSocket } from "./useWebSocket";
 import { useConnectionStore } from "@/stores/connectionStore";
 
-
 interface FakeSocket {
   url: string;
   readyState: number;
@@ -54,7 +53,6 @@ class FakeWebSocket implements FakeSocket {
     this.onclose?.({ code, wasClean: code === 1000 } as CloseEvent);
   }
 }
-
 
 beforeEach(() => {
   allSockets.length = 0;

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -16,9 +16,8 @@ export function useWebSocket<T>(opts: Options<T>): { state: ConnectionState } {
   const { endpoint, query, onMessage, enabled = true } = opts;
   const [state, setLocalState] = useState<ConnectionState>("connecting");
   const onMessageRef = useRef(onMessage);
-  onMessageRef.current = onMessage; // always invoke the latest closure
+  onMessageRef.current = onMessage;
 
-  // Capture query snapshot so the dep array doesn't churn on every render.
   const queryKey = JSON.stringify(query ?? {});
 
   useEffect(() => {
@@ -87,8 +86,6 @@ export function useWebSocket<T>(opts: Options<T>): { state: ConnectionState } {
     return () => {
       unmounted = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
-      // Close CONNECTING sockets too — an unmount mid-handshake would otherwise leak a
-      // connection that completes in the background and stays open.
       if (
         socket &&
         (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -8,8 +8,6 @@ export class ApiError extends Error {
   }
 }
 
-// Runtime config (window.MA_CONFIG) is rendered into /config.js by the UI Helm
-// chart's init container. The Vite env vars are used as fallback for `npm run dev`.
 type MaConfig = { apiKey?: string; apiBaseUrl?: string };
 const runtimeConfig: MaConfig =
   (typeof window !== "undefined" && (window as unknown as { MA_CONFIG?: MaConfig }).MA_CONFIG) ||
@@ -37,7 +35,6 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
     const body = await res.text().catch(() => "");
     throw new ApiError(res.status, path, body || res.statusText);
   }
-  // Some endpoints (DELETE) return 204 with no body.
   if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
 }

--- a/ui/src/lib/wsUrl.ts
+++ b/ui/src/lib/wsUrl.ts
@@ -11,7 +11,6 @@ export function buildWsUrl(endpoint: WsEndpoint, query: Record<string, string> =
     throw new Error("API key is not set (window.MA_CONFIG.apiKey or VITE_MARIAALPHA_API_KEY)");
 
   const baseRaw = runtimeConfig.apiBaseUrl ?? import.meta.env.VITE_API_BASE_URL ?? "";
-  // Convert http(s) base to ws(s); empty base → relative URL goes through Vite proxy.
   const wsBase = baseRaw.replace(/^http:\/\//, "ws://").replace(/^https:\/\//, "wss://");
 
   const params = new URLSearchParams({ apiKey, ...query });

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -11,9 +11,6 @@ export default function Dashboard() {
   const [summary, setSummary] = useState<PortfolioSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const replaceAll = usePositionStore((s) => s.replaceAll);
-  // App-wide /ws/positions connection lives in AppWideStreams.
-  // We reload the REST snapshot whenever the shared connection becomes open
-  // so a reconnect resyncs the table without each page owning its own socket.
   const positionsWsState = useConnectionStore((s) => s.states["/ws/positions"]);
 
   const loadSnapshot = async (): Promise<void> => {

--- a/ui/src/pages/OrderEntry.tsx
+++ b/ui/src/pages/OrderEntry.tsx
@@ -10,8 +10,6 @@ import FillHistoryTable from "@/components/FillHistoryTable";
 export default function OrderEntry() {
   const replaceAll = useOrderStore((s) => s.replaceAll);
   const [error, setError] = useState<string | null>(null);
-  // App-wide /ws/orders connection lives in AppWideStreams;
-  // we re-fetch the REST snapshot on each reconnect.
   const ordersWsState = useConnectionStore((s) => s.states["/ws/orders"]);
 
   const loadSnapshot = async (): Promise<void> => {

--- a/ui/src/pages/Reconciliation.test.tsx
+++ b/ui/src/pages/Reconciliation.test.tsx
@@ -31,7 +31,6 @@ describe("Reconciliation page", () => {
       expect(screen.getByText(/No reconciliation breaks recorded/)).toBeInTheDocument();
     });
     expect(screen.getByTestId("card-Total breaks")).toHaveTextContent("0");
-    // No run record yet → Matched falls back to em-dash
     expect(screen.getByTestId("card-Matched")).toHaveTextContent("—");
   });
 
@@ -83,9 +82,7 @@ describe("Reconciliation page", () => {
     expect(screen.getByTestId("card-High")).toHaveTextContent("1");
     expect(screen.getByTestId("recon-bytype-table")).toBeInTheDocument();
     expect(screen.getByTestId("recon-run-status")).toHaveTextContent("SUCCESS");
-    // externalFillsCount=1, breaks=1 → matched=0
     expect(screen.getByTestId("card-Matched")).toHaveTextContent("0");
-    // Description column is wired through
     expect(screen.getByText(/External fill not matched internally/)).toBeInTheDocument();
   });
 

--- a/ui/src/pages/Reconciliation.tsx
+++ b/ui/src/pages/Reconciliation.tsx
@@ -96,7 +96,6 @@ export default function Reconciliation() {
       const r = await api<ReconRun[]>("/api/recon/runs");
       setRuns(r);
     } catch (e) {
-      // non-fatal — leave runs empty
       console.warn("recon runs failed", e);
     }
   }, []);
@@ -122,8 +121,6 @@ export default function Reconciliation() {
     void load();
   }, [load]);
 
-  // Matched count — when we know how many external fills came in, "matched" is external - breaks.
-  // Falls back to "—" when there's no run record (the engine hasn't fired for this date).
   const matched = useMemo<number | "—">(() => {
     if (summary?.run?.externalFillsCount == null) return "—";
     return Math.max(0, summary.run.externalFillsCount - summary.totalBreaks);

--- a/ui/src/pages/Strategies.test.tsx
+++ b/ui/src/pages/Strategies.test.tsx
@@ -30,7 +30,6 @@ describe("Strategies page", () => {
       expect(screen.getByTestId("row-AAPL")).toBeInTheDocument();
     });
     const row = screen.getByTestId("row-AAPL");
-    // "VWAP" appears in the active-strategy cell + the switch <select> option list
     expect(within(row).getAllByText("VWAP").length).toBeGreaterThan(0);
     expect(within(row).getByText(/LONG/)).toBeInTheDocument();
     expect(within(row).getByText(/TRENDING_UP/)).toBeInTheDocument();
@@ -52,7 +51,6 @@ describe("Strategies page", () => {
         <Strategies />
       </MemoryRouter>,
     );
-    // Wait for default-symbol rows to appear (the merge with DEFAULT_SYMBOLS)
     await waitFor(() => {
       expect(screen.getByTestId("row-MSFT")).toBeInTheDocument();
     });
@@ -80,7 +78,6 @@ describe("Strategies page", () => {
       expect(screen.getByTestId("row-TSLA")).toBeInTheDocument();
     });
     const row = screen.getByTestId("row-TSLA");
-    // 4 cells with em-dash content: strategy filled, signal empty, regime empty
     expect(within(row).getAllByText("—").length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/ui/src/pages/Strategies.tsx
+++ b/ui/src/pages/Strategies.tsx
@@ -17,8 +17,6 @@ interface StrategyState {
   };
 }
 
-// Static seed list — covers the simulator universe; users can still
-// type any other symbol into the "Bind new symbol" form.
 const DEFAULT_SYMBOLS = ["AAPL", "MSFT", "GOOGL", "AMZN", "TSLA", "NVDA"];
 
 const directionClass = (d: string): string => {
@@ -59,7 +57,6 @@ export default function Strategies() {
   const fetchState = useCallback(async () => {
     try {
       const states = await api<StrategyState[]>("/api/strategies/state");
-      // Merge with DEFAULT_SYMBOLS to always show simulator universe even if unrouted
       const known = new Set(states.map((s) => s.symbol));
       const merged = [
         ...states,

--- a/ui/src/stores/alertStore.ts
+++ b/ui/src/stores/alertStore.ts
@@ -15,12 +15,6 @@ interface AlertStore {
 
 const MAX_ALERTS = 50;
 
-/**
- * App-wide store for risk alerts streamed over `/ws/alerts`. Alerts arrive from the
- * `analytics.risk-alerts` Kafka topic via the API gateway WebSocket proxy. The store keeps a
- * bounded ring of the most recent alerts so the banner can render the active ones and the
- * Analytics page can render history.
- */
 export const useAlertStore = create<AlertStore>((set) => ({
   alerts: [],
   push: (a) => {

--- a/ui/src/stores/positionStore.ts
+++ b/ui/src/stores/positionStore.ts
@@ -21,7 +21,6 @@ export const usePositionStore = create<PositionStore>((set) => ({
         avgEntryPrice: u.avgEntryPrice,
         realizedPnl: u.realizedPnl,
         unrealizedPnl: u.unrealizedPnl,
-        // PositionUpdate has no totalPnl; compute it.
         totalPnl: u.realizedPnl + u.unrealizedPnl,
         lastMarkPrice: u.lastMarkPrice,
         updatedAt: u.timestamp,

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -12,13 +12,11 @@ afterAll(() => {
   server.close();
 });
 
-// Stub VITE env for tests
 Object.assign(import.meta.env, {
   VITE_MARIAALPHA_API_KEY: "test-key",
   VITE_API_BASE_URL: "",
 });
 
-// Recharts' ResponsiveContainer uses ResizeObserver which is absent in jsdom.
 global.ResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -1,4 +1,3 @@
-
 export type Side = "BUY" | "SELL";
 export type OrderType = "MARKET" | "LIMIT" | "STOP" | "IOC" | "FOK" | "GTC" | "ICEBERG" | "PEGGED";
 export type PegType = "MIDPOINT" | "PRIMARY" | "MARKET";
@@ -110,7 +109,6 @@ export interface SubmitOrderResponse {
   status: OrderStatus;
   submittedAt: string;
 }
-
 
 export type MarketTickEventType = "TRADE" | "QUOTE" | "BAR";
 export type MarketTickSource = "ALPACA" | "SIMULATED" | "IBKR";

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -1,4 +1,3 @@
-// REST response types — match Java DTOs in order-manager and post-trade.
 
 export type Side = "BUY" | "SELL";
 export type OrderType = "MARKET" | "LIMIT" | "STOP" | "IOC" | "FOK" | "GTC" | "ICEBERG" | "PEGGED";
@@ -12,7 +11,6 @@ export type OrderStatus =
   | "CANCELLED"
   | "REJECTED";
 
-// PortfolioSummaryResponse.java
 export interface PortfolioSummary {
   totalValue: number;
   cashBalance: number;
@@ -22,10 +20,9 @@ export interface PortfolioSummary {
   unrealizedPnl: number;
   totalPnl: number;
   openPositions: number;
-  asOf: string; // ISO 8601
+  asOf: string;
 }
 
-// PositionResponse.java
 export interface Position {
   symbol: string;
   netQuantity: number;
@@ -59,7 +56,6 @@ export interface Order {
   fills?: Fill[];
 }
 
-// FillResponse.java
 export interface Fill {
   fillId: string;
   orderId?: string;
@@ -80,11 +76,11 @@ export interface SubmitOrderRequest {
   quantity: number;
   limitPrice?: number;
   stopPrice?: number;
-  displayQuantity?: number; // ICEBERG only
+  displayQuantity?: number;
   tif?: TimeInForce;
   clientOrderId?: string;
-  pegType?: PegType; // PEGGED only
-  pegOffsetBps?: number; // PEGGED only
+  pegType?: PegType;
+  pegOffsetBps?: number;
 }
 
 export interface PeggedProgress {
@@ -115,9 +111,7 @@ export interface SubmitOrderResponse {
   submittedAt: string;
 }
 
-// WS payload types — match Java records in market-data-gateway / order-manager / execution-engine.
 
-// MarketTick.java
 export type MarketTickEventType = "TRADE" | "QUOTE" | "BAR";
 export type MarketTickSource = "ALPACA" | "SIMULATED" | "IBKR";
 export interface MarketTick {
@@ -135,7 +129,6 @@ export interface MarketTick {
   stale: boolean;
 }
 
-// PositionSnapshot.java (note: schema differs from PositionResponse — no totalPnl)
 export interface PositionUpdate {
   symbol: string;
   netQuantity: number;
@@ -146,7 +139,6 @@ export interface PositionUpdate {
   timestamp: string;
 }
 
-// OrderEvent.java
 export interface OrderEvent {
   orderId: string;
   status: OrderStatus;
@@ -177,7 +169,6 @@ export interface WsFill {
   filledAt: string;
 }
 
-// RiskAlert.java
 export interface RiskAlert {
   symbol: string;
   alertType: string;


### PR DESCRIPTION
  **3.4.1 — Program / Basket Trading (execution-engine)**

  Built on the existing coordinator + registry + progress pattern (the Iceberg/Pegged template), adapted for one-to-many fan-out instead of sequential slicing:

  - BasketTradingService validates all legs up front (all-or-nothing), then fans each leg through the standard OrderExecutionService.submitOrder pipeline — so every leg gets the full ten-check risk chain, SOR,
  venue routing, and emits its own orders.lifecycle events.
  - BasketRegistry (forward + reverse maps) and BasketCoordinator — hooked into OrderExecutionService.onExecutionReport right beside the iceberg/pegged coordinators, no-op for non-basket orders — track the
  aggregate. Status (SUBMITTED/PARTIALLY_FILLED/FILLED/REJECTED) is derived, with rejected legs excluded from the target so a basket still completes around a risk-rejected leg.
  - Race-safe: the basket and each leg are registered/linked before submission, and a leg's submission outcome never downgrades a fill that raced ahead.
  - REST: POST/GET /api/execution/baskets (already reachable through the gateway's /api/execution/** route — no gateway change). 5 metrics. 6 test classes (unit all green; 1 Testcontainers integration test).

  **3.4.3 — FIX Protocol Gateway (api-gateway)**

  An inbound FIX 4.4 acceptor (QuickFIX/J 2.3.2), the protocol sibling of the REST order-entry path:

  - FixGatewayServer (gated SmartLifecycle, disabled by default → no socket in tests/CI), FixApplication (MessageCracker with testable handlers that return the response message), FixOrderTranslator (pure
  NewOrderSingle → order mapping), FixGatewayClient (forwards to execution-engine), FixGatewayMetrics.
  - Handles NewOrderSingle → execution-engine, OrderCancelRequest → cancel, replying with ExecutionReport/OrderCancelReject. 2 test classes (translator + application), both green.
  - Scoped to plain order types: algo parents stay on REST /api/algo/orders because standard FIX tags can't carry MariaAlpha's per-strategy parameters — documented explicitly.

Closes #97
Closes #99